### PR TITLE
Refactored the new DataContainer to generalize to Container and allow for ConfigContainer too

### DIFF
--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -490,7 +490,7 @@ class ConfigContainer(etas.Container):
     _ELE_ATTR = "configs"
 
     @property
-    def _config(self):
+    def _configs(self):
         '''The list of Config instances stored in this container, independent
         of the container-specific name of the attribute in which they are
         stored.

--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -442,13 +442,51 @@ class Config(Serializable):
 
 
 class ConfigContainer(etas.Container):
-    '''Class for storing lists of Configs of the same type.  This is a
-    specialization of the `eta.core.serial.Container` class for configs.
+    '''Abstract base class for containers that store lists of `Config` class
+    instances.
 
-    This class cannot be instantiated directly; users of it should subclass and
-    define the `_ELE_CLS` attribute to denote that class of the `Config`
-    elements that this will store.
+    This class cannot be instantiated directly. Instead a subclass should
+    be created for each type of data to be stored. Subclasses MUST set the
+    following members:
+        -  `_ELE_CLS`: the class of the element stored in the container
+
+    In addition, sublasses MAY override the following members:
+        - `_ELE_CLS_FIELD`: the name of the private attribute that will store
+            the class of the elements in the container
+        - `_ELE_ATTR`: the name of the attribute that will store the elements
+            in the container
+
+    ConfigContainer subclasses embed their class names and underlying data
+    instance class names in their JSON representations, so they can be read
+    reflectively from disk.
+
+    Attributes:
+        <configs>: a list of Config instances. The field name <configs> is
+            specified by the `_ELE_ATTR` member of the ConfigContainer
+            subclass, and the class of the Config instances is specified by the
+            `_ELE_CLS` member
     '''
+
+    #
+    # The class of the configs stored in the container
+    #
+    # Subclasses MUST set this field
+    #
+    _ELE_CLS = None
+
+    #
+    # The name of the private attribute that will store the class of the
+    # configs in the container
+    #
+    # Subclasses MAY override this field
+    #
+    _ELE_CLS_FIELD = "_CONFIG_CLS"
+
+    #
+    # The name of the attribute that will store the configs in the container
+    #
+    # Subclasses MAY override this field
+    #
     _ELE_ATTR = "configs"
 
     @classmethod

--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -441,6 +441,28 @@ class Config(Serializable):
         return _parse_key(d, key, None, default)[0]
 
 
+class ConfigContainer(etas.Container):
+    '''Class for storing lists of Configs of the same type.  This is a
+    specialization of the `eta.core.serial.Container` class for configs.
+
+    This class cannot be instantiated directly; users of it should subclass and
+    define the `_ELE_CLS` attribute to denote that class of the `Config`
+    elements that this will store.
+    '''
+    _ELE_ATTR = "configs"
+
+    @classmethod
+    def _validate(cls):
+        '''Adds a validation to all subclasses that enforces only Config's can
+        be stored in this container.
+        '''
+        super(ConfigContainer, cls)._validate()
+
+        if not issubclass(cls._ELE_CLS, Config):
+            raise etas.ContainerError(
+                "_ELE_CLS for a ConfigContainer does not inherit from Config")
+
+
 class ConfigError(Exception):
     '''Exception raised when an invalid Config instance is encountered.'''
     pass

--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -489,6 +489,26 @@ class ConfigContainer(etas.Container):
     #
     _ELE_ATTR = "configs"
 
+    @property
+    def _config(self):
+        '''The list of Config instances stored in this container, independent
+        of the container-specific name of the attribute in which they are
+        stored.
+        '''
+        return self.__elements__
+
+    @classmethod
+    def get_config_class(cls):
+        '''Gets the class of Config stored in this container.'''
+        return cls._ELE_CLS
+
+    @classmethod
+    def get_config_class_name(cls):
+        '''Returns the fully-qualified class name string of the Config
+        instances in this container.
+        '''
+        return etau.get_class_name(cls._ELE_CLS)
+
     @classmethod
     def _validate(cls):
         '''Adds a validation to all subclasses that enforces only Config's can

--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -489,14 +489,6 @@ class ConfigContainer(etas.Container):
     #
     _ELE_ATTR = "configs"
 
-    @property
-    def _configs(self):
-        '''The list of Config instances stored in this container, independent
-        of the container-specific name of the attribute in which they are
-        stored.
-        '''
-        return self.__elements__
-
     @classmethod
     def get_config_class(cls):
         '''Gets the class of Config stored in this container.'''

--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -511,14 +511,20 @@ class ConfigContainer(etas.Container):
 
     @classmethod
     def _validate(cls):
-        '''Adds a validation to all subclasses that enforces only Config's can
-        be stored in this container.
+        '''Validates that a concrete ConfigContainer subclass definition is
+        valid.
+
+        ConfigContainers must only contain Config subclasses.
         '''
         super(ConfigContainer, cls)._validate()
-
         if not issubclass(cls._ELE_CLS, Config):
-            raise etas.ContainerError(
-                "_ELE_CLS for a ConfigContainer does not inherit from Config")
+            raise ConfigContainerError(
+                "%s is not a Config subclass" % cls._ELE_CLS)
+
+
+class ConfigContainerError(Exception):
+    '''Exception raised when an invalid ConfigContainer is encountered.'''
+    pass
 
 
 class ConfigError(Exception):

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -82,13 +82,6 @@ class DataContainer(etas.Container):
     #
     _ELE_ATTR = "data"
 
