### PR TITLE
Tar extraction and environment variable list

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -14,6 +14,7 @@
         "./models"
     ],
     "pythonpath_dirs": [],
+    "environment_vars": {},
     "max_model_versions_to_keep": -1,
     "allow_model_downloads": true,
     "default_sequence_idx" : "%05d",

--- a/eta/__init__.py
+++ b/eta/__init__.py
@@ -14,6 +14,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import *
+from future.utils import iteritems
 # pragma pylint: enable=redefined-builtin
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
@@ -23,7 +24,7 @@ import os
 import sys
 
 import eta.constants as etac
-from eta.core.config import EnvConfig
+from eta.core.config import Config, EnvConfig
 import eta.core.log as etal
 import eta.core.utils as etau
 
@@ -63,6 +64,12 @@ class ETAConfig(EnvConfig):
             d, "default_video_ext", env_var="ETA_DEFAULT_VIDEO_EXT",
             default=".mp4")
 
+        # This field does not support an environment variable syntax because it
+        # contains environment variables itself and the user can just set them
+        # directly if they prefer to configure outside of this config file
+        self.environment_vars = Config.parse_dict(
+            d, "environment_vars", default={})
+
 
 def startup_message():
     '''Logs ETA startup message.'''
@@ -82,3 +89,7 @@ config = ETAConfig.from_json(etac.CONFIG_JSON_PATH)
 
 # Augment system path
 sys.path = sys.path[:1] + config.pythonpath_dirs + sys.path[1:]
+
+# Set any environment variables
+for var, val in iteritems(config.environment_vars):
+    os.environ[var] = val

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -35,6 +35,7 @@ import six
 import string
 import subprocess
 import sys
+import tarfile
 import tempfile
 
 import eta.constants as etac
@@ -377,6 +378,34 @@ def move_file(inpath, outpath):
     '''
     ensure_basedir(outpath)
     shutil.move(inpath, outpath)
+
+
+def extract_tar(inpath, outdir=None, delete_tar=False):
+    '''Extracts the .tar or .targz file into the same directory and then
+    optionally deletes the tarball.
+
+    Args:
+        inpath: the path to the .tar or .tar.gz file
+        outdir: the directory into which to extract the archive contents. By
+            default, the directory containing the tar file is used
+        delete_tar: whether to delete the tar archive after extraction. By
+            default, this is False
+    '''
+    if inpath.endswith("tar"):
+        format = "r:"
+    elif inpath.endswith("tar.gz"):
+        format = "r:gz"
+    else:
+        raise ValueError(
+            "Expected file '%s' to have extension .tar or .tar.gz in order "
+            "to extract it" % inpath)
+
+    outdir = outdir or os.path.dirname(inpath) or "."
+    with tarfile.open(inpath, format) as tar:
+        tar.extractall(path=outdir)
+
+    if delete_tar:
+        delete_file(inpath)
 
 
 def multiglob(*patterns, **kwargs):

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -381,11 +381,11 @@ def move_file(inpath, outpath):
 
 
 def extract_tar(inpath, outdir=None, delete_tar=False):
-    '''Extracts the .tar or .targz file into the same directory and then
-    optionally deletes the tarball.
+    '''Extracts the .tar, tar.gz, .tgz, .tar.bz, and .tbz files into the same
+    directory and then optionally deletes the tarball.
 
     Args:
-        inpath: the path to the .tar or .tar.gz file
+        inpath: the path to the tar or compressed tar file
         outdir: the directory into which to extract the archive contents. By
             default, the directory containing the tar file is used
         delete_tar: whether to delete the tar archive after extraction. By
@@ -393,12 +393,14 @@ def extract_tar(inpath, outdir=None, delete_tar=False):
     '''
     if inpath.endswith("tar"):
         format = "r:"
-    elif inpath.endswith("tar.gz"):
+    elif inpath.endswith("tar.gz") or inpath.endswith("tgz"):
         format = "r:gz"
+    elif inpath.endswith("tar.bz") or inpath.endswith("tbz"):
+        format = "r:bz2"
     else:
         raise ValueError(
-            "Expected file '%s' to have extension .tar or .tar.gz in order "
-            "to extract it" % inpath)
+            "Expected file '%s' to have extension .tar, .tar.gz, .tgz,"
+            ".tar.bz, or .tbz in order to extract it" % inpath)
 
     outdir = outdir or os.path.dirname(inpath) or "."
     with tarfile.open(inpath, format) as tar:

--- a/eta/core/ziputils.py
+++ b/eta/core/ziputils.py
@@ -2,6 +2,13 @@
 '''
 Utility functions for working with zipped directories of files.
 
+Note that this module is not intended to provide general purpose zip-related
+utilities such as zipping and extracting arbitrary files and directories.
+For such functionality, see `eta.core.utils`. Rather, this module is
+specifically designed to automate the processing of parallel files and
+directories that arise when ETA modules support both both single inputs or zip
+files containing multiple inputs of the same type.
+
 Copyright 2017-2018, Voxel51, LLC
 voxel51.com
 


### PR DESCRIPTION
Introduces two small conveniences:
- an `eta.core.utils.extract_tar` method to extract a `.tar` or `.tar.gz`
- the ability to define a dict of environment variables to set in one's ETA config. This often comes in handy