### PR TITLE
ETA Image/Video Color Format Conversion to RGB

### DIFF
--- a/docs/core_dev_guide.md
+++ b/docs/core_dev_guide.md
@@ -76,3 +76,11 @@ more tips on writing cross-compatible code in ETA.
 We require all ETA code to adhere to our Python style guide. See
 `style_guide.md` for a description of our style, and see `linting_guide.md`
 for details on our code linting tools.
+
+
+## Image and Video Frame Color Formats
+
+ETA uses an RGB format for images and video frames.  All functions that read/write images and process images hence expect an RGB format.  This is not always the case: the popular OpenCV library (on which ETA partially relies) uses a BGR format.  This has two impacts:
+
+1. When we use OpenCV for IO, we explicitly convert to BGR from RGB, which although trivial can have a performance impact.
+2. If you use OpenCV inside of your code that uses ETA for image and video frame representation, then you need to be careful to convert to BGR before actually invoking the `cv2` functions.  We provide ample conversion routines in the `eta.core.image` module.

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -625,7 +625,7 @@ class ORBFeaturizer(Featurizer):
         return 32 * self.num_keypoints
 
     def _featurize(self, img):
-        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        gray = etai.rgb_to_gray(img)
         return self.orb.detectAndCompute(gray, None)[1].flatten()
 
 

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -1,10 +1,16 @@
 '''
 Core image processing tools.
 
+ETA uses OpenCV for some of its image-related processing.  OpenCV stores its
+images in BGR format.  ETA stores its images in RGB format.  This module's
+contract is that it expects RGB to be passed to it and RGB to be expected from
+it.
+
 Copyright 2017, Voxel51, LLC
 voxel51.com
 
 Brian Moore, brian@voxel51.com
+Jason Corso, jason@voxel51.com
 '''
 # pragma pylint: disable=redefined-builtin
 # pragma pylint: disable=unused-wildcard-import

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -478,6 +478,20 @@ def bgr_to_hex(blue, green, red):
     return rgb_to_hex(red, green, blue)
 
 
+def rgb_to_gray(img):
+    '''Converts the input RGB image to a grayscale image.'''
+    if is_gray(img):
+        return img
+    return cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
+
+
+def bgr_to_gray(img):
+    '''Converts the input BGR image to a grayscale image.'''
+    if is_gray(img):
+        return img
+    return cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+
+
 def rgb_to_bgr(img):
     '''Converts an RGB image to a BGR image (supports alpha).'''
     return _exchange_rb(img)

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -6,8 +6,7 @@ images in BGR format.  ETA stores its images in RGB format.  This module's
 contract is that it expects RGB to be passed to it and RGB to be expected from
 it.
 
-
-Copyright 2017, Voxel51, LLC
+Copyright 2017-2018, Voxel51, LLC
 voxel51.com
 
 Brian Moore, brian@voxel51.com
@@ -46,12 +45,12 @@ def decode(b, flag=cv2.IMREAD_UNCHANGED):
         bytes: the raw bytes of an image (e.g. from read() or from a web
             download)
         flag: an optional OpenCV image format flag. By default, the image is
-            returned in it's native format (color, grayscale, transparent, ...)
+            returned in its native format (color, grayscale, transparent, ...)
 
     Returns:
         A uint8 numpy array containing the image
     '''
-    vec = np.asarray(bytearray(b), dtype="uint8")
+    vec = np.asarray(bytearray(b), dtype=np.uint8)
     return _exchange_rb(cv2.imdecode(vec, flag))
 
 
@@ -61,7 +60,7 @@ def download(url, flag=cv2.IMREAD_UNCHANGED):
     Args:
         url: the URL of the image
         flag: an optional OpenCV image format flag. By default, the image is
-            returned in it's raw format
+            returned in its raw format
 
     Returns:
         A uint8 numpy array containing the image
@@ -75,7 +74,7 @@ def read(path, flag=cv2.IMREAD_UNCHANGED):
     Args:
         path: the path to the image on disk
         flag: an optional OpenCV image format flag. By default, the image is
-            returned in it's native format (color, grayscale, transparent, etc)
+            returned in its native format (color, grayscale, transparent, ...)
 
     Returns:
         A uint8 numpy array containing the image
@@ -105,7 +104,7 @@ def create(width, height, background=None):
         height (int): height of the image to create in pixels
         background (string): hex RGB (eg, "#ffffff")
     '''
