### PR TITLE
fixing a string issue for py3 support in the get_stream_info function.

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -69,7 +69,7 @@ def has_gpu():
         # No GPU on mac
         return False
     try:
-        return b"NVIDIA" in communicate(["lspci"])[1]
+        return "NVIDIA" in communicate(["lspci"], decode=True)[1]
     except OSError:
         # couldn't find lspci command...
         return False

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -69,7 +69,7 @@ def has_gpu():
         # No GPU on mac
         return False
     try:
-        return "NVIDIA" in communicate(["lspci"])[1]
+        return b"NVIDIA" in communicate(["lspci"])[1]
     except OSError:
         # couldn't find lspci command...
         return False

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -202,7 +202,7 @@ def get_stream_info(inpath):
     out = ffprobe.run(inpath)
 
     try:
-        info = json.loads(out)
+        info = json.loads(out.decode('utf-8'))
 
         for stream in info["streams"]:
             if stream["codec_type"] == "video":

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -199,10 +199,10 @@ def get_stream_info(inpath):
         "-show_streams",             # get stream info
         "-print_format", "json",     # return in JSON format
     ])
-    out = ffprobe.run(inpath)
+    out = ffprobe.run(inpath, decode=True)
 
     try:
-        info = json.loads(out.decode('utf-8'))
+        info = json.loads(out)
 
         for stream in info["streams"]:
             if stream["codec_type"] == "video":
@@ -1007,7 +1007,7 @@ class FFprobe(object):
         '''
         return " ".join(self._args) if self._args else None
 
-    def run(self, inpath):
+    def run(self, inpath, decode=False):
         '''Run the ffprobe binary with the specified input path.
 
         Args:
@@ -1015,6 +1015,8 @@ class FFprobe(object):
 
         Returns:
             out: the stdout from the ffprobe binary
+            decode: whether to decode the output bytes into utf-8 strings. By
+                default, the raw bytes are returned
 
         Raises:
             ExecutableNotFoundError: if the ffprobe binary cannot be found
@@ -1044,7 +1046,7 @@ class FFprobe(object):
         if self._p.returncode != 0:
             raise etau.ExecutableRuntimeError(self.cmd, err)
 
-        return out
+        return out.decode() if decode else out
 
 
 class FFprobeError(Exception):

--- a/eta/modules/resize_videos.py
+++ b/eta/modules/resize_videos.py
@@ -150,7 +150,7 @@ def _process_video(input_path, output_path, parameters):
         if etav.is_same_video_format(input_path, output_path):
             logger.info(
                 "Same video format detected, so no computation is required. "
-                "Just sylimking '%s' to '%s'" % (output_path, input_path))
+                "Just symlinking '%s' to '%s'" % (output_path, input_path))
             etau.symlink_file(input_path, output_path)
             return
 

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -115,14 +115,12 @@ class ParametersConfig(Config):
 
 
 def _sample_videos(sample_config):
-    # if no fps is provided, then setting to 0 will maintain native fps
-    fps = sample_config.parameters.fps or 0
     for data in sample_config.data:
         _sample_video(data.input_path, data.output_path, fps)
 
 
 def _sample_video(input_path, output_path, fps):
-    if fps > 0:
+    if fps is not None and fps > 0:
         logger.info(
             "Sampling video %s at %s fps", input_path, fps)
     else:

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -115,7 +115,8 @@ class ParametersConfig(Config):
 
 
 def _sample_videos(sample_config):
-    fps = sample_config.parameters.fps
+    # if no fps is provided, then setting to 0 will maintain native fps
+    fps = sample_config.parameters.fps or 0
     for data in sample_config.data:
         _sample_video(data.input_path, data.output_path, fps)
 

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -131,7 +131,7 @@ def _sample_video(input_path, output_path, fps):
         if etav.is_same_video_format(input_path, output_path):
             logger.info(
                 "Same video format detected, so no computation is required. "
-                "Just sylimking %s to %s" % (output_path, input_path))
+                "Just symlinking %s to %s" % (output_path, input_path))
             etau.symlink_file(input_path, output_path)
             return
 

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -115,12 +115,13 @@ class ParametersConfig(Config):
 
 
 def _sample_videos(sample_config):
+    fps = sample_config.parameters.fps or -1  # -1 uses default fps
     for data in sample_config.data:
         _sample_video(data.input_path, data.output_path, fps)
 
 
 def _sample_video(input_path, output_path, fps):
-    if fps is not None and fps > 0:
+    if fps > 0:
         logger.info(
             "Sampling video %s at %s fps", input_path, fps)
     else:


### PR DESCRIPTION
This fix is necessary to use the `get_stream_info` function on Python3.  Confirmed to still work in Python2.