### PR TITLE
Fixed a devious bug in the validation of object attributes

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -799,7 +799,7 @@ class VideoLabelsSchema(Serializable):
             AttributeContainerSchemaError: if the object attribute violates
                 the schema
         '''
-        obj_schema = self.objects[obj.label]
+        obj_schema = self.objects[label]
         obj_schema.validate_attribute(obj_attr)
 
     def validate_object(self, obj):


### PR DESCRIPTION
This bug was causing the object attributes to not be outputted during serialization of the VideoLabelsSchema.

```
@@ -799,7 +799,7 @@ class VideoLabelsSchema(Serializable):
             AttributeContainerSchemaError: if the object attribute violates
                 the schema
         '''
-        obj_schema = self.objects[obj.label]
+        obj_schema = self.objects[label]
         obj_schema.validate_attribute(obj_attr)
 ```

It was particularly nasty because the code here is captured within a try-catch block from the caller and hence the lack of a `obj.label` available did not output any clear error.