### PR TITLE
DataContainer added

### DIFF
--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -89,10 +89,6 @@ class DataContainer(Serializable):
         return iter(self._data)
 
     @property
-    def _CLS(self):
-        return etau.get_class_name(self)
-
-    @property
     def _data(self):
         '''Convenience accessor to get the list of data instances stored
         independent of what the name of that attribute is.
@@ -114,12 +110,12 @@ class DataContainer(Serializable):
         '''Adds a data instance to the container.
 
         Args:
-            instance: an instance for this container
+            instance: an instance of `_DATA_CLS`
         '''
         self._data.append(instance)
 
     def attributes(self):
-        return ["_CLS", "_DATA_CLS", "_DATA_ATTR", self._DATA_ATTR]
+        return ["_CLS", "_DATA_CLS", self._DATA_ATTR]
 
     def count_matches(self, filters, match=any):
         '''Counts number of data instances that match the filters.
@@ -157,9 +153,21 @@ class DataContainer(Serializable):
         })
 
     @classmethod
+    def get_class_name(cls):
+        '''Returns the fully-qualified class name string of this container.'''
+        return etau.get_class_name(cls)
+
+    @classmethod
     def get_data_class(cls):
         '''Gets the class of data instances stored in this container.'''
         return cls._DATA_CLS
+
+    @classmethod
+    def get_data_class_name(cls):
+        '''Returns the fully-qualified class name string of the data in this
+        container.
+        '''
+        return etau.get_class_name(cls._DATA_CLS)
 
     def get_matches(self, filters, match=any):
         '''Returns a data container containing only instances that match the
@@ -189,8 +197,8 @@ class DataContainer(Serializable):
         reflective parsing when reading from disk.
         '''
         d = OrderedDict()
-        d["_CLS"] = etau.get_class_name(self)
-        d["_DATA_CLS"] = etau.get_class_name(self._DATA_CLS)
+        d["_CLS"] = self.get_class_name()
+        d["_DATA_CLS"] = self.get_data_class_name()
         d[self._DATA_ATTR] = [o.serialize() for o in self._data]
         return d
 

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -68,20 +68,17 @@ class DataContainer(Serializable):
         '''
         self._validate()
 
-        data = []
-        if kwargs is not None:
-            if self._DATA_ATTR not in kwargs:
-                raise ValueError(
-                    "DataContainer expects the class data attribute name to"
-                    "match the data instances provided during init.")
-            data = kwargs[self._DATA_ATTR]
+        if kwargs and self._DATA_ATTR not in kwargs:
+            raise DataContainerError(
+                "Expected data to be provided in keyword argument '%s'; "
+                "found keys %s" % (self._DATA_ATTR, list(kwargs.keys())))
+        data = kwargs.get(self._DATA_ATTR, [])
 
-        if data is not None:
-            for d in data:
-                if not isinstance(d, self._DATA_CLS):
-                    raise ValueError(
-                        "DataContainer initialized with nonconforming data "
-                        "instances.")
+        for d in data:
+            if not isinstance(d, self._DATA_CLS):
+                raise DataContainerError(
+                    "Data container %s expects data of type %s but found "
+                    "%s" % (self.__class__, self._DATA_CLS, d.__class__))
 
         setattr(self, self._DATA_ATTR, data)
 
@@ -105,10 +102,13 @@ class DataContainer(Serializable):
     @classmethod
     def _validate(cls):
         if cls._DATA_CLS is None:
-            raise ValueError(
+            raise DataContainerError(
                 "_DATA_CLS is None; note that you cannot instantiate "
-                "DataContainer directly."
-            )
+                "DataContainer directly.")
+        if cls._DATA_ATTR is None:
+            raise DataContainerError(
+                "_DATA_ATTR is None; note that you cannot instantiate "
+                "DataContainer directly.")
 
     def add(self, instance):
         '''Adds a data instance to the container.

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -177,7 +177,10 @@ class DataContainer(Serializable):
             # Parse using provided class
             cls._validate()
             data_cls = cls._DATA_CLS
