### PR TITLE
Improving handling of default values for parameters

### DIFF
--- a/docs/modules_dev_guide.md
+++ b/docs/modules_dev_guide.md
@@ -84,7 +84,7 @@ a simple object detector module:
             "name": "weights",
             "type": "eta.core.types.Weights",
             "description": "The weights for the network",
-            "required": true,
+            "required": false,
             "default": "/path/to/weights.npz"
         }
     ]
@@ -144,7 +144,7 @@ Each spec has the fields:
 - `default`: (optional parameters only) the default value that is used
     for the optional parameter when it is omitted from a module configuration
     file. The default value must either be (a) a valid value for the declared
-    type of the parameter, or (b) set to `None`, which implies that the module
+    type of the parameter, or (b) set to `null`, which implies that the module
     can function without this parameter being set to a valid typed value
 
 
@@ -415,8 +415,7 @@ The `parameters` field defines the parameter values to use when executing the
 module. The possible fields that can be listed in `<parameters>` in the
 above JSON are defined by the `parameters` field of the module's metadata JSON
 file. In particular, each spec in the `parameters` field must contain all
-parameters that are _required_ and have _no default value_ in the module
-metadata file and may also contain any optional parameters.
+parameters that are _required_ and may also contain any optional parameters.
 Again, the particular parameters supported by the module are defined by
 the module's metadata JSON file, and all required parameters and zero or more
 optional parameters must be specified.

--- a/docs/modules_dev_guide.md
+++ b/docs/modules_dev_guide.md
@@ -138,12 +138,14 @@ Each spec has the fields:
 
 - `description`: a short free-text description of the field
 
-- `required`: (optional) whether the field is required for the module to
-    function. If omitted, the field is assumed to be required
+- `required`: (optional) whether a value must be provided for the field in all
+    module configuration files. If omitted, the field is assumed to be required
 
-- `default`: (optional, and parameters only) a default value for the parameter.
-    If a parameter is required but has a default value, it may be omitted from
-    the module configuration file
+- `default`: (optional parameters only) the default value that is used
+    for the optional parameter when it is omitted from a module configuration
+    file. The default value must either be (a) a valid value for the declared
+    type of the parameter, or (b) set to `None`, which implies that the module
+    can function without this parameter being set to a valid typed value
 
 
 #### Automatic generation of module metadata files

--- a/docs/modules_dev_guide.md
+++ b/docs/modules_dev_guide.md
@@ -629,18 +629,24 @@ class DataConfig(Config):
     '''Data configuration settings.
 
     Inputs:
-        {{input}} ({{type}}): {{description}}
+        {{input1}} ({{type1}}): {{description1}}
+        {{input2}} ({{type2}}): [None] {{description2}}
 
     Outputs:
-        {{output}} ({{type}}): {{description}}
+        {{output1}} ({{type3}}): {{description3}}
+        {{output2}} ({{type4}}): [None] {{description4}}
     '''
 
     def __init__(self, d):
-        # Template for parsing an input field
-        self.{{input}} = self.parse_{{type}}(d, "{{input}}")
+        # Template for parsing a required input
+        self.{{input1}} = self.parse_{{type1}}(d, "{{input1}}")
+        # Template for parsing an optional input
+        self.{{input2}} = self.parse_{{type2}}(d, "{{input2}}", default=None)
 
-        # Template for parsing an output field
-        self.{{output}} = self.parse_{{type}}(d, "{{output}}")
+        # Template for parsing a required output
+        self.{{output1}} = self.parse_{{type3}}(d, "{{output1}}")
+        # Template for parsing an optional output
+        self.{{output2}} = self.parse_{{type4}}(d, "{{output2}}", default=None)
 
 
 #
@@ -654,13 +660,16 @@ class ParametersConfig(Config):
     '''Parameter configuration settings.'''
 
     Parameters:
