### PR TITLE
Adds the eta script to the `setup.py` install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,5 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
     ],
+    scripts=['eta/eta'],
 )


### PR DESCRIPTION
Installs the eta script to the default binary path (including in a virtual environment) during a `pip install`.
(Not the best name for the branch, but...)  