### PR TITLE
Making `ObjectContainer` reflective

### DIFF
--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -64,6 +64,9 @@ class ObjectContainer(Serializable):
     def __iter__(self):
         return iter(self.objects)
 
+    def attributes(self):
+        return ["_CLS", "_OBJ_CLS", "objects"]
+
     def serialize(self):
         '''Custom serialization implementation for ObjectContainers that embeds
         the class name and the object class name in the JSON to enable


### PR DESCRIPTION
Making `eta.core.objects.ObjectContainer` embed the subclass name and underlying object class name in its JSON representation, so object containers can optionally be read reflectively from disk.

This change is fully backwards compatible.

Example:
```py
from eta.core.objects import Frame, ObjectContainer

frame = Frame(...)
frame.write_json("frame.json")

frame2 = ObjectContainer.from_json("frame.json")
print(frame2.__class__)  # Frame, not ObjectContainer
```