-        {{input}} ({{type}}): [{{default}}] {{description}}
+        {{parameter1}} ({{type5}}): {{description5}}
+        {{parameter2}} ({{type6}}): [{{default1}}] {{description6}}
     '''
 
     def __init__(self, d):
-        # Template for parsing a parameter with a default value
-        self.{{parameter}} = self.parse_{{type}}(
-            d, "{{parameter}}", default={{default}})
+        # Template for parsing a required parameter
+        self.{{parameter1}} = self.parse_{{type5}}(d, "{{parameter1}}")
+        # Template for parsing an optional parameter
+        self.{{parameter2}} = self.parse_{{type6}}(
+            d, "{{parameter2}}", default={{default1}})
 
 
 #

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -285,9 +285,8 @@ class PipelineBuilder(object):
         # Populate module parameters
         module_params = defaultdict(dict)
         for param_str, param in iteritems(pmeta.parameters):
-            val, found = _get_param_value(param_str, param, self.request)
-            if found:
-                module_params[param.module][param.name] = val
+            val = _get_param_value(param_str, param, self.request)
+            module_params[param.module][param.name] = val
 
         # Generate module configs
         for module in pmeta.execution_order:
@@ -344,30 +343,22 @@ def _get_param_value(param_str, param, request):
         request: the PipelineBuildRequest instance
 
     Returns:
-        val: the parameter value, or None if a value could not be found
-        found: True/False
+        val: the parameter value
     '''
     if param_str in request.parameters:
         # User-set parameter
         val = request.parameters[param_str]
-        found = True
     elif param.has_set_value:
         # Pipeline-set parameter
         val = param.set_value
-        found = True
-    elif param.has_default_value:
-         # Module-default value
-         val = param.default_value
-         found = True
     else:
-        val = None
-        found = False
+        # Module-default value
+        val = param.default_value
 
-    if found:
-        # Resolve parameter value
+    if val is not None:
         val = etat.resolve_value(val, param.param.type)
 
-    return val, found
+    return val
 
 
 def _get_incoming_connections(module, connections):

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -105,10 +105,9 @@ class PipelineBuildRequest(Configurable):
         # Ensure that required inputs were supplied
         for miname, miobj in iteritems(self.metadata.inputs):
             if miobj.is_required and miname not in self.inputs:
-                raise PipelineBuildRequestError((
+                raise PipelineBuildRequestError(
                     "Required input '%s' of pipeline '%s' was not "
-                    "supplied") % (miname, self.pipeline)
-                )
+                    "supplied" % (miname, self.pipeline))
 
     def _validate_parameters(self):
         # Validate parameters
@@ -118,18 +117,16 @@ class PipelineBuildRequest(Configurable):
                     "Pipeline '%s' has no tunable parameter '%s'" % (
                         self.pipeline, pname))
             if not self.metadata.is_valid_parameter(pname, pval):
-                raise PipelineBuildRequestError((
+                raise PipelineBuildRequestError(
                     "'%s' is not a valid value for parameter '%s' of pipeline "
-                    "'%s'") % (pval, pname, self.pipeline)
-                )
+                    "'%s'" % (pval, pname, self.pipeline))
 
         # Ensure that required parmeters were supplied
         for mpname, mpobj in iteritems(self.metadata.parameters):
             if mpobj.is_required and mpname not in self.parameters:
-                raise PipelineBuildRequestError((
+                raise PipelineBuildRequestError(
                     "Required parameter '%s' of pipeline '%s' was not "
-                    "specified") % (mpname, self.pipeline)
-                )
+                    "specified" % (mpname, self.pipeline))
 
 
 class PipelineBuildRequestError(Exception):

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -97,10 +97,9 @@ class PipelineBuildRequest(Configurable):
                 raise PipelineBuildRequestError(
                     "Pipeline '%s' has no input '%s'" % (self.pipeline, iname))
             if not self.metadata.is_valid_input(iname, ipath):
