### PR TITLE
Full support for publishing pipeline outputs

### DIFF
--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -263,14 +263,14 @@ class PipelineBuilder(object):
         for oname, opath in iteritems(self.outputs):
             ppath = self.pipeline_outputs[oname]
             if os.path.isfile(ppath):
-                # Output is a file, so copy it
-                etau.copy_file(ppath, opath)
+                # Output is a file
+                etau.copy_file(ppath, opath, check_ext=True)
             elif os.path.isdir(ppath):
-                # Output is a directory, so copy it
+                # Output is a directory
                 etau.copy_dir(ppath, opath)
             else:
-                # Output must be a sequence, so copy the base directory
-                etau.copy_dir(os.path.dirname(ppath), os.path.dirname(opath))
+                # Assume the output is a sequence
+                etau.copy_sequence(ppath, opath, check_ext=True)
 
         return True
 

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -721,6 +721,18 @@ class PipelineMetadata(Configurable, HasBlockDiagram):
         node_str = PipelineNode.get_input_str(name)
         return _get_sinks_with_source(node_str, self.connections)
 
+    def get_output_source(self, name):
+        '''Gets the source for the given output.
+
+        Args:
+            name: the pipeline output name
+
+        Returns:
+            the PipelineNode instance that the output is connected to
+        '''
+        node_str = PipelineNode.get_output_str(name)
+        return _get_sources_with_sink(node_str, self.connections)[0]
+
     def get_outgoing_connections(self, module):
         '''Gets the outgoing connections for the given module.
 

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -88,6 +88,7 @@ class ConcreteDataParams(object):
 
     def __init__(self):
         self._params = {
+            "name": None,
             "idx": eta.config.default_sequence_idx,
             "image_ext": eta.config.default_image_ext,
             "video_ext": eta.config.default_video_ext,
@@ -102,14 +103,27 @@ class ConcreteDataParams(object):
         '''
         return self._params
 
-    def render_for(self, name):
+    def render_for(self, name, hint=None):
         '''Render the type parameters for use with field `name`.
+
+        Args:
+            name: the field name
+            hint: an optional path hint from which to infer custom parameter
+                values (e.g. sequence indices or image/video extensions)
 
         Returns:
             a params dict
         '''
         params = self._params.copy()
         params["name"] = name
+        if hint:
+            hint_idx = etau.parse_sequence_idx_from_pattern(hint)
+            if hint_idx:
+                params["idx"] = hint_idx
+            if etai.is_supported_image(hint):
+                params["image_ext"] = os.path.splitext(hint)[1]
+            if etav.is_supported_video_file(hint):
+                params["video_ext"] = os.path.splitext(hint)[1]
         return params
 
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -602,6 +602,8 @@ def parse_pattern(patt):
     '''Inspects the files matching the given pattern and returns the numeric
     indicies of the sequence.
 
+    @todo handle whitespace patterns like "%5d"?
+
     Args:
         patt: a pattern with a one or more numeric sequences like
             "/path/to/frame-%05d.jpg" or `/path/to/clips/%02d-%d.mp4`

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -245,30 +245,72 @@ def call(args):
     return subprocess.call(args) == 0
 
 
-def copy_file(inpath, outpath):
-    '''Copies the input file to the output location, which can be a filepath or
-    a directory in which to write the file. The base output directory is
-    created if necessary, and any existing file will be overwritten.
+def copy_file(inpath, outpath, check_ext=False):
+    '''Copies the input file to the output location.
+
+    The output location can be a filepath or a directory in which to write the
+    file. The base output directory is created if necessary, and any existing
+    file will be overwritten.
+
+    Args:
+        inpath: the input path
+        outpath: the output location (file or directory)
+        check_ext: whether to check if the extensions of the input and output
+            paths match. Only applicable if the output path is not a directory
+
+    Raises:
+        OSError: if check_ext is True and the input and output paths have
+            different extensions
     '''
+    if not os.path.isdir(outpath) and check_ext:
+        assert_same_extensions(inpath, outpath)
     ensure_basedir(outpath)
     shutil.copy(inpath, outpath)
 
 
-def symlink_file(filepath, linkpath):
+def symlink_file(filepath, linkpath, check_ext=False):
     '''Creates a symlink at the given location that points to the given file.
+
     The base output directory is created if necessary, and any existing file
     will be overwritten.
+
+    Args:
+        filepath: a file or directory
+        linkpath: the desired symlink path
+        check_ext: whether to check if the extensions (or lack thereof, for
+            directories) of the input and output paths match
+
+    Raises:
+        OSError: if check_ext is True and the input and output paths have
+            different extensions
     '''
+    if check_ext:
+        assert_same_extensions(filepath, linkpath)
     ensure_basedir(linkpath)
     if os.path.exists(linkpath):
         os.remove(linkpath)
     os.symlink(os.path.realpath(filepath), linkpath)
 
 
