### PR TITLE
Making the new DataFileSequence handle both immutable and mutable 

### DIFF
--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -140,12 +140,19 @@ class DataFileSequence(etas.Serializable):
         self._immutable_bounds = immutable_bounds
         self._iter_index = None
 
+    def __getitem__(self, index):
+        '''Implements the get item interface to allow arbitrary access to the
+        paths in the sequence.
+        '''
+        return self.gen_path(index)
+
     def __iter__(self):
         '''Implements the iterable interface on the sequence of path names.'''
         self._iter_index = self._lower_bound - 1
         return self
 
     def __next__(self):
+        '''Implements the rest of the iterable interface.'''
         if self._iter_index is None:
             raise DataFileSequenceError("next called from outside iterable.")
 

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -241,6 +241,22 @@ class DataFileSequence(etas.Serializable):
     def from_dict(cls, d):
         return cls(d["sequence"])
 
+    @classmethod
+    def build_from_dir(cls, dir_path):
+        '''Factory method to build a `DataFileSequence` given a directory
+        path.
+        '''
+        file_pattern, _ = etau.parse_dir_pattern(dir_path)
+        return cls(file_pattern)
+
+    @classmethod
+    def build_from_pattern(cls, pattern):
+        '''Factory method to build a `DataFileSequence given a file pattern.
+
+        Note that this is just the standard way of constructing the class.
+        '''
+        return cls(pattern)
+
 
 class DataFileSequenceError(Exception):
     '''Error raised for out of bounds requests when working with

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -107,7 +107,7 @@ class DataFileSequence(etas.Serializable):
     default, where bounds mean the lowest and highest indices usable.
     Immutable bounds means that the class will provide error checking on the
     sequence indices based on their bounds at the time the instance was
-    initialized.  This files themselves during this time can be changed (this
+    initialized.  The files themselves during this time can be changed (this
     class does not enforce immutability on them).  If the instance is created
     with `immutable_bounds=False` then the user of the class will be able to
     add files to the end of the sequence in order, but not at random.

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -22,7 +22,6 @@ from builtins import *
 import os
 
 from eta.core.config import no_default
-import eta.constants as etac
 import eta.core.serial as etas
 import eta.core.utils as etau
 
@@ -210,7 +209,8 @@ class DataFileSequence(etas.Serializable):
         '''
         if self._immutable_bounds:
             if not self.check_bounds(index):
-                raise DataFileSequenceError("Index out of bounds for sequence.")
+                raise DataFileSequenceError(
+                    "Index out of bounds for sequence.")
         else:
             # In the mutable bounds case, enforce the behavior that the user
             # can add a file to the beginning or the end of the sequence.
@@ -276,8 +276,10 @@ class DataRecords(DataContainer):
             raise DataRecordsError(
                 "Need record_cls to add a DataRecords object")
 
-        dr = DataRecords(self._ELE_CLS,
-            records=[rc.from_dict(dc) for dc in d["records"]])
+        dr = DataRecords(
+            self._ELE_CLS,
+            records=[rc.from_dict(dc) for dc in d["records"]]
+        )
         self.records += dr.records
 
         return len(self.records)
@@ -326,7 +328,7 @@ class DataRecords(DataContainer):
 
         return sss
 
-    def cull(self, field, values, keep_values = False):
+    def cull(self, field, values, keep_values=False):
         ''' Cull records from our store based on the value in `field`.  If
         `keep_values` is True then the list `values` specifies which records to
         keep; otherwise, it specifies which records to remove (the default).

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -139,6 +139,25 @@ class DataFileSequence(etas.Serializable):
         self._lower_bound, self._upper_bound = \
             etau.parse_bounds_from_dir_pattern(self.sequence)
         self._immutable_bounds = immutable_bounds
+        self._iter_index = None
+
+    def __iter__(self):
+        '''Implements the iterable interface on the sequence of path names.'''
+        self._iter_index = self._lower_bound - 1
+        return self
+
+    def __next__(self):
+        if self._iter_index is None:
+            raise DataFileSequenceError("next called from outside iterable.")
+
+        self._iter_index += 1
+        if not self.check_bounds(self._iter_index):
+            self._iter_index = None
+            raise StopIteration
+
+        return self.gen_path(self._iter_index)
+
+    next = __next__  # Python 2 compatibility for iteration
 
     @property
     def extension(self):

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -104,7 +104,7 @@ class DataFileSequence(etas.Serializable):
 
     Implements various `eta.core.types.*Sequence*`.
 
-    This class has the ability to be have immutable bounds, which is the
+    This class has the ability to have immutable bounds, which is the
     default, where bounds mean the lowest and highest indices usable.
     Immutable bounds means that the class will provide error checking on the
     sequence indices based on their bounds at the time the instance was

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -472,7 +472,7 @@ def parse_dir_pattern(dir_path):
 
     Returns:
         a tuple containing:
-            - the numeric pattern used in the directory
+            - the numeric pattern used in the directory (the full path)
             - a list (or list of tuples if the pattern contains multiple
                 numbers) describing the numeric indices in the directory
 


### PR DESCRIPTION
Extended the DataFileSequence implementation to allow for it to be used when making new sequences as well, but not change the default behavior.  

Fully unit-tested.