-                raise PipelineBuildRequestError((
+                raise PipelineBuildRequestError(
                     "'%s' is not a valid value for input '%s' of pipeline "
-                    "'%s'") % (ipath, iname, self.pipeline)
-                )
+                    "'%s'" % (ipath, iname, self.pipeline))
 
         # Ensure that required inputs were supplied
         for miname, miobj in iteritems(self.metadata.inputs):
@@ -254,7 +253,7 @@ class PipelineBuilder(object):
 
             # Populate inputs
             iconns = _get_incoming_connections(module, pmeta.connections)
-            for iname, inode in iteritems(mmeta.inputs):
+            for iname in mmeta.inputs:
                 if iname in iconns:
                     isrc = iconns[iname]
                     if isrc.is_pipeline_input:

--- a/eta/core/command.py
+++ b/eta/core/command.py
@@ -108,7 +108,7 @@ class BuildPipeline(Command):
     @staticmethod
     def run(args):
         # PipelineBuildRequest dictionary
-        d = args.request or {}
+        d = args.request or {"inputs": {}, "parameters": {}}
 
         # Set values interactively
         if args.name:

--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -29,6 +29,22 @@ from eta.core.serial import Serializable
 import eta.core.utils as etau
 
 
+class NoDefault(object):
+    '''A placeholder class that is typically used to distinguish between an
+    argument that has _no default value_ and an argument that has the default
+    value `None`.
+    '''
+
+    def __bool__(self):
+        '''NoDefault instances always evaluate to False.'''
+        return False
+
+
+# A singleton NoDefault value that should be used whenever one needs to allow
+# `None` to be a default value
+no_default = NoDefault()
+
+
 class Configurable(object):
     '''Base class for classes that can be initialized with a Config instance.
 
@@ -111,14 +127,6 @@ class Configurable(object):
 
 class ConfigurableError(Exception):
     '''Exception raised when an invalid Configurable is encountered.'''
-    pass
-
-
-class no_default(object):
-    '''A placeholder class typically used as a default value for a keyword
-    argument of a function to distinguish between using `None` as a default
-    value.
-    '''
     pass
 
 

--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -202,7 +202,7 @@ class ConfigBuilder(Serializable):
             attributes=self._attributes)
 
     @classmethod
-    def from_json(*args, **kwargs):
+    def from_json(cls, *args, **kwargs):
         raise NotImplementedError("ConfigBuilders cannot be read from JSON")
 
 

--- a/eta/core/metadata.py
+++ b/eta/core/metadata.py
@@ -174,15 +174,15 @@ def _get_body(field):
 
 
 def _parse_default_element(body):
-    m = re.search(r"\[(?P<default>[^\]]*)\]", body)
+    m = re.search(r"\[(?P<default>.*)\]", body)
     if m:
         try:
             raw = m.group("default")
-            default = json.loads(raw)
-        except ValueError:
+            default = eval(raw) if raw else None
+        except Exception:
             raise ModuleDocstringError(
                 "Invalid default value '%s'. Remember that default values "
-                "must be expressed as JSON, not Python values." % raw)
+                "must be valid Python expressions, not JSON." % raw)
         body = body.replace(m.group(0), "")
         required = False
     else:

--- a/eta/core/metadata.py
+++ b/eta/core/metadata.py
@@ -184,7 +184,7 @@ def _parse_default_element(body):
                 "Invalid default value '%s'. Remember that default values "
                 "must be valid Python expressions, not JSON." % raw)
         body = body.replace(m.group(0), "")
-        required = False
+        required = (raw == "")
     else:
         default = None
         required = True

--- a/eta/core/metadata.py
+++ b/eta/core/metadata.py
@@ -21,7 +21,6 @@ from future.utils import iteritems, itervalues
 # pragma pylint: enable=wildcard-import
 
 from collections import defaultdict
-import json
 import logging
 import os
 import re
@@ -98,7 +97,7 @@ class ModuleDocstring(object):
                 for field in node:
                     self._parse_field(field)
             else:
-                logger.info("Ignoring unsupported node '%s'" % node.astext())
+                logger.info("Ignoring unsupported node '%s'", node.astext())
 
     def _parse_field(self, field):
         # Parse field content

--- a/eta/core/module.py
+++ b/eta/core/module.py
@@ -272,10 +272,19 @@ class ModuleParameterConfig(Config):
         self.type = self.parse_string(d, "type")
         self.description = self.parse_string(d, "description")
         self.required = self.parse_bool(d, "required", default=True)
-        self.default = self.parse_raw(d, "default", default=None)
+        if not self.required:
+            self.default = self.parse_raw(d, "default")
+        elif "default" in d:
+            raise ConfigError(
+                "Module parameter '%s' is required, so it should not have a "
+                "default value" % self.name)
 
     def attributes(self):
-        return ["name", "type", "description", "required", "default"]
+        attrs = ["name", "type", "description", "required"]
+        if not self.required:
+            attrs.append("default")
+
+        return attrs
 
 
 class ModuleInfo(Configurable):

--- a/eta/core/module.py
+++ b/eta/core/module.py
@@ -28,7 +28,6 @@ from eta.core.config import Config, ConfigError, Configurable
 from eta.core.diagram import HasBlockDiagram, BlockdiagModule
 import eta.core.log as etal
 import eta.core.types as etat
-import eta.core.utils as etau
 
 
 def load_all_metadata():

--- a/eta/core/module.py
+++ b/eta/core/module.py
@@ -28,6 +28,7 @@ from eta.core.config import Config, ConfigError, Configurable
 from eta.core.diagram import HasBlockDiagram, BlockdiagModule
 import eta.core.log as etal
 import eta.core.types as etat
+import eta.core.utils as etau
 
 
 def load_all_metadata():
@@ -89,13 +90,14 @@ def find_all_metadata():
         ModuleMetadataError: if the module names are not unique
     '''
     d = {}
