### PR TITLE
Call Serializable attributes

### DIFF
--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -293,7 +293,8 @@ class BaseDataRecord(etas.Serializable):
         Returns:
             the list of attributes to be serialized
         '''
-        return [a for a in vars(self) if a not in self.excluded()]
+        attr = super(BaseDataRecord, self).attributes()
+        return [a for a in attr if a not in self.excluded()]
 
     def clean_optional(self):
         '''Deletes any optional attributes from the data record that are not

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -290,6 +290,9 @@ class BaseDataRecord(etas.Serializable):
         '''Returns the list of attributes of the data record that are to be
         serialized, i.e., all attributes that are not in `excluded()`
 
+        Note that Serializable.attributes() is called to remove private
+        attributes (those starting with "_").
+
         Returns:
             the list of attributes to be serialized
         '''

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -288,10 +288,10 @@ class BaseDataRecord(etas.Serializable):
 
     def attributes(self):
         '''Returns the list of attributes of the data record that are to be
-        serialized, i.e., all attributes that are not in `excluded()`
+        serialized.
 
-        Note that Serializable.attributes() is called to remove private
-        attributes (those starting with "_").
+        All private attributes (those starting with "_") and attributes in
+        `excluded()` are omitted from this list.
 
         Returns:
             the list of attributes to be serialized


### PR DESCRIPTION
In Serializable private attributes are excluded.

Feel free to clean this up, but this fix allows MATE to work.

Here is Serializable's attributes defintion

```python
    def attributes(self):
        '''Returns a list of class attributes to be serialized.
        Subclasses can override this method, but, by default, all attributes
        in vars(self) are returned, minus private attributes (those starting
        with "_").
        In particular, subclasses may choose to override this method if they
        want their JSON files to be organized in a particular way.
        '''
        return [a for a in vars(self) if not a.startswith("_")]
```