### PR TITLE
Collection of small upgrades to ETA

### DIFF
--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -267,7 +267,7 @@ class PipelineBuilder(object):
         execution_order: a list of modules defining the order the pipeline
             modules will be executed
         module_inputs: a dictionary mapping module names to dictionaries
-            of module input names and their associated paths.
+            of module input names and their associated paths
         module_outputs: a dictionary mapping module names to dictionaries
             of module output names and their associated paths in `output_dir`
         module_parameters: a dictionary mapping modules names to dictionaries

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -125,7 +125,6 @@ def _run(
                 overwrite = True
 
             # Run job
-            pipeline_status.add_message("Job %s started" % job_config.name)
             job_config.pipeline_config_path = pipeline_config_path
             ran_last_job, success = etaj.run(
                 job_config, pipeline_status, overwrite=overwrite)

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -99,8 +99,6 @@ def write_json(obj, path, pretty_print=True):
             to be human readable; when False, it will be compact with no
             extra spaces or newline characters
     '''
-    if is_serializable(obj):
-        obj = obj.serialize()
     s = json_to_str(obj, pretty_print=pretty_print)
 
     etau.ensure_basedir(path)

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -170,23 +170,49 @@ class Serializable(object):
     def __str__(self):
         return self.to_str()
 
-    def attributes(self, dynamic=False, private=False):
+    def attributes(self):
         '''Returns a list of class attributes to be serialized.
+
+        This method is called internally by `serialize()` to determine the
+        class attributes to serialize.
+
+        Subclasses can override this method, but, by default, all attributes in
+        vars(self) are returned, minus private attributes, i.e., those starting
+        with "_". The order of the attributes in this list is preserved when
+        serializing objects, so a common pattern is for subclasses to override
+        this method if they want their JSON files to be organized in a
+        particular way.
+
+        Returns:
+            a list of class attributes to be serialized
+        '''
+        return [a for a in vars(self) if not a.startswith("_")]
+
+    def custom_attributes(self, dynamic=False, private=False):
+        '''Returns a customizable list of class attributes.
 
         By default, all attributes in vars(self) are returned, minus private
         attributes (those starting with "_").
 
-        The order of the attributes in this list is preserved when serializing
-        objects, so a common pattern is for subclasses to override this method
-        if they want their JSON files to be organized in a particular way.
+        Note that `attributes()`, not this method, is called by `serialize()`
+        when generating a list of attributes to serialize. To use this method
+        to set the attributes to serialize, use the `serialize(attributes=)`
+        syntax.
+
+        Args:
+            dynamic: whether to include dynamic properties, e.g., those defined
+                by getter/setter methods or the `@property` decorator. By
+                default, this is False
+            private: whether to include private properties, i.e., those
+                starting with "_". By default, this is False
+
+        Returns:
+            a list of class attributes
         '''
         if dynamic:
-            # Include dynamic properties
             attrs = [a for a in dir(self) if not callable(getattr(self, a))]
         else:
-            # Attributes only
             attrs = vars(self)
-
         if not private:
             attrs = [a for a in attrs if not a.startswith("_")]
         return attrs

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -163,7 +163,7 @@ class Picklable(object):
 class Serializable(object):
     '''Base class for objects that can be serialized.
 
-    Subclasses must implement from_dict(), which defines how to construct a
+    Subclasses must implement `from_dict()`, which defines how to construct a
     serializable object from a JSON dictionary.
     '''
 

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -161,8 +161,6 @@ class Serializable(object):
     '''
 
     def __str__(self):
-        '''Returns the string representation of this object as it would be
-        written to JSON.'''
         return self.to_str()
 
     def serialize(self, attributes=None):

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -252,6 +252,13 @@ class Data(Type):
         '''Returns True/False if `path` is a valid filepath for this type.'''
         raise NotImplementedError("subclass must implement is_valid_path()")
 
+    @staticmethod
+    def get_metadata(path):
+        '''Returns a dictionary containing metadata about the data at the
+        given path.
+        '''
+        raise NotImplementedError("subclass must implement get_metadata()")
+
 
 class ConcreteData(Data):
     '''The base type for concrete data types, which represent well-defined data
@@ -399,6 +406,14 @@ class Video(AbstractData):
             ImageSequence.is_valid_path(path)
         )
 
+    @staticmethod
+    def get_metadata(path):
+        if VideoFile.is_valid_path(path):
+            return VideoFile.get_metadata(path)
+        if ImageSequence.is_valid_path(path):
+            return ImageSequence.get_metadata(path)
+        raise TypeError("Unable to get metadata for '%s'" % path)
+
 
 class VideoFile(Video, File, ConcreteData):
     '''A video represented as a single encoded video file.
@@ -417,6 +432,10 @@ class VideoFile(Video, File, ConcreteData):
     @staticmethod
     def is_valid_path(path):
         return File.is_valid_path(path) and etav.is_supported_video_file(path)
+
+    @staticmethod
+    def get_metadata(path):
+        return etav.VideoStreamInfo.build_for(path).serialize(dynamic=True)
 
 
 class ImageSequence(Video, FileSequence, ConcreteData):

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -243,8 +243,9 @@ class ObjectArray(Array):
 class Data(Type):
     '''The base type for data, which are types that are stored on disk.
 
-    Data types must know how to validate whether a given path is valid path
-    for their type.
+    Data types must know how to:
+        (a) validate whether a given path is valid path for their type
+        (b) return metadata about an instance of data on disk
     '''
 
     @staticmethod

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -436,7 +436,7 @@ class VideoFile(Video, File, ConcreteData):
 
     @staticmethod
     def get_metadata(path):
-        return etav.VideoStreamInfo.build_for(path).serialize(dynamic=True)
+        return etav.VideoStreamInfo.build_for(path)
 
 
 class ImageSequence(Video, FileSequence, ConcreteData):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -181,6 +181,9 @@ class VideoStreamInfo(Serializable):
         '''
         return self.stream_info[key]
 
+    def attributes(self):
+        return self.custom_attributes(dynamic=True)
+
     @classmethod
     def build_for(cls, inpath):
         '''Builds a VideoStreamInfo object for the given video using


### PR DESCRIPTION
This PR adds a few small features:
- `eta.core.serial.Serializable.custom_attributes` method that supports a couple common patterns for generating attribute lists to serialize
- adding ability to optionally omit job-level status messages from `eta.core.status.PipelineStatus` when serializing. Some applications don't need this level of fine-grained logging
- adding interface to `eta.core.types.Data` for getting metadata about an instance of data