-    for pdir in eta.config.module_dirs:
-        for path in glob(os.path.join(pdir, "*.json")):
+    mdirs = etau.make_search_path(eta.config.module_dirs)
+    for mdir in mdirs:
+        for path in glob(os.path.join(mdir, "*.json")):
             name = os.path.splitext(os.path.basename(path))[0]
             if name in d:
                 raise ModuleMetadataError(
                     "Found two '%s' modules. Names must be unique." % name)
-            d[name] = os.path.abspath(path)
+            d[name] = path
 
     return d
 

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -508,9 +508,9 @@ class PipelineModule(Configurable):
     def _verify_parameter_values(self, param_dict):
         for name, val in param_dict:
             if not self.metadata.is_valid_parameter(name, val):
-                raise PipelineMetadataError((
+                raise PipelineMetadataError(
                     "'%s' is an invalid value for parameter '%s' of module "
-                    "'%s'") % (val, name, self.name))
+                    "'%s'" % (val, name, self.name))
 
 
 class PipelineNode(object):
@@ -813,9 +813,9 @@ def _parse_output(name, connections, modules):
     node_str = PipelineNode.get_output_str(name)
     sources = _get_sources_with_sink(node_str, connections)
     if len(sources) != 1:
-        raise PipelineMetadataError((
+        raise PipelineMetadataError(
             "Pipeline output '%s' must be connected to exactly one module "
-            "output, but was connected to %d") % (name, len(sources))
+            "output, but was connected to %d" % (name, len(sources))
         )
 
     source = sources[0]
@@ -845,26 +845,24 @@ def _validate_module_connections(modules, connections):
             node_str = PipelineNode.get_node_str(mname, iname)
             num_sources = len(_get_sources_with_sink(node_str, connections))
             if num_sources == 0 and node.is_required:
-                raise PipelineMetadataError((
+                raise PipelineMetadataError(
                     "Module '%s' input '%s' is required but has no incoming "
-                    "connection") % (mname, iname)
+                    "connection" % (mname, iname)
                 )
             if num_sources > 1:
-                raise PipelineMetadataError((
+                raise PipelineMetadataError(
                     "Module '%s' input '%s' must have one incoming connection "
-                    "but instead has %d incoming connections") % (
-                        mname, iname, num_sources)
-                )
+                    "but instead has %d incoming connections" % (
+                        mname, iname, num_sources))
 
         # Validate outputs
         for oname, node in iteritems(module.metadata.outputs):
             node_str = PipelineNode.get_node_str(mname, oname)
             num_sinks = len(_get_sinks_with_source(node_str, connections))
             if num_sinks == 0 and node.is_required:
-                raise PipelineMetadataError((
+                raise PipelineMetadataError(
                     "Module '%s' output '%s' is required but has no outgoing "
-                    "connections") % (mname, oname)
-                )
+                    "connections" % (mname, oname))
 
 
 def _compute_execution_order(connections):
@@ -890,8 +888,7 @@ def _compute_execution_order(connections):
     except etag.CyclicGraphError:
         raise PipelineMetadataError(
             "Unable to compute a valid execution order because the module "
-            "connections form a cyclic graph."
-        )
+            "connections form a cyclic graph.")
 
     return execution_order
 
@@ -1015,17 +1012,14 @@ def _create_node_connection(source, sink, modules):
             "'%s' cannot be a connection source" % source)
     if sink.is_pipeline_input or  sink.is_module_output:
         raise PipelineMetadataError(
-        "'%s' cannot be a connection sink" % sink)
+            "'%s' cannot be a connection sink" % sink)
     if source.is_module_output and sink.is_module_input:
         src = modules[source.module].metadata.get_output(source.node)
         snk = modules[sink.module].metadata.get_input(sink.node)
         if not issubclass(src.type, snk.type):
             raise PipelineMetadataError(
-                (
-                    "Module output '%s' ('%s') is not a valid input "
-                    "to module '%s' ('%s')"
-                ) % (source, src.type, sink, snk.type)
-            )
+                "Module output '%s' ('%s') is not a valid input to module "
+                "'%s' ('%s')" % (source, src.type, sink, snk.type))
 
     return PipelineConnection(source, sink)
 

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -31,7 +31,6 @@ import eta.core.graph as etag
 import eta.core.job as etaj
 import eta.core.log as etal
 import eta.core.module as etam