-def move_file(inpath, outpath):
-    '''Copies the input file to the output location, creating the base output
-    directory if necessary.
+def move_file(inpath, outpath, check_ext=False):
+    '''Copies the input file to the output location.
+
+    The output location can be a filepath or a directory in which to move the
+    file. The base output directory is created if necessary, and any existing
+    file will be overwritten.
+
+    Args:
+        inpath: the input path
+        outpath: the output location (file or directory)
+        check_ext: whether to check if the extensions of the input and output
+            paths match. Only applicable if the output path is not a directory
+
+    Raises:
+        OSError: if check_ext is True and the input and output paths have
+            different extensions
     '''
+    if not os.path.isdir(outpath) and check_ext:
+        assert_same_extensions(inpath, outpath)
     ensure_basedir(outpath)
     shutil.move(inpath, outpath)
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -479,9 +479,38 @@ def has_extension(filename, *args):
     Args:
         filename: a file name
         *args: extensions like ".txt" or ".json"
+
+    Returns:
+        True/False
     '''
     ext = os.path.splitext(filename)[1]
     return any(ext == a for a in args)
+
+
+def have_same_extesions(*args):
+    '''Determines whether all of the input paths have the same extension.
+
+    Args:
+        *args: filepaths
+
+    Returns:
+        True/False
+    '''
+    exts = [os.path.splitext(path)[1] for path in args]
+    return exts[1:] == exts[:-1]
+
+
+def assert_same_extensions(*args):
+    '''Asserts that all of the input paths have the same extension.
+
+    Args:
+        *args: filepaths
+
+    Raises:
+        OSError: if all input paths did not have the same extension
+    '''
+    if not have_same_extesions(*args):
+        raise OSError("Expected %s to have the same extensions" % str(args))
 
 
 def to_human_bytes_str(num_bytes):

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -602,8 +602,6 @@ def parse_pattern(patt):
     '''Inspects the files matching the given pattern and returns the numeric
     indicies of the sequence.
 
-    @todo handle whitespace patterns like "%5d"?
-
     Args:
         patt: a pattern with a one or more numeric sequences like
             "/path/to/frame-%05d.jpg" or `/path/to/clips/%02d-%d.mp4`
@@ -624,13 +622,15 @@ def parse_pattern(patt):
 
     def _make_regex(m):
         seq = m.group()
-        if seq.startswith("%0"):
-            return "(\\d{%d})" % int(seq[2:-1])     # zero-padded digits
-        return "((?<!0)[1-9]\\d*|0)"                # tight digits
+        if re.match(r"%0", seq):
+            return "(\\d{%d})" % int(seq[2:-1])         # zero-padding
+        if re.match(r"%\d+", seq):
+            # @todo improve this regex
+            return "([\\d\\s]{%d})" % int(seq[1:-1])    # whitespace-padding
+        return "((?<!0)[1-9]\\d*|0)"                    # tight
 
     # Build exact regex
     full_exp, num_inds = re.subn(seq_exp, _make_regex, patt)
-    full_exp = re.compile("^" + full_exp + "$")
 
     def _parse_matches():
         for f in files:

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -315,6 +315,73 @@ def move_file(inpath, outpath, check_ext=False):
     shutil.move(inpath, outpath)
 
 
+def copy_sequence(inpatt, outpatt, check_ext=False):
+    '''Copies the input sequence to the output sequence.
+
+    The base output directory is created if necessary, and any existing files
+    will be overwritten.
+
+    Args:
+        inpatt: the input sequence
+        outpatt: the output sequence
+        check_ext: whether to check if the extensions of the input and output
+            sequences match
+
+    Raises:
+        OSError: if check_ext is True and the input and output sequences have
+            different extensions
+    '''
+    if check_ext:
+        assert_same_extensions(inpatt, outpatt)
+    for idx in parse_pattern(inpatt):
+        copy_file(inpatt % idx, outpatt % idx)
+
+
+def symlink_sequence(inpatt, outpatt, check_ext=False):
+    '''Creates symlinks at the given locations that point to the given
+    sequence.
+
+    The base output directory is created if necessary, and any existing files
+    will be overwritten.
+
+    Args:
+        inpatt: the input sequence
+        outpatt: the output sequence
+        check_ext: whether to check if the extensions of the input and output
+            sequences match
+
+    Raises:
+        OSError: if check_ext is True and the input and output sequences have
+            different extensions
+    '''
+    if check_ext:
+        assert_same_extensions(inpatt, outpatt)
+    for idx in parse_pattern(inpatt):
+        symlink_file(inpatt % idx, outpatt % idx)
+
+
+def move_sequence(inpatt, outpatt, check_ext=False):
+    '''Moves the input sequence to the output sequence.
+
+    The base output directory is created if necessary, and any existing files
+    will be overwritten.
+
+    Args:
+        inpatt: the input sequence
+        outpatt: the output sequence
+        check_ext: whether to check if the extensions of the input and output
+            sequences match
+
+    Raises:
+        OSError: if check_ext is True and the input and output sequences have
+            different extensions
+    '''
+    if check_ext:
+        assert_same_extensions(inpatt, outpatt)
+    for idx in parse_pattern(inpatt):
+        move_file(inpatt % idx, outpatt % idx)
+
+
 def copy_dir(indir, outdir):
     '''Copies the input directory to the output directory. The base output
     directory is created if necessary, and any existing output directory will


### PR DESCRIPTION
Full support for including an `outputs` dictionary in a pipeline request. The outputs specified in this dictionary will be copied to the specified locations, and their file types, sequence patterns, etc. will be inherited by the pipeline.

Miscellaneous utilities included to support this functionality:
- Fully-functional `eta.core.utils.parse_pattern` function for parsing indices matching file sequences with arbitrary numbers of arbitrarily formatted int "sprintf" patterns
- Adding optional extension checking to `eta.core.utils` file moving utilities
- Utilities for copying/moving/symlinking file sequences