### PR TITLE
Changed the way the json writing works; ran into issues about unicode…

### DIFF
--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -42,10 +42,10 @@ def write_json(obj, path):
     '''
     if is_serializable(obj):
         obj = obj.serialize()
+    s = json.dumps(obj, indent=4, cls=JSONNumpyEncoder, ensure_ascii=False)
     ut.ensure_basedir(path)
     with open(path, "wt") as f:
-        f.write(json.dumps(obj, f, indent=4, cls=JSONNumpyEncoder,
-            ensure_ascii=False))
+        f.write(str(s))
 
 
 class Serializable(object):


### PR DESCRIPTION
…/str when writing json from python 2.7

And the first *bug* for cross-python23 happens...

I received the following error / traceback when I tried to write json from a piece of code that worked before the recent merge for cross-python23 support.

```
    serial.write_json(self.manifest.config, self.config.manifest_path_fs)
  File "/voxel51/w/eta/eta/core/serial.py", line 47, in write_json
    json.dump(obj, f, indent=4, cls=JSONNumpyEncoder, ensure_ascii=False)
  File "/usr/lib/python2.7/json/__init__.py", line 190, in dump
    fp.write(chunk)
TypeError: write() argument 1 must be unicode, not str
```

Digging around a bit and trying to fix within my code (by making various string unicode explicitly) did not fix it.  So, I believe this fix is the correct one (directly enforce the unicode string to the serialized json).