-from eta.core.serial import Serializable
 import eta.core.status as etas
 import eta.core.types as etat
 import eta.core.utils as etau
@@ -321,7 +320,7 @@ class PipelineInfo(Configurable):
         type_ = etat.parse_type(type_str)
         if not etat.is_pipeline(type_):
             raise PipelineMetadataError(
-                    "'%s' is not a valid pipeline type" % type_)
+                "'%s' is not a valid pipeline type" % type_)
         return type_
 
 
@@ -406,7 +405,7 @@ class PipelineParameter(object):
     @property
     def is_required(self):
         '''Returns True/False if this parameter must be set by the user.'''
-        return (self.param.is_required and not self.has_set_value)
+        return self.param.is_required and not self.has_set_value
 
     @property
     def has_set_value(self):
@@ -782,7 +781,7 @@ def _parse_input(name, connections, modules):
     '''
     node_str = PipelineNode.get_input_str(name)
     sinks = _get_sinks_with_source(node_str, connections)
-    if len(sinks) == 0:
+    if not sinks:
         raise PipelineMetadataError(
             "Pipeline input '%s' is not connected to any modules" % name)
 
@@ -858,8 +857,8 @@ def _validate_module_connections(modules, connections):
         # Validate outputs
         for oname, node in iteritems(module.metadata.outputs):
             node_str = PipelineNode.get_node_str(mname, oname)
-            num_sinks = len(_get_sinks_with_source(node_str, connections))
-            if num_sinks == 0 and node.is_required:
+            sinks = _get_sinks_with_source(node_str, connections)
+            if not sinks and node.is_required:
                 raise PipelineMetadataError(
                     "Module '%s' output '%s' is required but has no outgoing "
                     "connections" % (mname, oname))

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -879,11 +879,12 @@ def _compute_execution_order(connections):
     '''
     module_graph = etag.DirectedGraph()
     for c in connections:
