### PR TITLE
Pipeline optimization during building

### DIFF
--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -343,8 +343,7 @@ class PipelineBuilder(object):
         self._build_module_configs()
 
     def run(self):
-        '''Runs the built pipeline and publishes any outputs to their
-        specified locations.
+        '''Runs the built pipeline.
 
         Returns:
             True/False whether the pipeline completed successfully
@@ -357,24 +356,7 @@ class PipelineBuilder(object):
                 "You must build the pipeline before running it")
 
         # Run pipeline
-        success = etap.run(self.pipeline_config_path)
-        if not success:
-            return False
-
-        # Publish outputs
-        for oname, opath in iteritems(self.outputs):
-            ppath = self.pipeline_outputs[oname]
-            if os.path.isfile(ppath):
-                # Output is a file
-                etau.copy_file(ppath, opath, check_ext=True)
-            elif os.path.isdir(ppath):
-                # Output is a directory
-                etau.copy_dir(ppath, opath)
-            else:
-                # Assume the output is a sequence
-                etau.copy_sequence(ppath, opath, check_ext=True)
-
-        return True
+        return etap.run(self.pipeline_config_path)
 
     def cleanup(self):
         '''Cleans up the configs and output files generated when the pipeline

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -140,7 +140,9 @@ class PipelineBuildRequest(Configurable):
         - a pipeline of the specified name exists
         - all required pipeline inputs are provided and have valid values
         - any output paths specified must refer to valid pipeline output names
-            and the specified paths must be valid paths for each output type
+            and the specified paths must be either (a) valid paths for the
+            associated types, or (b) None, in which case their paths will be
+            automatically populated when the pipeline is built
         - all required pipeline parameters are provided and have valid values
 
     Note that any fields set to `None` are ignored, so any inputs/parameters
@@ -172,7 +174,7 @@ class PipelineBuildRequest(Configurable):
         self.pipeline = config.pipeline
         self.metadata = etap.load_metadata(config.pipeline)
         self.inputs = etau.remove_none_values(config.inputs)
-        self.outputs = etau.remove_none_values(config.outputs)
+        self.outputs = config.outputs
         self.parameters = etau.remove_none_values(config.parameters)
         self.eta_config = config.eta_config
         self.logging_config = config.logging_config
@@ -206,8 +208,10 @@ class PipelineBuildRequest(Configurable):
         for oname, opath in iteritems(self.outputs):
             if not self.metadata.has_output(oname):
                 raise PipelineBuildRequestError(
-                    "Pipeline '%s' has no output '%s'" % (
-                        self.pipeline, oname))
+                    "Pipeline '%s' has no output '%s'" %
+                    (self.pipeline, oname))
+            if not opath:
+                continue
             if not self.metadata.is_valid_output(oname, opath):
                 raise PipelineBuildRequestError(
                     "'%s' is not a valid value for output '%s' of pipeline "

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -457,32 +457,33 @@ class PipelineBuilder(object):
                     active_inputs[conn.sink.module].add(conn.sink.node)
 
         # Delete inactive inputs
-        for module in self.module_inputs:
-            if module not in active_modules:
-                del self.module_inputs[module]
+        self.module_inputs = {
+            m: i for m, i in iteritems(self.module_inputs)
+            if m in active_modules
+        }
 
         # Delete inactive outputs
-        for module, outputs in self.module_outputs:
-            if module not in active_modules:
-                del self.module_outputs[module]
-            else:
-                mmeta = pmeta.modules[module].metadata
-                for oname in outputs:
-                    if oname not in active_outputs[modle]:
-                        if not mmeta.get_output(oname).is_required:
-                            del self.module_outputs[module][oname]
+        self.module_outputs = {
+            m: o for m, o in iteritems(self.module_outputs)
+            if m in active_modules
+        }
+        for module, outputs in iteritems(self.module_outputs):
+            mmeta = pmeta.modules[module].metadata
+            mactive = active_outputs[module]
+            self.module_outputs[module] = {
+                n: p for n, p in iteritems(outputs)
+                if n in mactive or mmeta.get_output(n).is_required
+            }
 
         # Delete inactive parameters
-        self.module_params = {
-            module: params for module, params in iteritems(self.module_params)
-            if module in active_modules
+        self.module_parameters = {
+            m: p for m, p in iteritems(self.module_parameters)
+            if m in active_modules
         }
 
         # Update execution order
         self.execution_order = [
-            module for module in self.execution_order
-            if module in active_modules
-        ]
+            m for m in self.execution_order if m in active_modules]
 
     def _build_pipeline_config(self):
         # Build job configs

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -509,7 +509,7 @@ class PipelineBuilder(object):
                 .validate())
 
         # Build pipeline config
-        pipeline_config_builder = (etap.PipelineConfig.builder()
+        pipeline_config = (etap.PipelineConfig.builder()
             .set(name=self.request.pipeline)
             .set(status_path=self.pipeline_status_path)
             .set(overwrite=False)
@@ -520,7 +520,7 @@ class PipelineBuilder(object):
 
         # Write pipeline config
         logger.info("Writing pipeline config '%s'", self.pipeline_config_path)
-        pipeline_config_builder.write_json(self.pipeline_config_path)
+        pipeline_config.write_json(self.pipeline_config_path)
 
     def _build_module_configs(self):
         for module in self.execution_order:

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -299,11 +299,11 @@ class PipelineBuilder(object):
         self.pipeline_config_path = None
         self.pipeline_status_path = None
         self.pipeline_logfile_path = None
+        self.execution_order = []
         self.module_inputs = defaultdict(dict)
         self.module_outputs = defaultdict(dict)
         self.module_parameters = defaultdict(dict)
         self.pipeline_outputs = {}
-        self.execution_order = []
 
     def build(self, optimized=True):
         '''Builds the pipeline and writes the associated config files.
