### PR TITLE
Add `index_in_frame` to DetectedObject

### DIFF
--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -91,6 +91,8 @@ class DetectedObject(Serializable, HasBoundingBox):
         score: (optional) an optional score for the object
         frame_number: (optional) the frame number in which this object was
             detected
+        index_in_frame: (optional) the index of this object in the frame
+            where it was detected
         attrs: (optional) an ObjectAttributeContainer describing additional
             attributes of the object
     '''

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -97,7 +97,7 @@ class DetectedObject(Serializable, HasBoundingBox):
 
     def __init__(
             self, label, bounding_box, confidence=None, index=None, score=None,
-            frame_number=None, attrs=None):
+            frame_number=None, index_in_frame=None, attrs=None):
         '''Constructs a DetectedObject.
 
         Args:
@@ -176,7 +176,7 @@ class DetectedObject(Serializable, HasBoundingBox):
             index=d.get("index", None),
             score=d.get("score", None),
             frame_number=d.get("frame_number", None),
-            index_in_frame=d.get("index_in_frame", None)
+            index_in_frame=d.get("index_in_frame", None),
             attrs=attrs,
         )
 

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -108,7 +108,8 @@ class DetectedObject(Serializable, HasBoundingBox):
             score: (optional) an optional score for the object
             frame_number: (optional) the frame number in which this object was
                 detected
-            index_in_frame: (optional) the object index in one frame
+            index_in_frame: (optional) the index of this object in the frame
+                where it was detected
             attrs: (optional) an ObjectAttributeContainer describing additional
                 attributes of the object
         '''

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -108,6 +108,7 @@ class DetectedObject(Serializable, HasBoundingBox):
             score: (optional) an optional score for the object
             frame_number: (optional) the frame number in which this object was
                 detected
+            index_in_frame: (optional) the object index in one frame
             attrs: (optional) an ObjectAttributeContainer describing additional
                 attributes of the object
         '''
@@ -117,6 +118,7 @@ class DetectedObject(Serializable, HasBoundingBox):
         self.index = index
         self.score = score
         self.frame_number = frame_number
+        self.index_in_frame = index_in_frame
         self.attrs = attrs or ObjectAttributeContainer()
         self._meta = None  # Usable by clients to store temporary metadata
 
@@ -153,6 +155,8 @@ class DetectedObject(Serializable, HasBoundingBox):
             _attrs.append("score")
         if self.frame_number is not None:
             _attrs.append("frame_number")
+        if self.index_in_frame is not None:
+            _attrs.append("index_in_frame")
         if self.attrs:
             _attrs.append("attrs")
         return _attrs
@@ -172,6 +176,7 @@ class DetectedObject(Serializable, HasBoundingBox):
             index=d.get("index", None),
             score=d.get("score", None),
             frame_number=d.get("frame_number", None),
+            index_in_frame=d.get("index_in_frame", None)
             attrs=attrs,
         )
 


### PR DESCRIPTION
- Add a new attribute `index_in_frame` to DetectedObject to inform the original index of an object in a frame