-        return cls(data=[data_cls.from_dict(dd) for dd in d["data"]])
+        return cls(**{
+            cls._DATA_ATTR:
+            [data_cls.from_dict(dd) for dd in d[cls._DATA_ATTR]]
+        })
 
     @classmethod
     def _validate(cls):

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -66,6 +66,10 @@ class DataContainer(Serializable):
     def attributes(self):
         return ["_CLS", "_DATA_CLS", "data"]
 
+    @property
+    def _CLS(self):
+        return etau.get_class_name(self)
+
     def serialize(self):
         '''Custom serialization implementation for DataContainers that embeds
         the class name and the data class name in the JSON to enable

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -187,8 +187,8 @@ class DataContainer(Serializable):
         })
 
     @property
-    def num(self):
-        '''The number of data instances in the container.'''
+    def size(self):
+        '''Returns the number of data instances in the container.'''
         return len(self._data)
 
     def serialize(self):

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -1,0 +1,152 @@
+'''
+Core data structures for representing data and containers of data.
+
+Copyright 2017-2018, Voxel51, LLC
+voxel51.com
+
+Brian Moore, brian@voxel51.com
+Jason Corso, jason@voxel51.com
+'''
+# pragma pylint: disable=redefined-builtin
+# pragma pylint: disable=unused-wildcard-import
+# pragma pylint: disable=wildcard-import
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import *
+# pragma pylint: enable=redefined-builtin
+# pragma pylint: enable=unused-wildcard-import
+# pragma pylint: enable=wildcard-import
+
+
+from eta.core.geometry import RelativePoint
+from eta.core.serial import Serializable
+
+
+class DataContainer(Serializable):
+    '''Base class for containers that store lists of data instances.
+
+    This class should not be instantiated directly. Instead a subclass should
+    be created for each type of data to be stored.
+
+    Attributes:
+        data: a list of instances of data of a specific class
+    '''
+
+    # The class of the data stored in the container
+    _DATA_CLS = None
+
+    def __init__(self, data=None):
+        '''Constructs a DataContainer.
+
+        Args:
+            data: optional list of data instances to store.
+        '''
+        self._validate()
+        self.data = data or []
+
+    def __iter__(self):
+        return iter(self.data)
+
+    @classmethod
+    def get_data_class(cls):
+        '''Gets the class of data instances stored in this container.'''
+        return cls._DATA_CLS
+
+    @property
+    def num(self):
+        '''The number of data instances in the container.'''
+        return len(self.data)
+
+    def add(self, instance):
+        '''Adds a data instance to the container.
+
+        Args:
+            instance: an instance for this container
+        '''
+        self.data.append(instance)
+
+    def get_matches(self, filters, match=any):
+        '''Returns a data container containing only instances that match the
+        filters.
+
+        Args:
+            filters: a list of functions that accept data instances and return
+                True/False
+            match: a function (usually `any` or `all`) that accepts an iterable
+                and returns True/False. Used to aggregate the outputs of each
+                filter to decide whether a match has occurred. The default is
+                `any`
+        '''
+        return self.__class__(
+            data=list(filter(
+                lambda o: match(f(o) for f in filters),
+                self.data,
+            )),
+        )
+
+    def count_matches(self, filters, match=any):
+        '''Counts number of data instances that match the filters.
+
+        Args:
+            filters: a list of functions that accept data instances and return
+                True/False
+            match: a function (usually `any` or `all`) that accepts an iterable
+                and returns True/False. Used to aggregate the outputs of each
+                filter to decide whether a match has occurred. The default is
+                `any`
+        '''
+        return len(self.get_matches(filters, match=match).data)
+
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs an DataContainer from a JSON dictionary.'''
+        cls._validate()
+        return cls(data=[cls._DATA_CLS.from_dict(do) for do in d["data"]])
+
+    @classmethod
+    def _validate(cls):
+        if cls._DATA_CLS is None:
+            raise ValueError(
+                "_DATA_CLS is None; note that you cannot instantiate "
+                "DataContainer directly."
+            )
+
+
+class NamedRelativePoint(Serializable):
+    '''A relative point that also has a label.
+
+    Attributes:
+        label: object label
+        relative_point: a RelativePoint instance
+    '''
+
+    def __init__(self, label, relative_point):
+        '''Constructs a NamedRelativePoint.
+
+        Args:
+            label: label string
+            relative_point: a RelativePoint instance
+        '''
+        self.label = str(label)
+        self.relative_point = relative_point
+
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs a NamedRelativePoint from a JSON dictionary.'''
+        return cls(
+            d["label"],
+            RelativePoint.from_dict(d["relative_point"]),
+        )
+
+
+class LocalizedTags(DataContainer):
+    '''Container for points in an image or frame that each have a label
+    associated with them (tags).'''
+
+    _DATA_CLS = NamedRelativePoint
+
+    def label_set(self):
+        '''Returns a set containing the labels of the NamedRelativePoints.'''
+        return set(dat.label for dat in self.data)

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -21,7 +21,6 @@ from builtins import *
 
 from collections import OrderedDict
 
-from eta.core.geometry import RelativePoint
 from eta.core.serial import Serializable
 import eta.core.utils as etau
 
@@ -194,40 +193,6 @@ class DataContainer(Serializable):
         return d
 
 
-class PointTag(Serializable):
-    '''A relative point that also has a label.
-
-    Attributes:
-        label: object label
-        relative_point: a RelativePoint instance
-    '''
-
-    def __init__(self, label, relative_point):
-        '''Constructs a PointTag.
-
-        Args:
-            label: label string
-            relative_point: a RelativePoint instance
-        '''
-        self.label = str(label)
-        self.relative_point = relative_point
-
-    @classmethod
-    def from_dict(cls, d):
-        '''Constructs a PointTag from a JSON dictionary.'''
-        return cls(
-            d["label"],
-            RelativePoint.from_dict(d["relative_point"]),
-        )
-
-
-class PointTagContainer(DataContainer):
-    '''Container for points in an image or frame that each have a label
-    associated with them (tags).'''
-
-    _DATA_CLS = PointTag
-    _DATA_ATTR = "points"
-
-    def label_set(self):
-        '''Returns a set containing the labels of the PointTags.'''
-        return set(p.label for p in self.points)
+class DataContainerError(Exception):
+    '''Exception raised when an invalid DataContainer is encountered.'''
+    pass

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -50,15 +50,39 @@ class DataContainer(Serializable):
 
     # The class of the data stored in the container
     _DATA_CLS = None
+    # The name of the attribute that the container will use to actually store
+    # the data in the container
+    _DATA_ATTR = "data"
 
-    def __init__(self, data=None):
+    def __init__(self, **kwargs):
         '''Constructs a DataContainer.
 
         Args:
-            data: optional list of data instances to store.
+            <data>: optional list of data instances to store; the actual name
+            of the data is arbitrary and up to the subclass.  For example, if
+            we store objects in an ObjectContainer, then we expect this to be
+            `objects=...` here.  This field_name must match the `_DATA_ATTR` of
+            the subclass.  The default for this is "data" in the event the
+            subclass does not want to customize it.
         '''
         self._validate()
-        self.data = data or []
+
+        data = []
+        if kwargs is not None:
+            if not self._DATA_ATTR in kwargs:
+                raise ValueError(
+                    "DataContainer expects the class data attribute name to"
+                    "match the data instances provided during init.")
+            data = kwargs[self._DATA_ATTR]
+
+        if data is not None:
+            for d in data:
+                if not isinstance(d, self._DATA_CLS):
+                    raise ValueError(
+                        "DataContainer initialized with nonconforming data "
+                        "instances.")
+
+        setattr(self, self._DATA_ATTR, data)
 
     def __iter__(self):
         return iter(self.data)

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -51,9 +51,9 @@ class DataContainer(Serializable):
 
     # The class of the data stored in the container
     _DATA_CLS = None
-    # The name of the attribute that the container will use to actually store
-    # the data in the container
-    _DATA_ATTR = "data"
+
+    # The name of the attribute that will store the data in the container
+    _DATA_ATTR = None
 
     def __init__(self, **kwargs):
         '''Constructs a DataContainer.

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -37,10 +37,14 @@ class DataContainer(Serializable):
 
     Examples:
         ```
-        tags= LocalizedTags(...)
+        from eta.core.data import DataContainer
+        from eta.core.geometry import LabeledPointContainer
+
+        tags = LabeledPointContainer(...)
         tags.write_json("tags.json")
+
         tags2 = DataContainer.from_json("tags.json")
-        print(tags2.__class__)  # LocalizedTags, not DataContainer
+        print(tags2.__class__)  # LabeledPointContainer, not DataContainer
         ```
 
     Attributes:
@@ -59,12 +63,14 @@ class DataContainer(Serializable):
         '''Constructs a DataContainer.
 
         Args:
-            <data>: optional list of data instances to store; the actual name
-            of the data is arbitrary and up to the subclass.  For example, if
-            we store objects in an ObjectContainer, then we expect this to be
-            `objects=...` here.  This field_name must match the `_DATA_ATTR` of
-            the subclass.  The default for this is "data" in the event the
-            subclass does not want to customize it.
+            <data>: an optional list of data instances to store in the
+                container. The appropriate name of this keyword argument is
+                determined by the `_DATA_ATTR` member of the container class.
+                If a subclass chooses not to override this attribute, then the
+                default keyword is "data"
+
+        Raises:
+            DataContainerError: if there was a problem parsing the input data
         '''
         self._validate()
 

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -44,7 +44,9 @@ class DataContainer(Serializable):
         ```
 
     Attributes:
-        data: a list of instances of data of a specific class.
+        <data>: a list of data instances. The field name <data> is specified by
+            the `_DATA_ATTR` member, and the class of the data instances is
+            specified by the `_DATA_CLS` member
     '''
 
     # The class of the data stored in the container

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -84,6 +84,9 @@ class DataContainer(Serializable):
 
         setattr(self, self._DATA_ATTR, data)
 
+    def __getitem__(self, index):
+        return self._data.__getitem__(index)
+
     def __iter__(self):
         return iter(self._data)
 

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -191,7 +191,7 @@ class DataContainer(Serializable):
         return d
 
 
-class NamedRelativePoint(Serializable):
+class PointTag(Serializable):
     '''A relative point that also has a label.
 
     Attributes:
@@ -200,7 +200,7 @@ class NamedRelativePoint(Serializable):
     '''
 
     def __init__(self, label, relative_point):
-        '''Constructs a NamedRelativePoint.
+        '''Constructs a PointTag.
 
         Args:
             label: label string
@@ -211,19 +211,20 @@ class NamedRelativePoint(Serializable):
 
     @classmethod
     def from_dict(cls, d):
-        '''Constructs a NamedRelativePoint from a JSON dictionary.'''
+        '''Constructs a PointTag from a JSON dictionary.'''
         return cls(
             d["label"],
             RelativePoint.from_dict(d["relative_point"]),
         )
 
 
-class LocalizedTags(DataContainer):
+class PointTagContainer(DataContainer):
     '''Container for points in an image or frame that each have a label
     associated with them (tags).'''
 
-    _DATA_CLS = NamedRelativePoint
+    _DATA_CLS = PointTag
+    _DATA_ATTR = "points"
 
     def label_set(self):
-        '''Returns a set containing the labels of the NamedRelativePoints.'''
-        return set(dat.label for dat in self.data)
+        '''Returns a set containing the labels of the PointTags.'''
+        return set(p.label for p in self.points)

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -1,5 +1,6 @@
 '''
-Core data structures for working with geometric objects.
+Core data structures for working with geometric concepts like points,
+bounding boxes, etc.
 
 Copyright 2017-2018, Voxel51, LLC
 voxel51.com
@@ -18,6 +19,7 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
+from eta.core.data import DataContainer
 import eta.core.image as etai
 from eta.core.serial import Serializable
 
@@ -145,6 +147,44 @@ class RelativePoint(Serializable):
     def from_dict(cls, d):
         '''Constructs a RelativePoint from a JSON dictionary.'''
         return cls(d["x"], d["y"])
+
+
+class LabeledPoint(Serializable):
+    '''A relative point that has an associated label.
+
+    Attributes:
+        label: object label
+        relative_point: a RelativePoint instance
+    '''
+
+    def __init__(self, label, relative_point):
+        '''Constructs a LabeledPoint.
+
+        Args:
+            label: label string
+            relative_point: a RelativePoint instance
+        '''
+        self.label = str(label)
+        self.relative_point = relative_point
+
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs a LabeledPoint from a JSON dictionary.'''
+        return cls(
+            d["label"],
+            RelativePoint.from_dict(d["relative_point"]),
+        )
+
+
+class LabeledPointContainer(DataContainer):
+    '''Container for points in an image that each have an associated label.'''
+
+    _DATA_CLS = LabeledPoint
+    _DATA_ATTR = "points"
+
+    def label_set(self):
+        '''Returns a set containing the labels of the LabeledPoints.'''
+        return set(p.label for p in self.points)
 
 
 def _make_square(x, y, w, h):

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -147,4 +147,7 @@ class ScoredObjects(ObjectContainer):
 
     def sort(self):
         '''Sorts the current object list in ascending order by score.'''
-        self.objects = sorted(self.objects, key=lambda o: o.score)
+        setattr(
+            self, self._DATA_ATTR,
+            sorted(self._data, key=lambda obj: obj.score)
+        )

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -1,5 +1,5 @@
 '''
-Core data structures for working with objects in images.
+Core data structures for working with detected objects in images.
 
 Copyright 2017-2018, Voxel51, LLC
 voxel51.com
@@ -18,57 +18,19 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
-from collections import OrderedDict
-
 from eta.core.data import DataContainer
 from eta.core.geometry import BoundingBox
 from eta.core.serial import Serializable
-import eta.core.utils as etau
 
 
 class ObjectContainer(DataContainer):
     '''Base class for containers that store lists of objects.
 
-    This class should not be instantiated directly. Instead a subclass should
-    be created for each type of object to be stored.
-
-    By default, ObjectContainer subclasses embed their class names and
-    underlying object class names in their JSON representations, so object
-    containers can be read reflectively from disk.
-
-    Examples:
-        ```
-        frame = Frame(...)
-        frame.write_json("frame.json")
-        frame2 = ObjectContainer.from_json("frame.json")
-        print(frame2.__class__)  # Frame, not ObjectContainer
-        ```
-
-    Attributes:
-        objects: a list of objects
+    Subclasses must set the `_DATA_CLS` attribute.
     '''
 
-    # The class of the objects stored in the container
     _DATA_CLS = None
     _DATA_ATTR = "objects"
-
-    @classmethod
-    def get_object_class(cls):
-        '''Gets the class of object stored in this container.'''
-        return cls._DATA_CLS
-
-    @property
-    def num_objects(self):
-        '''The number of objects in the container.'''
-        return len(self.objects)
-
-    @classmethod
-    def _validate(cls):
-        if cls._DATA_CLS is None:
-            raise ValueError(
-                "_DATA_CLS is None; note that you cannot instantiate "
-                "ObjectContainer directly."
-            )
 
 
 class DetectedObject(Serializable):

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -84,29 +84,6 @@ class Frame(ObjectContainer):
         return set(obj.label for obj in self.objects)
 
 
-class ObjectCounts(Serializable):
-    '''Container for counting objects in an image.'''
-
-    def __init__(self, counts=None):
-        '''Constructs an ObjectCounts container.
-
-        Args:
-            counts: optional list of ObjectCount objects
-        '''
-        self.counts = counts or []
-
-    def add(self, count):
-        '''Adds an ObjectCount to the container.'''
-        self.counts.append(count)
-
-    @classmethod
-    def from_dict(cls, d):
-        '''Constructs an ObjectCounts from a JSON dictionary.'''
-        return ObjectCounts(
-            counts=[ObjectCount.from_dict(dc) for dc in d["counts"]]
-        )
-
-
 class ObjectCount(Serializable):
     '''The number of instances of an object found in an image.'''
 
@@ -118,6 +95,13 @@ class ObjectCount(Serializable):
     def from_dict(cls, d):
         '''Constructs an ObjectCount from a JSON dictionary.'''
         return ObjectCount(d["label"], d["count"])
+
+
+class ObjectCounts(DataContainer):
+    '''Container for counting objects in an image.'''
+
+    _DATA_CLS = ObjectCount
+    _DATA_ATTR = "counts"
 
 
 class ScoredObject(Serializable):


### PR DESCRIPTION
Added a generalization of the existing `eta.core.objects.ObjectContainer` as a `DataContainer` definition in a new pym `eta.core.data`. 
- Fully backwards compatible. 
- Allows reflection on instantiation.
- Allows customized of actual field to be written in the file, for compatibility as well as usability.
- Adds indexing by ints.
- Updates objects classes to use this new structure.