-    @property
-    def _data(self):
-        '''The list of data instances stored in this container, independent of
-        the container-specific name of the attribute in which they are stored.
-        '''
-        return self.__elements__
-
     @classmethod
     def get_data_class(cls):
         '''Gets the class of data stored in this container.'''

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -19,13 +19,11 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
-from collections import OrderedDict
 
-from eta.core.serial import Serializable
-import eta.core.utils as etau
+from eta.core.serial import Container
 
 
-class DataContainer(Serializable):
+class DataContainer(Container):
     '''Base class for containers that store lists of data instances.
 
     This class should not be instantiated directly. Instead a subclass should
@@ -49,166 +47,13 @@ class DataContainer(Serializable):
 
     Attributes:
         <data>: a list of data instances. The field name <data> is specified by
-            the `_DATA_ATTR` member, and the class of the data instances is
-            specified by the `_DATA_CLS` member
+            the `_ELE_ATTR` member, and the class of the data instances is
+            specified by the `_ELE_CLS` member
     '''
-
-    # The class of the data stored in the container
-    _DATA_CLS = None
-
-    # The name of the attribute that will store the data in the container
-    _DATA_ATTR = None
-
-    def __init__(self, **kwargs):
-        '''Constructs a DataContainer.
-
-        Args:
-            <data>: an optional list of data instances to store in the
-                container. The appropriate name of this keyword argument is
-                determined by the `_DATA_ATTR` member of the container class.
-                If a subclass chooses not to override this attribute, then the
-                default keyword is "data"
-
-        Raises:
-            DataContainerError: if there was a problem parsing the input data
-        '''
-        self._validate()
-
-        if kwargs and self._DATA_ATTR not in kwargs:
-            raise DataContainerError(
-                "Expected data to be provided in keyword argument '%s'; "
-                "found keys %s" % (self._DATA_ATTR, list(kwargs.keys())))
-        data = kwargs.get(self._DATA_ATTR, [])
-
-        for d in data:
-            if not isinstance(d, self._DATA_CLS):
-                raise DataContainerError(
-                    "Data container %s expects data of type %s but found "
-                    "%s" % (self.__class__, self._DATA_CLS, d.__class__))
-
-        setattr(self, self._DATA_ATTR, data)
-
-    def __getitem__(self, index):
-        return self._data.__getitem__(index)
-
-    def __iter__(self):
-        return iter(self._data)
 
     @property
     def _data(self):
         '''Convenience accessor to get the list of data instances stored
         independent of what the name of that attribute is.
         '''
-        return getattr(self, self._DATA_ATTR)
-
-    @classmethod
-    def _validate(cls):
-        if cls._DATA_CLS is None:
-            raise DataContainerError(
-                "_DATA_CLS is None; note that you cannot instantiate "
-                "DataContainer directly.")
-        if cls._DATA_ATTR is None:
-            raise DataContainerError(
-                "_DATA_ATTR is None; note that you cannot instantiate "
-                "DataContainer directly.")
-
-    def add(self, instance):
-        '''Adds a data instance to the container.
-
-        Args:
-            instance: an instance of `_DATA_CLS`
-        '''
-        self._data.append(instance)
-
-    def attributes(self):
-        return ["_CLS", "_DATA_CLS", self._DATA_ATTR]
-
-    def count_matches(self, filters, match=any):
-        '''Counts number of data instances that match the filters.
-
-        Args:
-            filters: a list of functions that accept data instances and return
-                True/False
-            match: a function (usually `any` or `all`) that accepts an iterable
-                and returns True/False. Used to aggregate the outputs of each
-                filter to decide whether a match has occurred. The default is
-                `any`
-        '''
-        return self.get_matches(filters, match=match).num
-
-    @classmethod
-    def from_dict(cls, d):
-        '''Constructs an DataContainer from a JSON dictionary.
-
-        If the JSON contains the reflective `_CLS` and `_DATA_CLS` fields, they
-        are used to infer the underlying data classes, and this method can
-        be invoked as `DataContainer.from_dict`. Otherwise, this method must
-        be called on a concrete subclass of `DataContainer`.
-        '''
-        if "_CLS" in d and "_DATA_CLS" in d:
-            # Parse reflectively
-            cls = etau.get_class(d["_CLS"])
-            data_cls = etau.get_class(d["_DATA_CLS"])
-        else:
-            # Parse using provided class
-            cls._validate()
-            data_cls = cls._DATA_CLS
-        return cls(**{
-            cls._DATA_ATTR:
-            [data_cls.from_dict(dd) for dd in d[cls._DATA_ATTR]]
-        })
-
-    @classmethod
-    def get_class_name(cls):
-        '''Returns the fully-qualified class name string of this container.'''
-        return etau.get_class_name(cls)
-
-    @classmethod
-    def get_data_class(cls):
-        '''Gets the class of data instances stored in this container.'''
-        return cls._DATA_CLS
-
-    @classmethod
-    def get_data_class_name(cls):
-        '''Returns the fully-qualified class name string of the data in this
-        container.
-        '''
-        return etau.get_class_name(cls._DATA_CLS)
-
-    def get_matches(self, filters, match=any):
-        '''Returns a data container containing only instances that match the
-        filters.
-
-        Args:
-            filters: a list of functions that accept data instances and return
-                True/False
-            match: a function (usually `any` or `all`) that accepts an iterable
-                and returns True/False. Used to aggregate the outputs of each
-                filter to decide whether a match has occurred. The default is
-                `any`
-        '''
-        return self.__class__(**{
-            self._DATA_ATTR:
-            list(filter(lambda o: match(f(o) for f in filters), self._data))
-        })
-
-    @property
-    def size(self):
-        '''Returns the number of data instances in the container.'''
-        return len(self._data)
-
-    def serialize(self):
-        '''Custom serialization implementation for DataContainers that embeds
-        the class name, and the data class name in the JSON to enable
-        reflective parsing when reading from disk.
-        '''
-        d = OrderedDict()
-        d["_CLS"] = self.get_class_name()
-        d["_DATA_CLS"] = self.get_data_class_name()
-        d[self._DATA_ATTR] = [o.serialize() for o in self._data]
-        return d
-
-
-class DataContainerError(Exception):
-    '''Exception raised when an invalid DataContainer is encountered.'''
-    pass
+        return self._elements

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -60,9 +60,43 @@ class DataContainer(etas.Container):
             of the data instances is specified by the `_ELE_CLS` member
     '''
 
+    #
+    # The class of the data stored in the container
+    #
+    # Subclasses MUST set this field
+    #
+    _ELE_CLS = None
+
+    #
+    # The name of the private attribute that will store the class of the
+    # data in the container
+    #
+    # Subclasses MAY override this field
+    #
+    _ELE_CLS_FIELD = "_DATA_CLS"
+
+    #
+    # The name of the attribute that will store the data in the container
+    #
+    # Subclasses MAY override this field
+    #
+    _ELE_ATTR = "data"
+
     @property
     def _data(self):
-        '''Convenient access to the list of data instances stored independent
-        of what the name of that attribute is.
+        '''The list of data instances stored in this container, independent of
+        the container-specific name of the attribute in which they are stored.
         '''
