### PR TITLE
Adding method to VideoStreamInfo to get the aspect ratio of a video

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -112,6 +112,12 @@ class VideoStreamInfo(Serializable):
         )
 
     @property
+    def aspect_ratio(self):
+        '''The aspect ratio of the video.'''
+        width, height = self.frame_size
+        return width * 1.0 / height
+
+    @property
     def frame_rate(self):
         '''The frame rate.'''
         try:


### PR DESCRIPTION
@jeffreydominic @kunyilu please take a look at this PR and make a mental to use the properties that `VideoStreamInfo` provides for you!

I have seen you both write things like this:

```py
info = etav.VideoStreamInfo.from_json(...)
number_frames = info.stream_info["nb_frames"]
```

but you should be writing:

```py
info = etav.VideoStreamInfo.from_json(...)
number_frames = info.total_frame_count
```
