### PR TITLE
Adding DataFileSequence class and related utilities

### DIFF
--- a/eta/constants.py
+++ b/eta/constants.py
@@ -27,6 +27,7 @@ import os
 # Directories
 ETA_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.dirname(ETA_DIR)
+EXAMPLES_DIR = os.path.join(BASE_DIR, 'examples')
 
 
 # Paths

--- a/eta/constants.py
+++ b/eta/constants.py
@@ -27,7 +27,7 @@ import os
 # Directories
 ETA_DIR = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = os.path.dirname(ETA_DIR)
-EXAMPLES_DIR = os.path.join(BASE_DIR, 'examples')
+EXAMPLES_DIR = os.path.join(BASE_DIR, "examples")
 
 
 # Paths

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -163,12 +163,12 @@ class DataFileSequence(etas.Serializable):
 
     @classmethod
     def from_dict(cls, d):
-        return DataFileSequence(d['sequence'])
+        return cls(d["sequence"])
 
 
 class DataFileSequenceError(Exception):
     '''Error raised for out of bounds requests when working with
-    `DataFileSequence`s
+    `DataFileSequence`s.
     '''
     pass
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -503,33 +503,33 @@ def parse_dir_pattern(dir_path):
 
 
 def parse_bounds_from_dir_pattern(dir_pattern):
-    '''Inspects the files satisfying the dir_pattern and returns the minimum
-    and maximum usable values for indices satisfying that pattern.
+    '''Inspects the files satisfying the given pattern and returns the minimum
+    and maximum usable indices satisfying it.
 
     Args:
-        dir_pattern: string for the dir pattern, e.g., '/foo/%05d.json'
+        dir_pattern: string for the dir pattern, e.g., "/foo/%05d.json"
 
     Returns:
         a tuple containing:
-            - The first permissible value (usually 0 or 1).
-            - The last permissible value ("n" not "n+1")
+            - The first permissible value (usually 0 or 1)
+            - The last permissible value (inclusive)
     '''
     def _extract_num(s, prefix):
         '''Extract the numeric value in a string when we know the preceding
         string.
         '''
-        return int(re.match('[0-9]+', s[len(prefix):]).group(0))
+        return int(re.match("[0-9]+", s[len(prefix):]).group(0))
 
     pieces = re.split("(%[0-9]*d)", dir_pattern)
-    if len(pieces) is not 3:
+    if len(pieces) != 3:
         raise ValueError(
-            'dir_pattern should have one integer term specifying the range.')
+            "dir_pattern should have one integer term specifying the range.")
 
-    if re.match('%0+', pieces[1]) is None:
+    if re.match("%0+", pieces[1]) is None:
         # No leading zero here
-        wild = '*'
+        wild = "*"
     else:
-        wild = '[0-9]'*int(re.search('[0-9]+', pieces[1]).group(0))
+        wild = "[0-9]" * int(re.search("[0-9]+", pieces[1]).group(0))
 
     glob_expression = pieces[0] + wild + pieces[2]
 
@@ -538,9 +538,10 @@ def parse_bounds_from_dir_pattern(dir_pattern):
     # general case.
     globbed = sorted(glob.glob(glob_expression))
 
-
-    return (_extract_num(globbed[0], pieces[0]),
-        _extract_num(globbed[-1], pieces[0]))
+    return (
+        _extract_num(globbed[0], pieces[0]),
+        _extract_num(globbed[-1], pieces[0])
+    )
 
 
 def random_key(n):

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -502,6 +502,47 @@ def parse_dir_pattern(dir_path):
     return patt, indices
 
 
+def parse_bounds_from_dir_pattern(dir_pattern):
+    '''Inspects the files satisfying the dir_pattern and returns the minimum
+    and maximum usable values for indices satisfying that pattern.
+
+    Args:
+        dir_pattern: string for the dir pattern, e.g., '/foo/%05d.json'
+
+    Returns:
+        a tuple containing:
+            - The first permissible value (usually 0 or 1).
+            - The last permissible value ("n" not "n+1")
+    '''
+    def _extract_num(s, prefix):
+        '''Extract the numeric value in a string when we know the preceding
+        string.
+        '''
+        return int(re.match('[0-9]+', s[len(prefix):]).group(0))
+
+    pieces = re.split("(%[0-9]*d)", dir_pattern)
+    if len(pieces) is not 3:
+        raise ValueError(
+            'dir_pattern should have one integer term specifying the range.')
+
+    if re.match('%0+', pieces[1]) is None:
+        # No leading zero here
+        wild = '*'
+    else:
+        wild = '[0-9]'*int(re.search('[0-9]+', pieces[1]).group(0))
+
+    glob_expression = pieces[0] + wild + pieces[2]
+
+    # This glob is a bad idea if the directory is enormous, but the alternative
+    # requires linearly scanning the entire directory, which is bad for the
+    # general case.
+    globbed = sorted(glob.glob(glob_expression))
+
+
+    return (_extract_num(globbed[0], pieces[0]),
+        _extract_num(globbed[-1], pieces[0]))
+
+
 def random_key(n):
     '''Generates an n-lenth random key of lowercase characters and digits.'''
     return "".join(


### PR DESCRIPTION
For some work I was doing, I needed an object to marry with the many new `eta.core.types.*Sequence*`.  Their use so far as been through individualized code varying per use.  This class unifies it a bit more and adds error checking to the code.

- Add `DataFileSequence`
- Add utility function `parse_bounds_from_dir_pattern`
- Added `EXAMPLES_DIR` to `eta.constants`.