@@ -428,12 +428,15 @@ class PipelineBuilder(object):
         # Populate module parameters
         for param in itervalues(pmeta.parameters):
             val = _get_param_value(param, self.request)
-            self.module_params[param.module][param.name] = val
+            if val:
+                self.module_parameters[param.module][param.name] = val
 
         # Set execution order
         self.execution_order = pmeta.execution_order
 
     def _optimize_pipeline(self):
+        logger.info("Optimizing pipeline")
+
         # Get PipelineMetadata
         pmeta = self.request.metadata
 
@@ -529,7 +532,7 @@ class PipelineBuilder(object):
                 self.module_inputs[module], self.module_outputs[module])
             module_config = (etam.GenericModuleConfig.builder()
                 .set(data=[data])
-                .set(parameters=self.module_params[module])
+                .set(parameters=self.module_parameters[module])
                 .validate())
 
             # Write module config

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -562,10 +562,9 @@ class PipelineBuilder(object):
     def _get_module_config_path(self, module):
         return os.path.join(self.config_dir, module + MODULE_CONFIG_EXT)
 
-    def _get_data_path(self, module, node, path_hints):
+    def _get_data_path(self, module, node):
         basedir = os.path.join(self.output_dir, module)
-        hint = _get_path_hint(module, node.name, path_hints)
-        params = self._concrete_data_params.render_for(node.name, hint=hint)
+        params = self._concrete_data_params.render_for(node.name)
         return node.type.gen_path(basedir, params)
 
 
