### PR TITLE
Adding ability to compute intersections of bounding boxes and related quantities

### DIFF
--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -60,6 +60,9 @@ class BoundingBox(Serializable):
             img: an image
             force_square: whether to (minimally) manipulate the bounding box
                 during extraction so that the returned subimage is square
+
+        Returns:
+            the extracted subimage
         '''
         x1, y1 = self.top_left.coords_in(img=img)
         x2, y2 = self.bottom_right.coords_in(img=img)

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -217,7 +217,7 @@ class RelativePoint(Serializable):
 
     @classmethod
     def origin(cls):
-        '''Returns an relative point at the origin.'''
+        '''Returns a relative point at the origin.'''
         return cls(0, 0)
 
     @classmethod

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -138,11 +138,7 @@ class BoundingBox(Serializable):
         Returns:
             the overlap area, in [0, 1]
         '''
-        xli = max(self.top_left.x, bbox.top_left.x)
-        xri = min(self.bottom_right.x, bbox.bottom_right.x)
-        yti = max(self.top_left.y, bbox.top_left.y)
-        ybi = min(self.bottom_right.y, bbox.bottom_right.y)
-        return max(0, xri - xli) * max(0, ybi - yti)
+        return self.get_intersection(bbox).area()
 
     def overlap_ratio(self, bbox):
         '''Computes the overlap ratio with the given bounding box, defined as

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -37,7 +37,7 @@ class BoundingBox(Serializable):
         self.bottom_right = bottom_right
 
     def __str__(self):
-        return self.top_left.__str__() + " -- " + self.bottom_right.__str__()
+        return "%s x %s" % (self.top_left, self.bottom_right)
 
     def coords_in(self, **kwargs):
         '''Returns the coordinates of the bounding box in the specified image.

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -102,9 +102,32 @@ class BoundingBox(Serializable):
 
     def area(self):
         '''Computes the area of the bounding box, in [0, 1].'''
-        dx = self.bottom_right.x - self.top_left.x
-        dy = self.bottom_right.y - self.top_left.y
-        return dx * dy
+        w = self.bottom_right.x - self.top_left.x
+        h = self.bottom_right.y - self.top_left.y
+        return w * h
+
+    def get_intersection(self, bbox):
+        '''Returns the bounding box describing the intersection of this
+        bounding box with the given bounding box.
+
+        If the bounding boxes do not intersect, an empty bounding box is
+        returned.
+
+        Args:
+            bbox: a BoundingBox
+
+        Returns:
+            a bounding box describing the intersection
+        '''
+        tlx = max(self.top_left.x, bbox.top_left.x)
+        tly = max(self.top_left.y, bbox.top_left.y)
+        brx = min(self.bottom_right.x, bbox.bottom_right.x)
+        bry = min(self.bottom_right.y, bbox.bottom_right.y)
+
+        if (brx - tlx < 0) or (bry - tly < 0):
+            return BoundingBox.empty()
+
+        return BoundingBox(RelativePoint(tlx, tly), RelativePoint(brx, bry))
 
     def overlap_area(self, bbox):
         '''Computes the area of the overlap with the given bounding box.

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -136,6 +136,11 @@ class BoundingBox(Serializable):
         return oa / (self.area() + bbox.area() - oa) if oa > 0 else 0
 
     @classmethod
+    def empty(cls):
+        '''Returns an empty bounding box.'''
+        return cls(RelativePoint.origin(), RelativePoint.origin())
+
+    @classmethod
     def from_dict(cls, d):
         '''Constructs a BoundingBox from a JSON dictionary.'''
         return cls(
@@ -197,6 +202,11 @@ class RelativePoint(Serializable):
         x /= 1.0 * w
         y /= 1.0 * h
         return cls(x, y)
+
+    @classmethod
+    def origin(cls):
+        '''Returns an relative point at the origin.'''
+        return cls(0, 0)
 
     @classmethod
     def from_dict(cls, d):

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -74,22 +74,24 @@ class BoundingBox(Serializable):
         return img[y, x, ...]
 
     def pad_relative(self, alpha):
-        '''Returns a bounding box padded by the given relative amount.
+        '''Returns a bounding box whose length and width are expanded (or
+        shrunk, when alpha < 0) by (100 * alpha)%.
 
-        The length and width of the bounding box will be
+        The coordinates are clamped to [0, 1] x [0, 1] if necessary.
+
         Args:
             alpha: the desired padding relative to the size of this
-                bounding box; a float in [0, 1]
+                bounding box; a float in [-1, \inf)
 
         Returns:
             the padded bounding box
         '''
