### PR TITLE
added an option to the serial.write_json file to not have the json ou…

### DIFF
--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -40,7 +40,7 @@ def write_json(obj, path, pretty_print=True):
             an instance of a subclass of serial.Serializable
         path: the output path
         pretty_print: when True (default), the resulting json will be outputted
-            to be human readable; when False, the it will be compact with no
+            to be human readable; when False, it will be compact with no
             extra spaces or newline characters.
     '''
     if is_serializable(obj):


### PR DESCRIPTION
…tput formatted as pretty-print; a client need.  The default behavior is still the same.

Client constraints lead to new functionality :)