@@ -574,18 +573,6 @@ class PipelineBuilderError(Exception):
     PipelineBuilder.
     '''
     pass
-
-
-def _get_path_hint(module, output, path_hints):
-    '''Gets a path hint for the given module output, if possible.
-
-    Args:
-        module: the module name
-        output: the module output name
-        path_hints: a dict mapping PipelineNode strings to paths
-    '''
-    node_str = etap.PipelineNode.get_node_str(module, output)
-    return path_hints.get(node_str, None)
 
 
 def _get_param_value(param, request):

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -457,33 +457,31 @@ class PipelineBuilder(object):
                     active_inputs[conn.sink.module].add(conn.sink.node)
 
         # Delete inactive inputs
-        self.module_inputs = {
-            m: i for m, i in iteritems(self.module_inputs)
-            if m in active_modules
-        }
+        for module in list(self.module_inputs.keys()):
+            if module not in active_modules:
+                del self.module_inputs[module]
 
         # Delete inactive outputs
-        self.module_outputs = {
-            m: o for m, o in iteritems(self.module_outputs)
-            if m in active_modules
-        }
-        for module, outputs in iteritems(self.module_outputs):
-            mmeta = pmeta.modules[module].metadata
-            mactive = active_outputs[module]
-            self.module_outputs[module] = {
-                n: p for n, p in iteritems(outputs)
-                if n in mactive or mmeta.get_output(n).is_required
-            }
+        for module in list(self.module_outputs.keys()):
+            if module not in active_modules:
+                del self.module_outputs[module]
+            else:
+                mmeta = pmeta.modules[module].metadata
+                for oname in list(self.module_outputs[module].keys()):
+                    if oname not in active_outputs[module]:
+                        if not mmeta.get_output(oname).is_required:
+                            del self.module_outputs[module][oname]
 
         # Delete inactive parameters
-        self.module_parameters = {
-            m: p for m, p in iteritems(self.module_parameters)
-            if m in active_modules
-        }
+        for module in list(self.module_parameters.keys()):
+            if module not in active_modules:
+                del self.module_parameters[module]
 
         # Update execution order
         self.execution_order = [
-            m for m in self.execution_order if m in active_modules]
+            module for module in self.execution_order
+            if module in active_modules
+        ]
 
     def _build_pipeline_config(self):
         # Build job configs

--- a/eta/core/command.py
+++ b/eta/core/command.py
@@ -67,15 +67,12 @@ class BuildCommand(Command):
         # Build pipeline from a PipelineBuildRequest JSON file
         eta build -r '/path/to/pipeline/request.json'
 
-        # Build pipeline from a PipelineBuildRequest dictionary
-        eta build -r '{...}'
-
         # Build a pipeline request interactively, run it, and cleanup after
         eta build \\
             -n video_formatter \\
-            -i '{"video": "examples/data/water.mp4"}' \\
-            -o '{"formatted_video": "out/water-small.mp4"}' \\
-            -p '{"format_videos.scale": 0.5}' \\
+            -i 'video="examples/data/water.mp4"' \\
+            -o 'formatted_video="water-small.mp4"' \\
+            -p 'format_videos.scale=0.5' \\
             --run-now --cleanup
     '''
 
@@ -87,16 +84,16 @@ class BuildCommand(Command):
         parser.add_argument("-n", "--name", help="pipeline name")
         parser.add_argument(
             "-i", "--inputs", type=etas.load_json,
-            metavar="'{\"key\": val, ...}'", help="pipeline inputs")
+            metavar="'key=val,...'", help="pipeline inputs")
         parser.add_argument(
             "-o", "--outputs", type=etas.load_json,
-            metavar="'{\"key\": val, ...}'", help="pipeline outputs")
+            metavar="'key=val,...'", help="pipeline outputs")
         parser.add_argument(
             "-p", "--parameters", type=etas.load_json,
-            metavar="'{\"key\": val, ...}'", help="pipeline parameters")
+            metavar="'key=val,...'", help="pipeline parameters")
         parser.add_argument(
             "-e", "--eta-config", type=etas.load_json,
-            metavar="'{\"key\": val, ...}'", help="ETA config settings")
+            metavar="'key=val,...'", help="ETA config settings")
         parser.add_argument(
             "-l", "--logging", type=etas.load_json,
             metavar="'{\"key\": val, ...}'", help="logging config settings")

--- a/eta/core/command.py
+++ b/eta/core/command.py
@@ -96,7 +96,10 @@ class BuildCommand(Command):
             metavar="'key=val,...'", help="ETA config settings")
         parser.add_argument(
             "-l", "--logging", type=etas.load_json,
-            metavar="'{\"key\": val, ...}'", help="logging config settings")
+            metavar="'key=val,...'", help="logging config settings")
+        parser.add_argument(
+            "-u", "--unoptimized", action="store_true",
+            help="don't optimize the pipeline when building")
         parser.add_argument(
             "--run-now", action="store_true",
             help="run the pipeline after building")
@@ -141,7 +144,8 @@ class BuildCommand(Command):
         # Build pipeline
         logger.info("Building pipeline '%s'", request.pipeline)
         builder = etab.PipelineBuilder(request)