-        if c.is_module_connection:
-            module_graph.add_edge(c.source.module, c.sink.module)
+        module_graph.add_edge(c.source.module, c.sink.module)
 
     try:
         execution_order = module_graph.sort()
+        execution_order.remove(PIPELINE_INPUT_NAME)
+        execution_order.remove(PIPELINE_OUTPUT_NAME)
     except etag.CyclicGraphError:
         raise PipelineMetadataError(
             "Unable to compute a valid execution order because the module "

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -204,13 +204,14 @@ def find_all_metadata():
         PipelineMetadataError: if the pipeline names are not unique
     '''
     d = {}
-    for pdir in eta.config.pipeline_dirs:
+    pdirs = etau.make_search_path(eta.config.pipeline_dirs)
+    for pdir in pdirs:
         for path in glob(os.path.join(pdir, "*.json")):
             name = os.path.splitext(os.path.basename(path))[0]
             if name in d:
                 raise PipelineMetadataError(
                     "Found two '%s' pipelines. Names must be unique." % name)
-            d[name] = os.path.abspath(path)
+            d[name] = path
 
     return d
 

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -40,8 +40,7 @@ def load_json(path_or_str):
     '''
     if os.path.isfile(path_or_str):
         return read_json(path_or_str)
-    else:
-        return json.loads(path_or_str)
+    return json.loads(path_or_str)
 
 
 def read_json(path):

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -30,7 +30,7 @@ import eta.core.utils as etau
 import eta.core.weights as etaw
 
 
-###### Utilities ###############################################################
+###### Utilities ##############################################################
 
 
 def parse_type(type_str):
@@ -111,14 +111,14 @@ class ConcreteDataParams(object):
         return params
 
 
-###### Base type ###############################################################
+###### Base type ##############################################################
 
 
 class Type(object):
     '''The base type for all types.'''
 
 
-###### Pipeline types ##########################################################
+###### Pipeline types #########################################################
 
 
 class Pipeline(Type):
@@ -126,7 +126,7 @@ class Pipeline(Type):
     pass
 
 
-###### Module types ############################################################
+###### Module types ###########################################################
 
 
 class Module(Type):
@@ -134,7 +134,7 @@ class Module(Type):
     pass
 
 
-###### Builtin types ###########################################################
+###### Builtin types ##########################################################
 
 
 class Builtin(Type):
@@ -322,7 +322,7 @@ class RelativeRectangle(Object):
         )
 
 
-###### Data types ##############################################################
+###### Data types #############################################################
 
 
 class Data(Type):
@@ -399,7 +399,7 @@ class FileSequence(AbstractData):
         if not String.is_valid_value(path):
             return False
         try:
-            path % 1
+            _ = path % 1
             return True
         except TypeError:
             return False
@@ -415,7 +415,7 @@ class DualFileSequence(AbstractData):
         if not String.is_valid_value(path):
             return False
         try:
-            path % (1, 2)
+            _ = path % (1, 2)
             return True
         except TypeError:
             return False

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -51,7 +51,7 @@ def parse_type(type_str):
 
 
 def resolve_value(val, type_):
-    '''Resolves the given value of the given type.'''
+    '''Resolves the given value of the given type, if necessary.'''
     if isinstance(type_, Weights):
         val = etaw.find_weights(val)
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -214,6 +214,28 @@ def delete_file(path):
         pass
 
 