+        w = self.bottom_right.x - self.top_left.x
+        h = self.bottom_right.y - self.top_left.y
 
-        whalf = 0.5 * (self.bottom_right.x - self.top_left.x)
-        hhalf = 0.5 * (self.bottom_right.y - self.top_left.y)
-
-        wpad = max(-whalf, alpha * whalf)
-        hpad = max(-hhalf, alpha * hhalf)
+        alpha = max(alpha, -1)
+        wpad = 0.5 * alpha * w
+        hpad = 0.5 * alpha * h
 
         tlx, tly = RelativePoint.clamp(
             self.top_left.x - wpad, self.top_left.y - hpad)
@@ -144,6 +146,7 @@ class BoundingBox(Serializable):
 
 class HasBoundingBox(object):
     '''Mixin to explicitly indicate that an instance has a bounding box.'''
+
     def get_bounding_box(self):
         raise NotImplementedError(
             "Classes implementing HasBoundingBox need to implement the "

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -140,8 +140,12 @@ class BoundingBox(Serializable):
         Returns:
             the overlap ratio, in [0, 1]
         '''
-        oa = self.get_intersection(bbox).area()
-        return oa / (self.area() + bbox.area() - oa) if oa > 0 else 0
+        inter_area = self.get_intersection(bbox).area()
+        union_area = self.area() + bbox.area() - inter_area
+        try:
+            return inter_area / union_area
+        except ZeroDivisionError:
+            return 0.0
 
     @classmethod
     def empty(cls):

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -129,21 +129,10 @@ class BoundingBox(Serializable):
 
         return BoundingBox(RelativePoint(tlx, tly), RelativePoint(brx, bry))
 
-    def overlap_area(self, bbox):
-        '''Computes the area of the overlap with the given bounding box.
-
-        Args:
-            bbox: a BoundingBox
-
-        Returns:
-            the overlap area, in [0, 1]
-        '''
-        return self.get_intersection(bbox).area()
-
     def overlap_ratio(self, bbox):
         '''Computes the overlap ratio with the given bounding box, defined as
-        the area of the intersection (overlap) divided by the area of the
-        union of the two bounding boxes.
+        the area of the intersection divided by the area of the union of the
+        two bounding boxes.
 
         Args:
             bbox: a BoundingBox
@@ -151,7 +140,7 @@ class BoundingBox(Serializable):
         Returns:
             the overlap ratio, in [0, 1]
         '''
-        oa = self.overlap_area(bbox)
+        oa = self.get_intersection(bbox).area()
         return oa / (self.area() + bbox.area() - oa) if oa > 0 else 0
 
     @classmethod


### PR DESCRIPTION
Make-shift test suite:
```py
import eta.core.geometry as etag

tl = etag.RelativePoint(0.25, 0.25)
br = etag.RelativePoint(0.75, 0.75)
bb = etag.BoundingBox(tl, br)

print(bb.pad_relative(0.1))
# expected: (0.225, 0.225) x (0.775, 0.775)
print(bb.pad_relative(1))
# expected: (0.000, 0.000) x (1.000, 1.000)
print(bb.pad_relative(-0.1))
# expected: (0.275, 0.275) x (0.725, 0.725)
print(bb.pad_relative(-1))
# expected: (0.500, 0.500) x (0.500, 0.500)

print(bb.area())
# expected: 1/4 = 0.25
print(bb.get_intersection(bb).area())
# expected: 1/4 = 0.25
print(bb.overlap_ratio(bb))
# expected: 1

tl1 = etag.RelativePoint(0, 0)
br1 = etag.RelativePoint(0.5, 0.5)
bb1 = etag.BoundingBox(tl1, br1)

tl2 = etag.RelativePoint(0.25, 0.25)
br2 = etag.RelativePoint(0.75, 0.75)
bb2 = etag.BoundingBox(tl2, br2)

print(bb1.get_intersection(bb2).area())
print(bb2.get_intersection(bb1).area())
# expected: 1/16 = 0.0625

print(bb1.overlap_ratio(bb2))
print(bb2.overlap_ratio(bb1))
# expected: 1/7 = 0.142857142857

tl3 = etag.RelativePoint(0, 0)
br3 = etag.RelativePoint(0.5, 0.5)
bb3 = etag.BoundingBox(tl3, br3)

tl4 = etag.RelativePoint(0.5, 0)
br4 = etag.RelativePoint(1, 1)
bb4 = etag.BoundingBox(tl4, br4)

print(bb3.get_intersection(bb4).area())
# expected: 0

print(bb3.overlap_ratio(bb4))
# expected: 0
```