-        builder.build()
+        optimized = not args.unoptimized
+        builder.build(optimized=optimized)
 
         if args.run_now:
             # Run pipeline

--- a/eta/core/command.py
+++ b/eta/core/command.py
@@ -184,16 +184,22 @@ class RunCommand(Command):
     @staticmethod
     def run(args):
         if args.config:
-            logger.info("Running ETA pipeline '%s'", args.config)
-            etap.run(args.config)
+            _run_pipeline(args.config)
 
         if args.last:
             config = etab.find_last_built_pipeline()
             if config:
-                logger.info("Running ETA pipeline '%s'", config)
-                etap.run(config)
+                _run_pipeline(args.config)
             else:
                 logger.info("No built pipelines found...")
+
+
+def _run_pipeline(config):
+    logger.info("Running ETA pipeline '%s'", config)
+    etap.run(config)
+
+    logger.info(
+        "\n***** To clean this pipeline *****\neta clean -c %s\n", config)
 
 
 class CleanCommand(Command):

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -736,6 +736,22 @@ class PipelineMetadata(Configurable, HasBlockDiagram):
         node_str = PipelineNode.get_output_str(name)
         return _get_sources_with_sink(node_str, self.connections)[0]
 
+    def get_incoming_connections(self, module):
+        '''Gets the incoming connections for the given module.
+
+        Args:
+            module: the module name
+
+        Returns:
+            a list of PipelineConnections describing the incoming connections
+                for the given module
+        '''
+        iconns = []
+        for c in self.connections:
+            if c.sink.module == module:
+                iconns.append(c)
+        return iconns
+
     def get_outgoing_connections(self, module):
         '''Gets the outgoing connections for the given module.
 

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -619,11 +619,6 @@ class PipelineConnection(object):
     def __str__(self):
         return "%s -> %s" % (self.source, self.sink)
 
-    @property
-    def is_module_connection(self):
-        '''Returns True/False if this connection is between module nodes.'''
-        return self.source.is_module_node and self.sink.is_module_node
-
 
 class PipelineMetadata(Configurable, HasBlockDiagram):
     '''Class the encapsulates the architecture of a pipeline.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -32,17 +32,40 @@ import eta.core.utils as etau
 
 
 def load_json(path_or_str):
-    '''Loads JSON from argument.
+    '''Loads JSON from the input argument.
+
+    The input argument can be any of the following:
+        (a) the path to a JSON file on disk
+        (b) a string that can be directly parsed via `json.loads`
+        (c) a string containing a comma-seperated list of key=val values
+            defining a JSON dictionary, where each value must be parsable via
+            `json.loads(val)`
 
     Args:
-        path_or_str: can either be the path to a JSON file or a JSON string
+        path_or_str: the JSON path or string any of the above supported formats
 
     Returns:
-        the JSON dictionary
+        the loaded JSON
+
+    Raises:
+        ValueError: if no JSON could be decoded
     '''
     if os.path.isfile(path_or_str):
+        # Read from disk
         return read_json(path_or_str)
-    return json.loads(path_or_str)
+    try:
+        # Parse from JSON string
+        return json.loads(path_or_str)
+    except ValueError:
+        try:
+            # Try to parse comma-seperated list of key=value pairs
+            d = {}
+            for chunk in path_or_str.split(","):
+                key, value = chunk.split("=")
+                d[key] = json.loads(value)
+            return d
+        except ValueError:
+            raise ValueError("Unable to load JSON from '%s'" % path_or_str)
 
 
 def read_json(path):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -46,7 +46,17 @@ def load_json(path_or_str):
 
 
 def read_json(path):
-    '''Reads JSON from file.'''
+    '''Reads JSON from file.
+
+    Args:
+        path: the path to the JSON file
+
+    Returns:
+        a dict or list containing the loaded JSON
+
+    Raises:
+        ValueError: if the JSON file was invalid
+    '''
     try:
         with open(path, "rt") as f:
             return json.load(f)

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -539,6 +539,18 @@ def _to_human_binary_str(num, suffix):
     return "%3.1f %s%s" % (num, unit, suffix)
 
 
+def make_tar(dir_path, tar_path):
+    '''Makes a .tar.gz file containing the given directory.
+
+    Args:
+        dir_path: the directory to tar
+        tar_path: the path + filename of the .tar.gz file to create
+    '''
+    outpath = re.sub(r"\.tar\.gz$", "", tar_path)
+    rootdir, basedir = os.path.split(os.path.realpath(dir_path))
+    shutil.make_archive(outpath, "gztar", rootdir, basedir)
+
+
 def extract_tar(inpath, outdir=None, delete_tar=False):
     '''Extracts the contents of a .tar, tar.gz, .tgz, .tar.bz, or .tbz file.
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -580,6 +580,18 @@ def extract_tar(inpath, outdir=None, delete_tar=False):
         delete_file(inpath)
 
 
