### PR TITLE
changed the pickle import to dill as it is more robust and can handle…

### DIFF
--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -19,8 +19,8 @@ from builtins import *
 # pragma pylint: enable=wildcard-import
 
 import collections
+import dill as pickle
 import json
-import pickle
 
 import numpy as np
 


### PR DESCRIPTION
… instancemethods without any hacky code.  Still on the fence about the longterm utility of any pickler.  When a class's code changes so does the pickle need to.