-        return self._elements
+        return self.__elements__
+
+    @classmethod
+    def get_data_class(cls):
+        '''Gets the class of data stored in this container.'''
+        return cls._ELE_CLS
+
+    @classmethod
+    def get_data_class_name(cls):
+        '''Returns the fully-qualified class name string of the data instances
+        in this container.
+        '''
+        return etau.get_class_name(cls._ELE_CLS)

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -19,19 +19,28 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
+import eta.core.serial as etas
+import eta.core.utils as etau
 
-from eta.core.serial import Container
 
+class DataContainer(etas.Container):
+    '''Abstract base class for containers that store lists of `Serializable`
+    data class instances.
 
-class DataContainer(Container):
-    '''Base class for containers that store lists of data instances.
+    This class cannot be instantiated directly. Instead a subclass should
+    be created for each type of data to be stored. Subclasses MUST set the
+    following members:
+        -  `_ELE_CLS`: the class of the element stored in the container
 
-    This class should not be instantiated directly. Instead a subclass should
-    be created for each type of data to be stored.
+    In addition, sublasses MAY override the following members:
+        - `_ELE_CLS_FIELD`: the name of the private attribute that will store
+            the class of the elements in the container
+        - `_ELE_ATTR`: the name of the attribute that will store the elements
+            in the container
 