+def make_zip(dir_path, zip_path):
+    '''Makes a .zip file containing the given directory.
+
+    Args:
+        dir_path: the directory to zip
+        zip_path: the path + filename of the .zip file to create
+    '''
+    outpath = os.path.splitext(zip_path)[0]
+    rootdir, basedir = os.path.split(os.path.realpath(dir_path))
+    shutil.make_archive(outpath, "zip", rootdir, basedir)
+
+
 def extract_zip(inpath, outdir=None, delete_zip=False):
     '''Extracts the contents of a .zip file.
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -219,13 +219,13 @@ def get_stream_info(inpath):
     Raises:
         FFprobeError: if no stream info was found
     '''
-    ffprobe = FFprobe(opts=[
-        "-show_streams",             # get stream info
-        "-print_format", "json",     # return in JSON format
-    ])
-    out = ffprobe.run(inpath, decode=True)
-
     try:
+        ffprobe = FFprobe(opts=[
+            "-show_streams",             # get stream info
+            "-print_format", "json",     # return in JSON format
+        ])
+        out = ffprobe.run(inpath, decode=True)
+
         info = json.loads(out)
 
         for stream in info["streams"]:
@@ -236,7 +236,7 @@ def get_stream_info(inpath):
             "No stream found with codec_type = video. Returning the first "
             "stream")
         return info["streams"][0]  # default to the first stream
-    except Exception:
+    except:
         raise FFprobeError("Unable to get stream info for '%s'" % inpath)
 
 

--- a/eta/core/ziputils.py
+++ b/eta/core/ziputils.py
@@ -40,7 +40,7 @@ def make_zip(zip_path):
     Args:
         zip_path: the output zip file path
     '''
-    outpath = zip_path.replace(".zip", "")
+    outpath = os.path.splitext(zip_path)[0]
     rootdir, basedir = os.path.split(outpath)
     shutil.make_archive(outpath, "zip", rootdir, basedir)
 
@@ -91,7 +91,7 @@ def make_parallel_dirs(zip_path, ref_paths):
             directories
         ref_paths: a list of reference paths, which may be files or directories
     '''
-    base = zip_path.replace(".zip", "")
+    base = os.path.splitext(zip_path)[0]
     return [os.path.join(base, _get_basename_no_ext(p)) for p in ref_paths]
 
 
@@ -110,7 +110,7 @@ def make_parallel_files(zip_path, ref_files):
         zip_path: the zip file path for which to generate the parallel files
         ref_files: a list of reference filepaths
     '''
-    base = zip_path.replace(".zip", "")
+    base = os.path.splitext(zip_path)[0]
     return [os.path.join(base, _get_basename(p)) for p in ref_files]
 
 


### PR DESCRIPTION
tl;dr specify the outputs you want in your pipeline build requests, and the builder will now automatically omit any unnecessary computations!

Currently, all pipeline outputs are assumed to be required and are always computed when a pipeline is built. Recently support was added for an `outputs` field in `PipelineBuildRequest`s to specify where to write a subset of the pipeline outputs. This PR completes extends this feature by adding the notion of "pipeline optimization" to `PipelineBuilder`. Now when a pipeline is built, the builder will (optionally, but by default this now happens) inspect the module graph and omit any unnecessary modules and avoid writing unnecessary data files to disk.

In principle, we could now combine all of our analytics into one gigantic pipeline with outputs for each possible analytic, and the builder could automatically compute a minimal path through the pipeline to generate the requested output(s)!