### PR TITLE
Adding local modules and pipelines directories to default ETA config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To setup your environment, copy the example configuration file
 cp config-example.json config.json
 ```
 
-and then edit your config file to provide the (full) paths to the relevant
+and then edit your config file to provide the paths to the relevant
 directories in your installation. If you do not require a customized
 installation, the example configuration file contains the pattern `{{eta}}`
 that you can perform a quick find-and-replace on to populate the config:
@@ -88,6 +88,11 @@ sed -i '' -e "s|{{eta}}|$(pwd)|g" config.json
 # on most linux distributions
 sed -i -e "s|{{eta}}|$(pwd)|g" config.json
 ```
+
+The default config includes the `eta/modules` and `eta/pipelines` directories
+in your module and pipeline config search paths, respectively. In addition,
+it includes the relative paths `./modules` and `./pipelines` to support the
+typical directory structure that we adopt for our individual projects.
 
 
 ## Installing the command-line utility

--- a/config-example.json
+++ b/config-example.json
@@ -1,8 +1,14 @@
 {
     "config_dir": "{{eta}}/configs",
     "output_dir": "{{eta}}/out",
-    "module_dirs": ["{{eta}}/eta/modules"],
-    "pipeline_dirs": ["{{eta}}/eta/pipelines"],
+    "module_dirs": [
+        "{{eta}}/eta/modules",
+        "./modules"
+    ],
+    "pipeline_dirs": [
+        "{{eta}}/eta/pipelines",
+        "./pipelines"
+    ],
     "weights_dirs": ["{{eta}}/eta/cache"],
     "default_sequence_idx" : "%05d",
     "default_video_ext": ".mp4",

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -227,7 +227,7 @@ class PipelineBuilder(object):
                 etaj.JobConfig.builder()
                     .set(name=module)
                     .set(working_dir=".")
-                    .set(script=etam.find_exe(metadata.info.exe))
+                    .set(script=etam.find_exe(metadata))
                     .set(config_path=self._get_module_config_path(module))
                     .validate()
             )

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -101,6 +101,8 @@ class PipelineBuildRequest(Configurable):
                     "'%s' is not a valid value for input '%s' of pipeline "
                     "'%s'") % (ipath, iname, self.pipeline)
                 )
+            # Convert to absolute paths
+            self.inputs[iname] = os.path.abspath(ipath)
 
         # Ensure that required inputs were supplied
         for miname, miobj in iteritems(self.metadata.inputs):
@@ -122,6 +124,9 @@ class PipelineBuildRequest(Configurable):
                     "'%s' is not a valid value for parameter '%s' of pipeline "
                     "'%s'") % (pval, pname, self.pipeline)
                 )
+            # Convert any data parameters to absolute paths
+            if self.metadata.parameters[pname].is_data:
+                self.parameters[pname] = os.path.abspath(pval)
 
         # Ensure that required parmeters were supplied
         for mpname, mpobj in iteritems(self.metadata.parameters):

--- a/eta/core/module.py
+++ b/eta/core/module.py
@@ -123,25 +123,26 @@ def find_metadata(module_name):
             "Could not find module '%s'" % module_name)
 
 
-def find_exe(module_exe):
-    '''Finds the given module executable.
+def find_exe(module_metadata):
+    '''Finds the executable for the given ModuleMetadata instance.
 
-    Module executables must be in one of the directories in
-    `eta.config.module_dirs`.
+    Args:
+        module_metadata: the ModuleMetadata instance for the module
 
     Returns:
-        the path to the module executable
+        the (absolute) path to the module executable
 
     Raises:
         ModuleMetadataError: if the module executable could not be found
     '''
-    for pdir in eta.config.module_dirs:
-        exe_path = os.path.join(pdir, module_exe)
-        if os.path.isfile(exe_path):
-            return exe_path
+    meta_path = find_metadata(module_metadata.info.name)
+    exe_path = os.path.join(
+        os.path.dirname(meta_path), module_metadata.info.exe)
+    if not os.path.isfile(exe_path):
+        raise ModuleMetadataError(
+            "Could not find module executable '%s'" % exe_path)
 
-    raise ModuleMetadataError(
-        "Could not find module executable '%s'" % module_exe)
+    return exe_path
 
 
 # @todo should pass a PipelineConfig instance here, not just the path. The need

--- a/eta/core/module.py
+++ b/eta/core/module.py
@@ -83,7 +83,8 @@ def find_all_metadata():
     module metadata files. To load these files, use `load_all_metadata()`.
 
     Returns:
-        a dictionary mapping module names to module metadata filenames
+        a dictionary mapping module names to (absolute paths to) module
+            metadata filenames
 
     Raises:
         ModuleMetadataError: if the module names are not unique
@@ -95,7 +96,7 @@ def find_all_metadata():
             if name in d:
                 raise ModuleMetadataError(
                     "Found two '%s' modules. Names must be unique." % name)
-            d[name] = path
+            d[name] = os.path.abspath(path)
 
     return d
 
@@ -106,8 +107,11 @@ def find_metadata(module_name):
     Module metadata files must be JSON files in one of the directories in
     `eta.config.module_dirs`.
 
+    Args:
+        module_name: the name of the module
+
     Returns:
-        the path to the module metadata file
+        the (absolute) path to the module metadata file
 
     Raises:
         ModuleMetadataError: if the module metadata file could not be found

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -409,6 +409,16 @@ class PipelineParameter(object):
         self._validate()
 
     @property
+    def is_builtin(self):
+        '''Returns True/False if this parameter is a Builtin.'''
+        return self.param.is_builtin
+
+    @property
+    def is_data(self):
+        '''Returns True/False if this parameter is Data.'''
+        return self.param.is_data
+
+    @property
     def is_required(self):
         '''Returns True/False if this parameter must be set by the user.'''
         return (

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -198,7 +198,8 @@ def find_all_metadata():
     pipeline metadata files. To load these files, use `load_all_metadata()`.
 
     Returns:
-        a dictionary mapping pipeline names to pipeline metadata filenames
+        a dictionary mapping pipeline names to (absolute paths to) pipelines
+            metadata filenames
 
     Raises:
         PipelineMetadataError: if the pipeline names are not unique
@@ -210,7 +211,7 @@ def find_all_metadata():
             if name in d:
                 raise PipelineMetadataError(
                     "Found two '%s' pipelines. Names must be unique." % name)
-            d[name] = path
+            d[name] = os.path.abspath(path)
 
     return d
 
@@ -222,7 +223,7 @@ def find_metadata(pipeline_name):
     `eta.config.pipeline_dirs`.
 
     Returns:
-        the path to the pipeline metadata file
+        the (absolute) path to the pipeline metadata file
 
     Raises:
         PipelineMetadataError: if the pipeline could not be found


### PR DESCRIPTION
Adding `./modules` and `./pipelines` directories to the default ETA config, which supports our typical project structure.

Also updating the pipeline building mechanism to always convert relative paths to absolute paths, for portability. 

Addresses https://github.com/voxel51/eta/issues/75.