+def make_search_path(dirs):
+    '''Makes a search path for the given directories by doing the following:
+        - converting all paths to absolute paths
+        - removing duplicate directories
+
+    The order of the original directories is preserved.
+
+    Args:
+        dirs: a list of relative or absolute directory paths
+
+    Returns:
+        a list of absolute paths with duplicates removed
+    '''
+    paths = []
+    for path in dirs:
+        apath = os.path.abspath(path)
+        if apath not in paths:
+            paths.append(apath)
+
+    return paths
+
+
 def ensure_path(path):
     '''Ensures that the given path is ready for writing by deleting any
     existing file and ensuring that the base directory exists.

--- a/eta/modules/clip_videos.py
+++ b/eta/modules/clip_videos.py
@@ -69,9 +69,9 @@ class ParametersConfig(Config):
     '''Parameter configuration settings.
 
     Parameters:
-        frames (eta.core.types.String): [null] A frames string specifying the
+        frames (eta.core.types.String): [None] A frames string specifying the
             clips to generate
-        events_json_path (eta.core.types.EventSeries): [null] An EventSeries
+        events_json_path (eta.core.types.EventSeries): [None] An EventSeries
             specifying the clips to generate
     '''
 

--- a/eta/modules/embed_vgg16.py
+++ b/eta/modules/embed_vgg16.py
@@ -76,7 +76,7 @@ class ParametersConfig(Config):
     '''Parameter configuration settings.
 
     Parameters:
-        crop_box (eta.core.types.Rectangle): [null] A region of interest of
+        crop_box (eta.core.types.Rectangle): [None] A region of interest of
             each frame to extract before embedding
     '''
 

--- a/eta/modules/resize_videos.json
+++ b/eta/modules/resize_videos.json
@@ -47,7 +47,7 @@
         {
             "name": "size",
             "type": "eta.core.types.Array",
-            "description": "The output [width, height] of the video",
+            "description": "The output (width, height) of the video",
             "required": false,
             "default": null
         }

--- a/eta/modules/resize_videos.py
+++ b/eta/modules/resize_videos.py
@@ -67,12 +67,12 @@ class ParametersConfig(Config):
     '''Parameter configuration settings.
 
     Parameters:
-        size (eta.core.types.Array): [null] The output [width, height] of the
+        size (eta.core.types.Array): [None] The output (width, height) of the
             video
-        scale (eta.core.types.Number): [null] A numeric scale factor to apply
-        scale_str (eta.core.types.String): [null] A scale string; an argument
+        scale (eta.core.types.Number): [None] A numeric scale factor to apply
+        scale_str (eta.core.types.String): [None] A scale string; an argument
             for ffmpeg scale=
-        ffmpeg_out_opts (eta.core.types.Array): [null] An array of ffmpeg
+        ffmpeg_out_opts (eta.core.types.Array): [None] An array of ffmpeg
             output options
     '''
 

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -74,8 +74,8 @@ class ParametersConfig(Config):
     @todo add a fps/clips module keyword to handle each case separately.
 
     Parameters:
-        fps (eta.core.types.Number): [null] The output frame rate
-        clips_path (eta.core.types.EventDetection): [null] Per-frame binary
+        fps (eta.core.types.Number): [None] The output frame rate
+        clips_path (eta.core.types.EventDetection): [None] Per-frame binary
             labels indicating which frames to sample
     '''
 


### PR DESCRIPTION
This pull request simplifies the definition of module parameters for metadata purposes. Now module parameters can be either be:
- `required`: the user must provide a value
- `optional`: the user may provide a value for the parameter, but a default value is provided in case they don't
(Previously there was a confusing hybrid notion of a required parameter that provides a default value)

This PR also:
- updates the module metadata generation tool to require default values to be expressed in Python format, not JSON. This is more intuitive as the values themselves are parsed from `.py` files
- fixes a bug in the module metadata generation script that caused stray `default` attributes to appear in the definitions of required fields