-    image = np.zeros((height, width, 3), np.uint8)
+    image = np.zeros((height, width, 3), dtype=np.uint8)
 
     if background:
         image[:] = hex_to_rgb(background)
@@ -116,7 +115,7 @@ def create(width, height, background=None):
 def overlay(im1, im2, x0=0, y0=0):
     '''Overlays im2 onto im1 at the specified coordinates.
 
-    ***Caution: im1 will be modified in-place if possible.***
+    *** Caution: im1 will be modified in-place if possible. ***
 
     Args:
         im1: a non-transparent image

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -492,6 +492,16 @@ def bgr_to_gray(img):
     return cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 
 
+def gray_to_bgr(img):
+    '''Convert a grayscale image to an BGR image.'''
+    return cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+
+
+def gray_to_rgb(img):
+    '''Convert a grayscale image to an RGB image.'''
+    return cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+
+
 def rgb_to_bgr(img):
     '''Converts an RGB image to a BGR image (supports alpha).'''
     return _exchange_rb(img)

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -838,7 +838,7 @@ class ModelManager(Configurable, Serializable):
             ModelError: if model downloading is not currently allowed
         '''
         if force or not os.path.isfile(model_path):
-            if not eta.allow_model_downloads:
+            if not eta.config.allow_model_downloads:
                 raise ModelError(
                     "Model downloading is currently disabled. Modify your ETA "
                     "config to change this setting.")

--- a/eta/core/primitives.py
+++ b/eta/core/primitives.py
@@ -22,6 +22,7 @@ from builtins import *
 import cv2
 import numpy as np
 
+import eta.core.image as etai
 import eta.core.utils as etau
 import eta.core.video as etav
 
@@ -125,7 +126,7 @@ def polar_to_img(polar):
     hsv[..., 1] = 255
     #hsv[..., 2] = np.minimum(255 * mag, 255)  # [0, 255]
     hsv[..., 2] = cv2.normalize(mag, None, 0, 255, cv2.NORM_MINMAX)  # [0, 255]
-    return cv2.cvtColor(hsv.astype(np.uint8), cv2.COLOR_HSV2BGR)
+    return cv2.cvtColor(hsv.astype(np.uint8), cv2.COLOR_HSV2RGB)
 
 
 class FarnebackDenseOpticalFlow(DenseOpticalFlow):
@@ -174,7 +175,7 @@ class FarnebackDenseOpticalFlow(DenseOpticalFlow):
             cv2.OPTFLOW_FARNEBACK_GAUSSIAN if use_gaussian_filter else 0)
 
     def process_frame(self, img):
-        curr_frame = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        curr_frame = etai.rgb_to_gray(img)
         if self._prev_frame is None:
             # There is no previous frame for the first frame, so we set
             # it to the current frame, which implies that the flow for
@@ -423,7 +424,7 @@ class EdgeDetector(object):
 
                 if vid_path:
                     # Write edges video
-                    p.write(cv2.cvtColor(edges, cv2.COLOR_GRAY2BGR))
+                    p.write(cv2.cvtColor(edges, cv2.COLOR_GRAY2RGB))
 
     def process_frame(self, img):
         '''Performs edge detection on the next frame.
@@ -466,7 +467,7 @@ class CannyEdgeDetector(EdgeDetector):
 
     def process_frame(self, img):
         # works in OpenCV 3 and OpenCV 2
-        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        gray = etai.rgb_to_gray(img)
         return cv2.Canny(
             gray, threshold1=self.threshold1, threshold2=self.threshold2,
             apertureSize=self.aperture_size, L2gradient=self.l2_gradient)
@@ -475,7 +476,7 @@ class CannyEdgeDetector(EdgeDetector):
 class FeaturePointDetector(object):
     '''Base class for feature point detection methods.'''
 
-    KEYPOINT_DRAW_COLOR = (0, 255, 0)
+    KEYPOINT_DRAW_COLOR = (0, 255, 0)  # BGR
 
     def process_video(self, input_path, coords_path=None, vid_path=None):
         '''Detect feature points using self.detector.
@@ -504,8 +505,10 @@ class FeaturePointDetector(object):
 
                 if vid_path:
                     # Write feature points video