-    By default, DataContainer subclasses embed their class names and
-    underlying data instance class names in their JSON representations, so
-    data containers can be read reflectively from disk.
+    DataContainer subclasses embed their class names and underlying data
+    instance class names in their JSON representations, so they can be read
+    reflectively from disk.
 
     Examples:
         ```
@@ -47,8 +56,8 @@ class DataContainer(Container):
 
     Attributes:
         <data>: a list of data instances. The field name <data> is specified by
-            the `_ELE_ATTR` member, and the class of the data instances is
-            specified by the `_ELE_CLS` member
+            the `_ELE_ATTR` member of the DataContainer subclass, and the class
+            of the data instances is specified by the `_ELE_CLS` member
     '''
 
     @property

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -53,7 +53,7 @@ class DataContainer(Container):
 
     @property
     def _data(self):
-        '''Convenience accessor to get the list of data instances stored
-        independent of what the name of that attribute is.
+        '''Convenient access to the list of data instances stored independent
+        of what the name of that attribute is.
         '''
         return self._elements

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -179,8 +179,8 @@ class LabeledPoint(Serializable):
 class LabeledPointContainer(DataContainer):
     '''Container for points in an image that each have an associated label.'''
 
-    _DATA_CLS = LabeledPoint
-    _DATA_ATTR = "points"
+    _ELE_CLS = LabeledPoint
+    _ELE_ATTR = "points"
 
     def label_set(self):
         '''Returns a set containing the labels of the LabeledPoints.'''

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -1,5 +1,5 @@
 '''
-Core data structures for working with detected objects in images.
+Core data structures for working with detected objects in images and videos.
 
 Copyright 2017-2018, Voxel51, LLC
 voxel51.com

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -64,29 +64,20 @@ class ObjectAttribute(Serializable):
 
 
 class ObjectAttributeContainer(DataContainer):
-    '''A generic container for `ObjectAttribute`s or its subclasses.'''
+    '''A container for object attributes.'''
 
     _ELE_CLS = ObjectAttribute
     _ELE_CLS_FIELD = "_ATTR_CLS"
     # Note: we can't use "attributes" here due to `Serialiable.attributes()`
     _ELE_ATTR = "attrs"
 
-    @classmethod
-    def _validate(cls):
-        '''Validates that an ObjectAttributeContainer definition is valid.
+    def category_set(self):
+        '''Returns the set of attribute categories in the container.'''
+        return set(attr.category for attr in self)
 
-        `ObjectAttributeContainer`s must only contain `ObjectAttribute`s or
-        subclasses of them.
-        '''
-        super(ObjectAttributeContainer, cls)._validate()
-        if not issubclass(cls._ELE_CLS, ObjectAttribute):
-            raise ObjectAttributeContainerError(
-                "%s is not an ObjectAttribute subclass" % cls._ELE_CLS)
-
-
-class ObjectAttributeContainerError(Exception):
-    '''Exception raised when an invalid ConfigContainer is encountered.'''
-    pass
+    def label_set(self):
+        '''Returns the set of attribute labels in the container.'''
+        return set(attr.label for attr in self)
 
 
 class DetectedObject(Serializable):

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -146,6 +146,21 @@ class DetectedObject(Serializable):
         '''
         return self.bounding_box.extract_from(img, force_square=force_square)
 
+    def attributes(self):
+        '''Returns the list of attributes to serialize.
+
+        Optional attributes that were not provided (e.g. are None) are omitted
+        from this list.
+        '''
+        _attrs = ["label", "confidence", "bounding_box"]
+        if self.index is not None:
+            _attrs.append("index")
+        if self.frame_number is not None:
+            _attrs.append("frame_number")
+        if self.attrs is not None:
+            _attrs.append("attrs")
+        return _attrs
+
     @classmethod
     def from_dict(cls, d):
         '''Constructs a DetectedObject from a JSON dictionary.'''

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -107,19 +107,34 @@ class DetectedObject(Serializable):
         label: object label
         confidence: detection confidence
         bounding_box: a BoundingBox around the object
+        index: (optional) an index assigned to the object
+        frame_number: (optional) the frame number in which this object was
+            detected
+        attrs: (optional) an `ObjectAttributeContainer` describing additional
+            attributes of the object
     '''
 
-    def __init__(self, label, confidence, bounding_box):
+    def __init__(
+            self, label, confidence, bounding_box, index=None,
+            frame_number=None, attrs=None):
         '''Constructs a DetectedObject.
 
         Args:
             label: object label string
             confidence: detection confidence, in [0, 1]
             bounding_box: a BoundingBox around the object
+            index: (optional) an index assigned to the object
+            frame_number: (optional) the frame number in which this object was
+                detected
+            attrs: (optional) an `ObjectAttributeContainer` describing
+                additional attributes of the object
         '''
         self.label = str(label)
         self.confidence = float(confidence)
         self.bounding_box = bounding_box
+        self.index = index
+        self.frame_number = frame_number
+        self.attrs = attrs
 
     def extract_from(self, img, force_square=False):
         '''Extracts the subimage containing this object from the image.

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -23,17 +23,6 @@ from eta.core.geometry import BoundingBox
 from eta.core.serial import Serializable
 
 
-class ObjectContainer(DataContainer):
-    '''Base class for containers that store lists of objects.
-
-    Subclasses must set the `_ELE_CLS` attribute.
-    '''
-
-    _ELE_CLS = None
-    _ELE_CLS_FIELD = "_OBJ_CLS"
-    _ELE_ATTR = "objects"
-
-
 class ObjectAttribute(Serializable):
     '''Base class for object attributes.'''
 
@@ -179,7 +168,7 @@ class DetectedObject(Serializable):
         )
 
 
-class DetectedObjectContainer(ObjectContainer):
+class DetectedObjectContainer(DataContainer):
     '''Base class for containers that store lists of `DetectedObject`s.'''
 
     _ELE_CLS = DetectedObject
@@ -196,6 +185,8 @@ class Frame(ObjectContainer):
     '''
 
     _ELE_CLS = DetectedObject
+    _ELE_CLS_FIELD = "_OBJ_CLS"
+    _ELE_ATTR = "objects"
 
     def label_set(self):
         '''Returns a set containing the labels of the DetectedObjects.'''
@@ -258,10 +249,12 @@ class ScoredObject(Serializable):
         )
 
 
-class ScoredObjects(ObjectContainer):
+class ScoredObjects(DataContainer):
     '''Container for scored objects.'''
 
     _ELE_CLS = ScoredObject
+    _ELE_CLS_FIELD = "_OBJ_CLS"
+    _ELE_ATTR = "objects"
 
     def sort(self):
         '''Sorts the current object list in ascending order by score.'''

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -24,7 +24,7 @@ from eta.core.serial import Serializable
 
 
 class ObjectAttribute(Serializable):
-    '''Base class for object attributes.'''
+    '''An attribute of a detected object.'''
 
     def __init__(self, category=None, label=None, confidence=None):
         '''Constructs an ObjectAttribute.
@@ -308,5 +308,5 @@ class ScoredObjects(DataContainer):
         '''Sorts the current object list in ascending order by score.'''
         setattr(
             self, self._ELE_ATTR,
-            sorted(self._data, key=lambda obj: obj.score)
+            sorted(self.objects, key=lambda obj: obj.score)
         )

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -190,13 +190,16 @@ class DetectedObjectContainer(ObjectContainer):
 
 
 class Frame(ObjectContainer):
-    '''Container for detected objects in a frame.'''
+    '''Container for detected objects in a frame.
+
+    @todo Deprecate this container in favor of DetectedObjectContainer
+    '''
 
     _ELE_CLS = DetectedObject
 
     def label_set(self):
         '''Returns a set containing the labels of the DetectedObjects.'''
-        return set(obj.label for obj in self.objects)
+        return set(obj.label for obj in self)
 
 
 class ObjectCount(Serializable):

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -30,7 +30,74 @@ class ObjectContainer(DataContainer):
     '''
 
     _ELE_CLS = None
+    _ELE_CLS_FIELD = "_OBJ_CLS"
     _ELE_ATTR = "objects"
+
+
+class ObjectAttribute(Serializable):
+    '''Base class for object attributes.'''
+
+    def __init__(self, category=None, label=None, confidence=None):
+        '''Constructs an ObjectAttribute.
+
+        Args:
+            category: (optional) the attribute category
+            label: (optional) the attribute label
+            confidence: (optional) the confidence of the label, in [0, 1]
+        '''
+        self.category = category
+        self.label = label
+        self.confidence = float(confidence)
+
+    def attributes(self):
+        '''Returns the list of attributes to serialize.
+
+        Optional attributes that were not provided (e.g. are None) are omitted
+        from this list.
+        '''
+        _attrs = []
+        if self.category is not None:
+            _attrs.append("category")
+        if self.label is not None:
+            _attrs.append("label")
+        if self.confidence is not None:
+            _attrs.append("confidence")
+        return _attrs
+
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs an ObjectAttribute from a JSON dictionary.'''
+        return cls(
+            category=d.get("category", None),
+            label=d.get("label", None),
+            confidence=d.get("confidence", None),
+        )
+
+
+class ObjectAttributeContainer(DataContainer):
+    '''A generic container for `ObjectAttribute`s or its subclasses.'''
+
+    _ELE_CLS = ObjectAttribute
+    _ELE_CLS_FIELD = "_ATTR_CLS"
+    # Note: we can't use "attributes" here due to `Serialiable.attributes()`
+    _ELE_ATTR = "attrs"
+
+    @classmethod
+    def _validate(cls):
+        '''Validates that an ObjectAttributeContainer definition is valid.
+
+        `ObjectAttributeContainer`s must only contain `ObjectAttribute`s or
+        subclasses of them.
+        '''
+        super(ObjectAttributeContainer, cls)._validate()
+        if not issubclass(cls._ELE_CLS, ObjectAttribute):
+            raise ObjectAttributeContainerError(
+                "%s is not an ObjectAttribute subclass" % cls._ELE_CLS)
+
+
+class ObjectAttributeContainerError(Exception):
+    '''Exception raised when an invalid ConfigContainer is encountered.'''
+    pass
 
 
 class DetectedObject(Serializable):

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -26,11 +26,11 @@ from eta.core.serial import Serializable
 class ObjectContainer(DataContainer):
     '''Base class for containers that store lists of objects.
 
-    Subclasses must set the `_DATA_CLS` attribute.
+    Subclasses must set the `_ELE_CLS` attribute.
     '''
 
-    _DATA_CLS = None
-    _DATA_ATTR = "objects"
+    _ELE_CLS = None
+    _ELE_ATTR = "objects"
 
 
 class DetectedObject(Serializable):
@@ -77,7 +77,7 @@ class DetectedObject(Serializable):
 class Frame(ObjectContainer):
     '''Container for detected objects in a frame.'''
 
-    _DATA_CLS = DetectedObject
+    _ELE_CLS = DetectedObject
 
     def label_set(self):
         '''Returns a set containing the labels of the DetectedObjects.'''
@@ -100,8 +100,8 @@ class ObjectCount(Serializable):
 class ObjectCounts(DataContainer):
     '''Container for counting objects in an image.'''
 
-    _DATA_CLS = ObjectCount
-    _DATA_ATTR = "counts"
+    _ELE_CLS = ObjectCount
+    _ELE_ATTR = "counts"
 
 
 class ScoredObject(Serializable):
@@ -143,11 +143,11 @@ class ScoredObject(Serializable):
 class ScoredObjects(ObjectContainer):
     '''Container for scored objects.'''
 
-    _DATA_CLS = ScoredObject
+    _ELE_CLS = ScoredObject
 
     def sort(self):
         '''Sorts the current object list in ascending order by score.'''
         setattr(
-            self, self._DATA_ATTR,
+            self, self._ELE_ATTR,
             sorted(self._data, key=lambda obj: obj.score)
         )

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -164,11 +164,29 @@ class DetectedObject(Serializable):
     @classmethod
     def from_dict(cls, d):
         '''Constructs a DetectedObject from a JSON dictionary.'''
+        if "attrs" in d:
+            attrs = ObjectAttributeContainer.from_dict(d["attrs"])
+        else:
+            attrs = None
+
         return cls(
             d["label"],
             d["confidence"],
             BoundingBox.from_dict(d["bounding_box"]),
+            index=d.get("index", None),
+            frame_number=d.get("frame_number", None),
+            attrs=attrs,
         )
+
+
+class DetectedObjectContainer(ObjectContainer):
+    '''Base class for containers that store lists of `DetectedObject`s.'''
+
+    _ELE_CLS = DetectedObject
+
+    def label_set(self):
+        '''Returns a set containing the labels of the DetectedObjects.'''
+        return set(obj.label for obj in self)
 
 
 class Frame(ObjectContainer):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -366,6 +366,7 @@ class Container(Serializable):
             ele_cls = etau.get_class(d[cls._ELE_CLS_FIELD])
         else:
             # Parse using provided class
+            cls._validate()
             ele_cls = cls._ELE_CLS
 
         return cls(**{

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -214,13 +214,6 @@ class Container(Serializable):
     '''
 
     #
-    # The name of the private attribute that will store the class
-    #
-    # Subclasses MAY override this field
-    #
-    _CLS_FIELD = "_CLS"
-
-    #
     # The class of the element stored in the container
     #
     # Subclasses MUST set this field
@@ -333,7 +326,7 @@ class Container(Serializable):
         '''Returns the list of class attributes that will be serialized by this
         Container.
         '''
-        return [self._CLS_FIELD, self._ELE_CLS_FIELD, self._ELE_ATTR]
+        return ["_CLS", self._ELE_CLS_FIELD, self._ELE_ATTR]
 
     def serialize(self):
         '''Serializes the object into a dictionary.
@@ -343,7 +336,7 @@ class Container(Serializable):
         reflective parsing when reading from disk.
         '''
         d = OrderedDict()
-        d[self._CLS_FIELD] = self.get_class_name()
+        d["_CLS"] = self.get_class_name()
         d[self._ELE_CLS_FIELD] = etau.get_class_name(self._ELE_CLS)
         d[self._ELE_ATTR] = [o.serialize() for o in self.__elements__]
         return d
@@ -352,7 +345,7 @@ class Container(Serializable):
     def from_dict(cls, d):
         '''Constructs a Container from a JSON dictionary.
 
-        If the dictionary has the `cls._CLS_FIELD` and `cls._ELE_CLS_FIELD`
+        If the dictionary has the `"_CLS"` and `cls._ELE_CLS_FIELD`
         keys, they are used to infer the Container class and underlying element
         classes, respectively, and this method can be invoked on any
         `Container` subclass that has the same `_ELE_CLS_FIELD` setting.
@@ -362,7 +355,7 @@ class Container(Serializable):
         '''
         if cls._CLS_FIELD in d and cls._ELE_CLS_FIELD in d:
             # Parse reflectively
-            cls = etau.get_class(d[cls._CLS_FIELD])
+            cls = etau.get_class(d["_CLS"])
             ele_cls = etau.get_class(d[cls._ELE_CLS_FIELD])
         else:
             # Parse using provided class

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -243,12 +243,12 @@ class Container(Serializable):
     _ELE_ATTR = None
 
     def __init__(self, **kwargs):
-        '''Constructs a Container.
+        '''Constructs a Container subclass.
 
         Args:
-            <element>: an optional list of elements to store in the container.
+            <element>: an optional list of elements to store in the Container.
             The appropriate name of this keyword argument is determined by the
-            `_ELE_ATTR` member of the container class.
+            `_ELE_ATTR` member of the Container subclass.
 
         Raises:
             ContainerError: if there was a problem parsing the input
@@ -305,11 +305,12 @@ class Container(Serializable):
         return ["_CLS", "_ELE_CLS", self._ELE_ATTR]
 
     def count_matches(self, filters, match=any):
-        '''Counts number of elements that match the filters.
+        '''Counts the number of elements in the Container that match the
+        given filters.
 
         Args:
-            filters: a list of functions that accept elements and return
-                True/False
+            filters: a list of functions that accept instances of class
+                `_ELE_CLS`and return True/False
             match: a function (usually `any` or `all`) that accepts an iterable
                 and returns True/False. Used to aggregate the outputs of each
                 filter to decide whether a match has occurred. The default is

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -353,7 +353,19 @@ class Container(Serializable):
         Otherwise, this method must be called on the same concrete `Container`
         subclass from which the JSON was generated.
         '''
-        if cls._CLS_FIELD in d and cls._ELE_CLS_FIELD in d:
+        if cls._ELE_CLS_FIELD is None:
+            raise ContainerError(
+                "%s is an abstract container and cannot be used to load a "
+                "JSON dictionary. Please use a Container subclass that "
+                "defines its `_ELE_CLS_FIELD` member" % cls)
+
+        if "_CLS" in d:
+            if cls._ELE_CLS_FIELD not in d:
+                raise ContainerError(
+                    "Cannot use %s to reflectively load this container "
+                    "because the expected field '%s' was not found in the "
+                    "JSON dictionary" % (cls, cls._ELE_CLS_FIELD))
+
             # Parse reflectively
             cls = etau.get_class(d["_CLS"])
             ele_cls = etau.get_class(d[cls._ELE_CLS_FIELD])

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -194,29 +194,52 @@ class Serializable(object):
 
 
 class Container(Serializable):
-    '''Base class for flexible containers that store lists of serializable
-    elements.
+    '''Abstract base class for flexible containers that store lists of
+    `Serializable` elements.
 
-    This class should not be instantiated directly. Instead a subclass should
-    be created for each type of data to be stored.  The two common direct
-    sub-classes of this `Container` are `DataContainer` and `ConfigContainer`
-    to store data and `Config` instances respectively.  See these two class
-    definitions for examples of using `Container`.
+    Container subclasses embed their class names and underlying element class
+    names in their JSON representations, so they can be read reflectively from
+    disk.
 
-    By default, Container subclasses embed their class names and underlying
-    data instance class names in their JSON representations, so data
-    containers can be read reflectively from disk.
+    This class cannot be instantiated directly.
 
-    Attributes:
-        <element>: a list of elements. The field name <element> is specified
-            by the `_ELE_ATTR` member, and the class of the elements is
-            specified by the `_ELE_CLS` member
+    This class currently has only two direct subclasses, which bifurcate the
+    container implementation into two distinct categories:
+        - `eta.core.data.DataContainer`: base class for containers that store
+            lists of `Serializable` data instances
+        - `eta.core.config.ConfigContainer`: base class for containers that
+            store lists of `Config` instances
+
+    See `DataContainer` and `ConfigContainer` for concrete usage examples.
     '''
 
+    #
+    # The name of the private attribute that will store the class
+    #
+    # Subclasses MAY override this field
+    #
+    _CLS_FIELD = "_CLS"
+
+    #
     # The class of the element stored in the container
+    #
+    # Subclasses MUST set this field
+    #
     _ELE_CLS = None
 
+    #
+    # The name of the private attribute that will store the class of the
+    # elements in the container
+    #
+    # Subclasses MUST set this field
+    #
+    _ELE_CLS_FIELD = None
+
+    #
     # The name of the attribute that will store the elements in the container
+    #
+    # Subclasses MUST set this field
+    #
     _ELE_ATTR = None
 
     def __init__(self, **kwargs):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -193,6 +193,187 @@ class Serializable(object):
         return cls.from_dict(read_json(path))
 
 
+class Container(Serializable):
+    '''Base class for flexible containers that store lists of serializable
+    elements.
+
+    This class should not be instantiated directly. Instead a subclass should
+    be created for each type of data to be stored.  The two common direct
+    sub-classes of this `Container` are `DataContainer` and `ConfigContainer`
+    to store data and `Config` instances respectively.  See these two class
+    definitions for examples of using `Container`.
+
+    By default, Container subclasses embed their class names and underlying
+    data instance class names in their JSON representations, so data
+    containers can be read reflectively from disk.
+
+    Attributes:
+        <element>: a list of elements. The field name <element> is specified
+            by the `_ELE_ATTR` member, and the class of the elements is
+            specified by the `_ELE_CLS` member
+    '''
+
+    # The class of the element stored in the container
+    _ELE_CLS = None
+
+    # The name of the attribute that will store the elements in the container
+    _ELE_ATTR = "elements"
+
+    def __init__(self, **kwargs):
+        '''Constructs a Container.
+
+        Args:
+            <element>: an optional list of elements to store in the container.
+            The appropriate name of this keyword argument is determined by the
+            `_ELE_ATTR` member of the container class.  If a subclass chooses
+            not to override this attribute, then the default keyword is
+            "elements"
+
+        Raises:
+            ContainerError: if there was a problem parsing the input
+        '''
+        self._validate()
+
+        if kwargs and self._ELE_ATTR not in kwargs:
+            raise ContainerError(
+                "Expected elements to be provided in keyword argument '%s'; "
+                "found keys %s" % (self._ELE_ATTR, list(kwargs.keys())))
+        elements = kwargs.get(self._ELE_ATTR, [])
+
+        for e in elements:
+            if not isinstance(e, self._ELE_CLS):
+                raise ContainerError(
+                    "Container %s expects elements of type %s but found "
+                    "%s" % (self.__class__, self._ELE_CLS, e.__class__))
+
+        setattr(self, self._ELE_ATTR, elements)
+
+    def __getitem__(self, index):
+        return self._elements.__getitem__(index)
+
+    def __iter__(self):
+        return iter(self._elements)
+
+    @property
+    def _elements(self):
+        '''Convenient access function to get the list of elements stored
+        independent of what the name of that attribute is.
+        '''
+        return getattr(self, self._ELE_ATTR)
+
+    @classmethod
+    def _validate(cls):
+        if cls._DATA_CLS is None:
+            raise DataContainerError(
+                "_DATA_CLS is None; note that you cannot instantiate "
+                "DataContainer directly.")
+        if cls._DATA_ATTR is None:
+            raise DataContainerError(
+                "_DATA_ATTR is None; note that you cannot instantiate "
+                "DataContainer directly.")
+
+    def add(self, instance):
+        '''Adds a data instance to the container.
+
+        Args:
+            instance: an instance of `_DATA_CLS`
+        '''
+        self._data.append(instance)
+
+    def attributes(self):
+        return ["_CLS", "_DATA_CLS", self._DATA_ATTR]
+
+    def count_matches(self, filters, match=any):
+        '''Counts number of data instances that match the filters.
+
+        Args:
+            filters: a list of functions that accept data instances and return
+                True/False
+            match: a function (usually `any` or `all`) that accepts an iterable
+                and returns True/False. Used to aggregate the outputs of each
+                filter to decide whether a match has occurred. The default is
+                `any`
+        '''
+        return self.get_matches(filters, match=match).num
+
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs an DataContainer from a JSON dictionary.
+
+        If the JSON contains the reflective `_CLS` and `_DATA_CLS` fields, they
+        are used to infer the underlying data classes, and this method can
+        be invoked as `DataContainer.from_dict`. Otherwise, this method must
+        be called on a concrete subclass of `DataContainer`.
+        '''
+        if "_CLS" in d and "_DATA_CLS" in d:
+            # Parse reflectively
+            cls = etau.get_class(d["_CLS"])
+            data_cls = etau.get_class(d["_DATA_CLS"])
+        else:
+            # Parse using provided class
+            cls._validate()
+            data_cls = cls._DATA_CLS
+        return cls(**{
+            cls._DATA_ATTR:
+            [data_cls.from_dict(dd) for dd in d[cls._DATA_ATTR]]
+        })
+
+    @classmethod
+    def get_class_name(cls):
+        '''Returns the fully-qualified class name string of this container.'''
+        return etau.get_class_name(cls)
+
+    @classmethod
+    def get_data_class(cls):
+        '''Gets the class of data instances stored in this container.'''
+        return cls._DATA_CLS
+
+    @classmethod
+    def get_data_class_name(cls):
+        '''Returns the fully-qualified class name string of the data in this
+        container.
+        '''
+        return etau.get_class_name(cls._DATA_CLS)
+
+    def get_matches(self, filters, match=any):
+        '''Returns a data container containing only instances that match the
+        filters.
+
+        Args:
+            filters: a list of functions that accept data instances and return
+                True/False
+            match: a function (usually `any` or `all`) that accepts an iterable
+                and returns True/False. Used to aggregate the outputs of each
+                filter to decide whether a match has occurred. The default is
+                `any`
+        '''
+        return self.__class__(**{
+            self._DATA_ATTR:
+            list(filter(lambda o: match(f(o) for f in filters), self._data))
+        })
+
+    @property
+    def size(self):
+        '''Returns the number of data instances in the container.'''
+        return len(self._data)
+
+    def serialize(self):
+        '''Custom serialization implementation for DataContainers that embeds
+        the class name, and the data class name in the JSON to enable
+        reflective parsing when reading from disk.
+        '''
+        d = OrderedDict()
+        d["_CLS"] = self.get_class_name()
+        d["_DATA_CLS"] = self.get_data_class_name()
+        d[self._DATA_ATTR] = [o.serialize() for o in self._data]
+        return d
+
+
+class ContainerError(Exception):
+    '''Exception raised when an invalid Container is encountered.'''
+    pass
+
+
 def is_serializable(obj):
     '''Returns True if the object is serializable (i.e., implements the
     Serializable interface) and False otherwise.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -270,16 +270,13 @@ class Container(Serializable):
         setattr(self, self._ELE_ATTR, elements)
 
     def __getitem__(self, index):
-        return self._elements.__getitem__(index)
+        return self.__elements__.__getitem__(index)
 
     def __iter__(self):
-        return iter(self._elements)
+        return iter(self.__elements__)
 
     @property
-    def _elements(self):
-        '''Convenient access function to get the list of elements stored
-        independent of what the name of that attribute is.
-        '''
+    def __elements__(self):
         return getattr(self, self._ELE_ATTR)
 
     @classmethod
@@ -299,10 +296,12 @@ class Container(Serializable):
         Args:
             instance: an instance of `_ELE_CLS`
         '''
-        self._elements.append(instance)
+        self.__elements__.append(instance)
 
-    def attributes(self):
-        return ["_CLS", "_ELE_CLS", self._ELE_ATTR]
+    @property
+    def size(self):
+        '''Returns the number of elements in the container.'''
+        return len(self.__elements__)
 
     def count_matches(self, filters, match=any):
         '''Counts the number of elements in the Container that match the

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -322,6 +322,23 @@ class Container(Serializable):
                 lambda o: match(f(o) for f in filters), self.__elements__))
         })
 
+    def _sort_by_attr(self, attr, reverse=False):
+        '''Sorts the elements in the container by the given attribute.
+
+        Elements whose attribute is None are always put at the end of the list.
+
+        Args:
+            attr: the element attribute to sort by
+            reverse: whether to sort in descending order. The default is False
+        '''
+        def field_none_last(ele):
+            val = getattr(ele, attr)
+            return ((val is None) ^ reverse, val)  # always puts None last
+
+        setattr(
+            self, self._ELE_ATTR, sorted(
+                self.__elements__, reverse=reverse, key=field_none_last))
+
     def attributes(self):
         '''Returns the list of class attributes that will be serialized by this
         Container.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -279,7 +279,7 @@ class Container(Serializable):
         self._elements.append(instance)
 
     def attributes(self):
-        return ["_CLS", "_ELE_CLS", self._DATA_ATTR]
+        return ["_CLS", "_ELE_CLS", self._ELE_ATTR]
 
     def count_matches(self, filters, match=any):
         '''Counts number of elements that match the filters.


### PR DESCRIPTION
`Config`s sometimes also need to be represented in a container and they are distinct from data.  So, this PR generalizes the recently added `DataContainer` to be just `Container` and maintains two top-level subclasses from it: `DataContainer` and `ConfigContainer` that establish sub-trees. This reflection attributes are switched from `_DATA_XXX` to `_ELE_XXX` for element to denote that a container can handle lots of different types of things.

This is the simplest way to implement this more general container.