### PR TITLE
Small improvements to models registry

### DIFF
--- a/docs/models_dev_guide.md
+++ b/docs/models_dev_guide.md
@@ -62,12 +62,12 @@ The following is an example contents of a `manifest.json` file:
     "models": [
         {
             "base_name": "VGG-16",
-            "base_filename": "vgg16_weights.npz",
+            "base_filename": "vgg16-imagenet.npz",
             "version": null,
-            "description": "VGG-16 network originally trained by Frossard for the 1000 classes from ImageNet",
+            "description": "VGG-16 model trained on ImageNet. Source: https://github.com/ethereon/caffe-tensorflow",
             "manager": {
                 "config": {
-                    "google_drive_id": "0B7phNvpRqNdpT0lZU1NOWXIzRlE"
+                    "google_drive_id": "0B_-5gc091ngGMzBFMVJ0RE9HNmc"
                 },
                 "type": "eta.core.models.ETAModelManager"
             },
@@ -194,11 +194,15 @@ To publish a new model, you can follow the general receipe:
 
 ```py
 #
-# Full workflow for publishing a new model
+# Full workflow for publishing a new public ETA model
+#
+# Assumes the model has been uploaded to Google Drive by an ETA administrator
+# and you have the ID of the model in Google Drive
 #
 
 name = "your-model@1.0"
 description = "a short description of your model"
+google_drive_id = "XXXXXXXX"
 
 #
 # Recommend paths for the given model by looking for older versions
@@ -215,12 +219,9 @@ base_filename, models_dir = etam.recommend_paths_for_model(name)
 #
 etam.register_model_dry_run(name, base_filename, models_dir)
 
-#
-# Example use of ETAModelManager
-#
-# Assumes the model has been uploaded to Google Drive by an ETA administrator
-#
-manager = etam.ETAModelManager.from_dict({"google_drive_id": "XXXXXXXX"})
+# Construct the ModelManager instance for your model
+config = etam.ETAModelManagerConfig({"google_drive_id": google_drive_id})
+manager = etam.ETAModelManager(config)
 
 # Register the model
 etam.register_model(

--- a/docs/models_dev_guide.md
+++ b/docs/models_dev_guide.md
@@ -64,6 +64,7 @@ The following is an example contents of a `manifest.json` file:
             "base_name": "VGG-16",
             "base_filename": "vgg16_weights.npz",
             "version": null,
+            "description": "VGG-16 network originally trained by Frossard for the 1000 classes from ImageNet",
             "manager": {
                 "config": {
                     "google_drive_id": "0B7phNvpRqNdpT0lZU1NOWXIzRlE"
@@ -115,7 +116,7 @@ import eta.core.models as etam
 
 # Loads the model by name
 # Automatically downloads the model from the cloud, if necessary
-weights = NpzModelWeights(name)
+weights = etam.NpzModelWeights(name).load()
 
 # Dictionary-based access to the weights
 weights["layer-1"]
@@ -189,27 +190,41 @@ automatically load a model given only its `name`. See the
 
 #### Publishing a new model
 
-To publish a new model, you can follow the general receipt:
+To publish a new model, you can follow the general receipe:
 
 ```py
 #
 # Full workflow for publishing a new model
 #
 
+name = "your-model@1.0"
+description = "a short description of your model"
+
+#
 # Recommend paths for the given model by looking for older versions
 # of the model in the model manifests
+#
+# If you already know how you want to register your model, you can provide the
+# appropriate models directory and base filename yourself
+#
 base_filename, models_dir = etam.recommend_paths_for_model(name)
 
+#
 # Perform a dry run of the model registration to check for any errors
 # before uploading the model to the cloud
+#
 etam.register_model_dry_run(name, base_filename, models_dir)
 
-# Upload the file to remote storage
-# Then instantiate the relevant ModelManager describing its location
-manager = ...
+#
+# Example use of ETAModelManager
+#
+# Assumes the model has been uploaded to Google Drive by an ETA administrator
+#
+manager = etam.ETAModelManager.from_dict({"google_drive_id": "XXXXXXXX"})
 
 # Register the model
-etam.register_model(name, base_filename, models_dir, manager)
+etam.register_model(
+    name, base_filename, models_dir, manager, description=description)
 ```
 
 The above process can be completely automated for custom cloud storage

--- a/docs/models_dev_guide.md
+++ b/docs/models_dev_guide.md
@@ -190,53 +190,50 @@ automatically load a model given only its `name`. See the
 
 #### Publishing a new model
 
-To publish a new model, you can follow the general receipe:
+By default, all ETA models are stored in a Google Drive folder with permissions
+set to be publicly readable. You can publish a new model to this public
+registry as follows:
 
 ```py
 #
-# Full workflow for publishing a new public ETA model
+# Publishing a new public ETA model
 #
 # Assumes the model has been uploaded to Google Drive by an ETA administrator
 # and you have the ID of the model in Google Drive
 #
 
+# The name for your model
 name = "your-model@1.0"
-description = "a short description of your model"
+
+# The ID of your model in Google Drive
 google_drive_id = "XXXXXXXX"
 
-#
-# Recommend paths for the given model by looking for older versions
-# of the model in the model manifests
-#
-# If you already know how you want to register your model, you can provide the
-# appropriate models directory and base filename yourself
-#
-base_filename, models_dir = etam.recommend_paths_for_model(name)
+# A short description of your model
+description = "a short description of your model"
 
 #
-# Perform a dry run of the model registration to check for any errors
-# before uploading the model to the cloud
+# The base filename (no version information, which is added automatically) and
+# models directory, respectively, to use when downloading the model. If you
+# are uploading a new version of an existing model, these arguments can be set
+# to None and the same values are inherited from the most recent version of the
+# model
 #
-etam.register_model_dry_run(name, base_filename, models_dir)
+base_filename = "your-model-weights.npz"
+models_dir = "/path/to/models/dir"
 
-# Construct the ModelManager instance for your model
-config = etam.ETAModelManagerConfig({"google_drive_id": google_drive_id})
-manager = etam.ETAModelManager(config)
-
-# Register the model
-etam.register_model(
-    name, base_filename, models_dir, manager, description=description)
+# Publish the model
+etam.publish_public_model(
+    name, google_drive_id, description=description, base_filename=None,
+    models_dir=None)
 ```
 
-The above process can be completely automated for custom cloud storage
-applications, including the uploading of the model to cloud storage and the
-generation of the relevant model manager instance describing the model.
-To do this, one should implement a new subclass of
-`eta.core.models.ModelManager`.
+The above code internally uses an `eta.core.models.ETAModelManager` to manage
+access to the model in the public Google Drive folder. However, the publishing
+process can be easily extended to custom cloud storage solutions. To do so,
+one should implement a new subclass of `eta.core.models.ModelManager` and use
+it together with the `eta.core.models.register_model` function to implement a
+custom publishing workflow.
 
-> Note: Only Voxel51 administrators can upload models to cloud storage, so
-> one must submit a request to have the ETAModelManager instance generated for
-> your model
 
 #### Flushing local models
 

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -682,7 +682,7 @@ class Model(Serializable):
         if not self.has_version:
             return self.base_filename
         base, ext = os.path.splitext(self.base_filename)
-        return base + "-" + self.version + ext
+        return base + "-v" + self.version + ext
 
     @property
     def has_version(self):

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -741,8 +741,8 @@ class Model(Serializable):
         '''Constructs a Model from a JSON dictionary.'''
         return cls(
             d["base_name"], d["base_filename"],
-            ModelManager.from_dict(d["manager"]), d["date_created"],
-            d.get("version", None))
+            ModelManager.from_dict(d["manager"]), d.get("version", None),
+            d.get("description", None), d.get("date_created", None))
 
 
 class ModelWeights(object):

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -255,16 +255,86 @@ def init_models_dir(new_models_dir):
     manifest.write_to_dir(new_models_dir)
 
 
-def recommend_paths_for_model(name):
-    '''Recommends a base filename and models directory for the given model
-    name, if possible.
+def publish_public_model(
+        name, google_drive_id, description=None, base_filename=None,
+        models_dir=None):
+    '''Publishes a new model to the public ETA model registry.
 
-    The recommendations are made by looking up the corresponding values from
-    the latest version of the model currently registered.
+    This function assumes that the model has been uploaded to Google Drive by
+    an ETA administrator and that you have the ID of the file to provide here.
+
+    This function performs the following actions:
+        - recommends a base filename and models directory, if necessary
+        - performs a dry run of the model registration process to check for
+            potential problems
+        - registers the model in the manifest of its models directory
+
+    The keyword arguments `base_filename` and `models_dir` configure the
+    filename (version information is added automatically) and models directory,
+    respectively, to use when downloading the model. If you are uploading a
+    new version of an existing model, these arguments can be omitted and the
+    same values are inherited from the most recent version of the model. If
+    this is a brand new model, these values are required
+
+    If the specified models directory does not have a models manifest file, one
+    is created. Note that new models directories are not automatically added to
+    your models search path, so models in a newly initialized directory will
+    not be findable until you add the directory to your models search path.
+
+    Args:
+        name: a name for the model, which can optionally have "@<ver>" appended
+            to assign a version to the model
+        google_drive_id: the ID of the model file in Google Drive
+        description: an optional description for the model
+        base_filename: an optional base filename to use when writing the model
+            to disk. By default, a value is inferred as explained above
+        models_dir: an optional directory in which to register the model. By
+            default, a value is inferred as explained above
+
+    Raises:
+        ModelError: if the publishing failed for any reason
+    '''
+    # Recommend paths if necessary
+    base_filename, models_dir = recommend_paths_for_model(
+        name, base_filename=base_filename, models_dir=models_dir)
+
+    # Perform a dry run of the model registration
+    register_model_dry_run(name, base_filename, models_dir)
+
+    # Construct model manager instance for model
+    config = ETAModelManagerConfig({"google_drive_id": google_drive_id})
+    manager = ETAModelManager(config)
+
+    # Register model
+    register_model(
+        name, base_filename, models_dir, manager, description=description)
+
+
+def recommend_paths_for_model(
+        name, model_path=None, base_filename=None, models_dir=None):
+    '''Recommends a base filename and models directory for the given model,
+    if possible, using the provided information to inform the recommendation.
+
+    The recommendations are made using the first applicable option below:
+        (a) if `base_filename` or `models_dir` is provided, that value is used
+        (b) if an older version of the model exists, the `base_filename` and
+            `models_dir` values are inherited from that model as necesasry
+        (c) if `model_path` is provided, `base_filename` and `models_dir` are
+            set to the filename and base directory of the model path, as
+            necessary
+        (d) None is returned
 
     Args:
         name: the model name, which can optionally have "@<ver>" appended
             to assign a version to the model
+        model_path: an optional path to the model on disk. If provided and
+            this path may be used to recommended values as described above
+        base_filename: an optional base filename to use when writing the model
+            to disk. If provided, this value is directly returned. If not
+            provided, a value is recommended as explained above
+        models_dir: an optional directory in which to register the model. If
+            provided, this value is directly returned. If not provided, a value
+            is recommended as explained above
 
     Returns:
         base_filename: the recommended base filename for the model, or None if
@@ -274,10 +344,46 @@ def recommend_paths_for_model(name):
     '''
     try:
         base_name = Model.parse_name(name)[0]
-        model, models_dir, _ = _find_model(base_name)
-        return model.base_filename, models_dir
+        model, _rec_models_dir, _ = _find_model(base_name)
+        _rec_base_filename = model.base_filename
     except ModelError:
-        return None, None
+        _rec_base_filename = None
+        _rec_models_dir = None
+
+    # Recommend base filename
+    if not base_filename:
+        if _rec_base_filename:
+            base_filename = _rec_base_filename
+            logger.info(
+                "Found a previous model version '%s'; recommending the same "
+                "base filename: '%s'", model.name, base_filename)
+        elif model_path:
+            base_filename = os.path.basename(model_path)
+            logger.info(
+                "No previous model version found; recommending the base "
+                "filename of the input model path: '%s'", base_filename)
+        else:
+            logger.info("Unable to recommended a base filename...")
+            base_filename = None
+
+    # Recommend models directory
+    if not models_dir:
+        if _rec_models_dir:
+            models_dir = _rec_models_dir
+            logger.info(
+                "Found a previous model version '%s'; recommending the same "
+                "model directory: '%s'", model.name, models_dir)
+        elif model_path:
+            models_dir = os.path.dirname(model_path)
+            logger.info(
+                "No previous model version found; recommending the parent "
+                "directory of the model path as the models directory:",
+                models_dir)
+        else:
+            logger.info("Unable to recommended a models directory...")
+            models_dir = None
+
+    return base_filename, models_dir
 
 
 def register_model_dry_run(name, base_filename, models_dir):

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -377,7 +377,7 @@ def recommend_paths_for_model(
             models_dir = os.path.dirname(model_path)
             logger.info(
                 "No previous model version found; recommending the parent "
-                "directory of the model path as the models directory:",
+                "directory of the model path as the models directory: '%s'",
                 models_dir)
         else:
             logger.info("Unable to recommended a models directory...")

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -308,7 +308,7 @@ def register_model_dry_run(name, base_filename, models_dir):
     # Verify name
     logger.info("Verifying that model name '%s' is valid", name)
     base_name, version = Model.parse_name(name)
-    model = Model(base_name, base_filename, None, None, version=version)
+    model = Model(base_name, base_filename, None, version=version)
 
     # Verify novelty
     logger.info("Verifying that model '%s' does not yet exist", name)
@@ -332,7 +332,7 @@ def register_model_dry_run(name, base_filename, models_dir):
     return model.get_path_in_dir(models_dir)
 
 
-def register_model(name, base_filename, models_dir, manager):
+def register_model(name, base_filename, models_dir, manager, description=None):
     '''Registers a new model in the given models directory.
 
     If the directory does not have a models manifest file, one is created.
@@ -351,6 +351,7 @@ def register_model(name, base_filename, models_dir, manager):
             this model locally on disk
         models_dir: the directory in which to register the model
         manager: the ModelManager instance for the model
+        description: an optional description for the model
 
     Raises:
         ModelError: if the registration failed for any reason
@@ -362,7 +363,8 @@ def register_model(name, base_filename, models_dir, manager):
     base_name, version = Model.parse_name(name)
     date_created = etau.get_isotime()
     model = Model(
-        base_name, base_filename, manager, date_created, version=version)
+        base_name, base_filename, manager, version=version,
+        description=description, date_created=date_created)
 
     # Initialize models directory, if necessary
     if not ModelsManifest.dir_has_manifest(models_dir):
@@ -634,33 +636,37 @@ class Model(Serializable):
         base_name: the base name of the model (no version info)
         base_filename: the base filename of the model (no version info)
         manager: the ModelManager instance that describes the remote storage
-            location of the model
-        date_created: the date that the model was created
-        version: the version of the model, or None if it has no version
+            location of the models_dir
+        version: the version of the model (if any)
+        description: a description of the model (if any)
+        date_created: the date that the model was created (if any)
     '''
 
     def __init__(
-            self, base_name, base_filename, manager, date_created,
-            version=None):
+            self, base_name, base_filename, manager, version=None,
+            description=None, date_created=None):
         '''Creates a Model instance.
 
         Args:
             base_name: the base name of the model
             base_filename: the base filename for the model
             manager: the ModelManager for the model
-            date_created: the date that the model was created
             version: (optional) the model version
+            description: (optional) a description of the model
+            date_created: (optional) the date that the model was created
         '''
         self.base_name = base_name
         self.base_filename = base_filename
         self.manager = manager
-        self.date_created = date_created
         self.version = version or None
+        self.description = description or None
+        self.date_created = date_created or None
 
     def attributes(self):
         # We do this so we can set the order the fields appear in the JSON
         return [
-            "base_name", "base_filename", "version", "manager", "date_created"]
+            "base_name", "base_filename", "version", "description", "manager",
+            "date_created"]
 
     @property
     def name(self):

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -418,12 +418,20 @@ def register_model_dry_run(name, base_filename, models_dir):
 
     # Verify novelty
     logger.info("Verifying that model '%s' does not yet exist", name)
-    if name in list_models():
+    models = _list_models()[0]
+    base_names = [mm[0].base_name for mm in itervalues(models)]
+    if name in models:
         raise ModelError("Model '%s' already exists" % name)
-    if base_name in list_models():
+    if name in base_names:
+        raise ModelError(
+            "A versioned model with base name '%s' already exists, and "
+            "publishing a versionless model with the same name as a versioned "
+            "model can lead to unexpected behavior. Please choose another "
+            "model name." % name)
+    if base_name in models:
         raise ModelError(
             "A versionless model with name '%s' already exists, and "
-            "publishing a versioned model with the same as a versionless "
+            "publishing a versioned model with the same name as a versionless "
             "model can lead to unexpected behavior. Please choose another "
             "model name." % base_name)
 

--- a/eta/models/manifest.json
+++ b/eta/models/manifest.json
@@ -2,9 +2,9 @@
     "models": [
         {
             "base_name": "VGG-16",
-            "base_filename": "vgg16_weights.npz",
+            "base_filename": "vgg16-imagenet.npz",
             "version": null,
-            "description": "VGG-16 network originally trained by Frossard for the 1000 classes from ImageNet",
+            "description": "VGG-16 model trained on ImageNet. Source: https://github.com/ethereon/caffe-tensorflow",
             "manager": {
                 "config": {
                     "google_drive_id": "0B_-5gc091ngGMzBFMVJ0RE9HNmc"

--- a/eta/models/manifest.json
+++ b/eta/models/manifest.json
@@ -4,6 +4,7 @@
             "base_name": "VGG-16",
             "base_filename": "vgg16_weights.npz",
             "version": null,
+            "description": "VGG-16 network originally trained by Frossard for the 1000 classes from ImageNet",
             "manager": {
                 "config": {
                     "google_drive_id": "0B_-5gc091ngGMzBFMVJ0RE9HNmc"


### PR DESCRIPTION
- adding a `publish_public_model` method to automate the process of publishing a public ETA model (assuming it has first been uploaded to Google Drive, which must be done by a Voxel51 admin)
- adding a `description` field to model entries
- updating VGG-16 model registry to include a description and informative filename