-                    img = cv2.drawKeypoints(
-                        img, keypoints, None, color=self.KEYPOINT_DRAW_COLOR)
+                    img = etai.bgr_to_rgb(
+                        cv2.drawKeypoints(
+                            etai.rgb_to_bgr(img), keypoints, None,
+                            color=self.KEYPOINT_DRAW_COLOR))
                     p.write(img)
 
     def process_frame(self, img):
@@ -548,7 +551,7 @@ class HarrisFeaturePointDetector(FeaturePointDetector):
 
     def process_frame(self, img):
         # works in OpenCV 3 and OpenCV 2
-        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        gray = etai.rgb_to_gray(img)
         gray = np.float32(gray)
         response = cv2.cornerHarris(
             gray, blockSize=self.block_size, ksize=self.aperture_size,

--- a/eta/core/primitives.py
+++ b/eta/core/primitives.py
@@ -322,6 +322,7 @@ class MOG2BackgroundSubtractor(BackgroundSubtractor):
         self._fgbg = None
 
     def process_frame(self, img):
+        # We pass in an RGB image b/c this algo is invariant to channel order
         fgmask = self._fgbg.apply(img, None, self.learning_rate)
         bgimg = self._fgbg.getBackgroundImage()
         return fgmask, bgimg
@@ -378,6 +379,7 @@ class KNNBackgroundSubtractor(BackgroundSubtractor):
         self._fgbg = None
 
     def process_frame(self, img):
+        # We pass in an RGB image b/c this algo is invariant to channel order
         fgmask = self._fgbg.apply(img, None, self.learning_rate)
         bgimg = self._fgbg.getBackgroundImage()
         return fgmask, bgimg
@@ -476,7 +478,7 @@ class CannyEdgeDetector(EdgeDetector):
 class FeaturePointDetector(object):
     '''Base class for feature point detection methods.'''
 
-    KEYPOINT_DRAW_COLOR = (0, 255, 0)  # BGR
+    KEYPOINT_RGB_COLOR = (0, 255, 0)  # RGB
 
     def process_video(self, input_path, coords_path=None, vid_path=None):
         '''Detect feature points using self.detector.
@@ -505,10 +507,10 @@ class FeaturePointDetector(object):
 
                 if vid_path:
                     # Write feature points video
-                    img = etai.bgr_to_rgb(
-                        cv2.drawKeypoints(
-                            etai.rgb_to_bgr(img), keypoints, None,
-                            color=self.KEYPOINT_DRAW_COLOR))
+                    # We pass in an RGB image b/c this function is invariant to
+                    # channel order
+                    img = cv2.drawKeypoints(
+                        img, keypoints, None, color=self.KEYPOINT_RGB_COLOR)
                     p.write(img)
 
     def process_frame(self, img):
@@ -550,9 +552,8 @@ class HarrisFeaturePointDetector(FeaturePointDetector):
         self.k = k
 
     def process_frame(self, img):
-        # works in OpenCV 3 and OpenCV 2
-        gray = etai.rgb_to_gray(img)
-        gray = np.float32(gray)
+        # Works in OpenCV 3 and OpenCV 2
+        gray = np.float32(etai.rgb_to_gray(img))
         response = cv2.cornerHarris(
             gray, blockSize=self.block_size, ksize=self.aperture_size,
             k=self.k)
@@ -590,6 +591,7 @@ class FASTFeaturePointDetector(FeaturePointDetector):
                 nonmaxSuppression=self.non_max_suppression)
 
     def process_frame(self, img):
+        # We pass in an RGB image b/c this algo is invariant to channel order
         return self._detector.detect(img, None)
 
 
@@ -621,6 +623,7 @@ class ORBFeaturePointDetector(FeaturePointDetector):
                 nfeatures=self.max_num_features, scoreType=self.score_type)
 
     def process_frame(self, img):
+        # We pass in an RGB image b/c this algo is invariant to channel order
         return self._detector.detect(img, None)
 
 

--- a/eta/core/vgg16.py
+++ b/eta/core/vgg16.py
@@ -35,7 +35,6 @@ from builtins import *
 import logging
 import os
 
-import cv2
 import numpy as np
 import tensorflow as tf
 
@@ -469,11 +468,9 @@ class VGG16Featurizer(Featurizer):
 
     def _featurize(self, img):
         '''Featurizes the image using the VGG-16 network.'''
-        if len(img.shape) == 2:
-            # Grayscale
-            img = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
-        elif img.shape[2] == 4:
-            # RGBA
+        if etai.is_gray(img):
+            img = etai.gray_to_rgb(img)
+        elif etai.has_alpha(img):
             img = img[:, :, :3]
 
         img = etai.resize(img, 224, 224)

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -6,7 +6,6 @@ images in BGR format.  ETA stores its images in RGB format.  This module's
 contract is that it expects RGB to be passed to it and RGB to be expected from
 it.  This includes video frames.
 
-
 Copyright 2017-2018, Voxel51, LLC
 voxel51.com
 

--- a/eta/models/manifest.json
+++ b/eta/models/manifest.json
@@ -6,7 +6,7 @@
             "version": null,
             "manager": {
                 "config": {
-                    "google_drive_id": "0B7phNvpRqNdpT0lZU1NOWXIzRlE"
+                    "google_drive_id": "0B_-5gc091ngGMzBFMVJ0RE9HNmc"
                 },
                 "type": "eta.core.models.ETAModelManager"
             },

--- a/examples/clean.bash
+++ b/examples/clean.bash
@@ -4,7 +4,7 @@
 # Usage:
 #   bash clean.bash
 #
-# Copyright 2017, Voxel51, LLC
+# Copyright 2017-2018, Voxel51, LLC
 # voxel51.com
 #
 # Brian Moore, brian@voxel51.com

--- a/examples/demo_embed_vgg16/embed_video-config.json
+++ b/examples/demo_embed_vgg16/embed_video-config.json
@@ -7,6 +7,7 @@
     "video_path": "../data/water-20frames/%05d.png",
     "video_frames_featurizer": {
         "backing_path": "out/eta-backing",
+        "backing_manager": "manual",
         "frame_featurizer": {
             "type": "eta.core.vgg16.VGG16Featurizer",
             "config": {}

--- a/examples/demo_images.py
+++ b/examples/demo_images.py
@@ -36,11 +36,11 @@ here = os.path.dirname(__file__)
 path1 = os.path.join(here, "data/water.jpg")
 path2 = os.path.join(here, "data/logo.pdf")
 
-img1 = etai.resize(etai.read(path1), height=540)
-img2 = etai.rasterize(path2, width=704)
+img1 = etai.resize(etai.read(path1), width=1024)
+img2 = etai.rasterize(path2, width=400)
 
-x0 = etai.Width("13.3%").render(img=img1)
-y0 = etai.Height("10%").render(img=img1)
+x0 = etai.Width("30%").render(img=img1)
+y0 = etai.Height("15%").render(img=img1)
 img3 = etai.overlay(img1, img2, x0=x0, y0=y0)
 
 plot(img3)

--- a/examples/demo_images.py
+++ b/examples/demo_images.py
@@ -27,7 +27,7 @@ import eta.core.image as etai
 
 
 def plot(img):
-    cv2.imshow("*** Press any key to exit ***", img)
+    cv2.imshow("*** Press any key to exit ***", etai.rgb_to_bgr(img))
     cv2.waitKey(0)
     cv2.destroyAllWindows()
 

--- a/examples/download_data.bash
+++ b/examples/download_data.bash
@@ -4,7 +4,7 @@
 # Usage:
 #   bash download_data.bash
 #
-# Copyright 2017, Voxel51, LLC
+# Copyright 2017-2018, Voxel51, LLC
 # voxel51.com
 #
 # Brian Moore, brian@voxel51.com
@@ -15,7 +15,7 @@ EXAMPLES=`dirname "$0"`
 ZIP="${EXAMPLES}/data.zip"
 
 python -c "from eta.core import web;\
-web.download_google_drive_file('${FILE}', path='${ZIP}')"
+    web.download_google_drive_file('${FILE}', path='${ZIP}')"
 
 unzip -o "${ZIP}" -d "${EXAMPLES}"
 rm "${ZIP}"


### PR DESCRIPTION
ETA established the contract that all images and videos would be represented internally at RGB rather than BGR.  This code enforces that through ETA.

- `eta.core.image` updated to include the contract
- `eta.core.image` updated to include more conversion routines and organized the code.
- `eta.core.video` updated to support the contract
- `eta.core.features` and `eta.core.primitives` updated to support the contract
- `eta.core.vgg16` refactored to completely remove cv2 direct dependency.
- demo files updated to support the contract
- documentation added to support it.