### PR TITLE
Return video info stream based on codec_type

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -21,6 +21,7 @@ import six
 
 import errno
 import json
+import logging
 from subprocess import Popen, PIPE
 import threading
 


### PR DESCRIPTION
Maybe `if` statements would be better. I'm not really familiar with `ffprobe` or its output patterns.