### PR TITLE
(PR for discussion) Adds VideoSemanticData: entity-centric representation

### DIFF
--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -620,6 +620,20 @@ class SpatiotemporalEntityContainer(DataContainer):
         SpatiotemporalLike.validate(item)
         super(SpatiotemporalEntityContainer, self).add(item)
 
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs a SpatiotemporalEntityContainer from a JSON dictionary.
+
+        Overrides the default Container approach because this is a container of
+        with items whose commonality is only a mixin.  This class interprets
+        them correctly.
+        '''
+        container = SpatiotemporalEntityContainer()
+        for di in d[cls._ELE_ATTR]:
+            # Can use Serializable.from_dict here because of forced reflectivity
+            container.add(Serializable.from_dict(di))
+        return container
+
 
 class TemporalEntityContainer(DataContainer):
     '''A container for instances observing the TemporalLike contract.'''
@@ -642,6 +656,20 @@ class TemporalEntityContainer(DataContainer):
         '''Validate and add the item to the container.'''
         TemporalLike.validate(item)
         super(TemporalEntityContainer, self).add(item)
+
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs a TemporalEntityContainer from a JSON dictionary.
+
+        Overrides the default Container approach because this is a container of
+        with items whose commonality is only a mixin.  This class interprets
+        them correctly.
+        '''
+        container = TemporalEntityContainer()
+        for di in d[cls._ELE_ATTR]:
+            # Can use Serializable.from_dict here because of forced reflectivity
+            container.add(Serializable.from_dict(di))
+        return container
 
 
 class DataFileSequence(Serializable):

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 import os
 
 from eta.core.config import no_default
-from eta.core.serial import Container, Serializable
+from eta.core.serial import Container, Serializable, IsAMixinForSerializables
 import eta.core.utils as etau
 
 
@@ -550,6 +550,67 @@ class AttributeContainerSchema(Serializable):
 class AttributeContainerSchemaError(Exception):
     '''Error raised when an AttributeContainerSchema is violated.'''
     pass
+
+
+class TemporalLike(IsAMixinForSerializables):
+    '''A mixin to establish a contract for temporal entities that can be stored
+    in containers.
+
+    Note to developer: This is a mixin class that is itself not Serializable,
+    but it can only be implemented on a class that is Serializable.  Hence it
+    inherits frmo the `IsAMixinForSerializables` base.  Note that this is
+    explicitly implemented at this time.
+    '''
+
+    def exists_at_frame(frame_number):
+        # XXX
+        raise NotImplementedError("subclass must implement exists_at_frame")
+
+
+class SpatiotemporalLike(TemporalLike):
+    '''A mixin to establish a contract for temporal entities that can be stored
+    in containers.
+    '''
+
+    def overlaps_at_frame(frame_number, bounding_box):
+        # XXX
+        raise NotImplementedError("subclass must implement overlaps_at_frame")
+
+
+class SpatiotemporalEntityContainer(DataContainer):
+    '''A container for instances observing the SpatiotemporalLike contract.'''
+    # XXX maybe move this to data
+
+    _ELE_CLS = SpatiotemporalLike
+    _ELE_CLS_FIELD = "_SPATIOTEMPORALENTITY_CLS"
+    _ELE_ATTR = "entities"
+
+    def __init__(self, schema=None, **kwargs):
+        '''Creates a SpatiotemporalContainer instance.
+
+        Args:
+            **kwargs: valid keyword arguments for DataContainer()
+        '''
+        super(SpatiotemporalEntityContainer, self).__init__(**kwargs)
+        # XXX this constructor may not be needed
+
+
+class TemporalEntityContainer(DataContainer):
+    '''A container for instances observing the TemporalLike contract.'''
+    # XXX maybe move this to data
+
+    _ELE_CLS = TemporalLike
+    _ELE_CLS_FIELD = "_TEMPORALENTITY_CLS"
+    _ELE_ATTR = "entities"
+
+    def __init__(self, schema=None, **kwargs):
+        '''Creates a TemporalContainer instance.
+
+        Args:
+            **kwargs: valid keyword arguments for DataContainer()
+        '''
+        super(TemporalEntityContainer, self).__init__(**kwargs)
+        # XXX this constructor may not be needed
 
 
 class DataFileSequence(Serializable):

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -19,7 +19,6 @@ from builtins import *
 # pragma pylint: enable=wildcard-import
 
 from eta.core.data import DataContainer, AttributeContainer
-from eta.core.data import SpatiotemporalLike
 from eta.core.geometry import BoundingBox, HasBoundingBox
 from eta.core.serial import Serializable
 
@@ -116,7 +115,7 @@ class DetectedObject(Serializable, HasBoundingBox):
         )
 
 
-class DetectedObjectContainer(DataContainer, SpatiotemporalLike):
+class DetectedObjectContainer(DataContainer):
     '''Base class for containers that store lists of `DetectedObject`s.'''
 
     _ELE_CLS = DetectedObject

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -19,6 +19,7 @@ from builtins import *
 # pragma pylint: enable=wildcard-import
 
 from eta.core.data import DataContainer, AttributeContainer
+from eta.core.data import SpatiotemporalLike
 from eta.core.geometry import BoundingBox, HasBoundingBox
 from eta.core.serial import Serializable
 
@@ -115,7 +116,7 @@ class DetectedObject(Serializable, HasBoundingBox):
         )
 
 
-class DetectedObjectContainer(DataContainer):
+class DetectedObjectContainer(DataContainer, SpatiotemporalLike):
     '''Base class for containers that store lists of `DetectedObject`s.'''
 
     _ELE_CLS = DetectedObject

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -315,6 +315,28 @@ def _recurse(v, reflective):
     return v
 
 
+class MixinError(Exception):
+    '''Exception raised when an invalid Mixin chain is encountered.'''
+    pass
+
+
+class IsAMixinForSerializables:
+    '''Implies that the Mixin class inheriting from this base may only be
+    applied to classes that inherit from `Serializable`.
+
+    Note that this requirement is not explicitly enforced at this time in the
+    code itself.  There is a validate function below but this is not explicitly
+    called anywhere at this time.
+    '''
+    @classmethod
+    def validate_mixin_use(cls):
+        '''Checks the use of the mixin to ensure proper inheritance from
+        `Serializable`.
+        '''
+        if not issubclass(cls, Serializable):
+            raise MixinError("Mixin error: %s is not Serializable" % cls)
+
+
 class Container(Serializable):
     '''Abstract base class for flexible containers that store lists of
     `Serializable` elements.
@@ -585,6 +607,8 @@ class Container(Serializable):
         if self._ELE_ATTR is None:
             raise ContainerError(
                 "Cannot instantiate a Container for which _ELE_ATTR is None")
+        if issubclass(self._ELE_CLS, IsAMixinForSerializables):
+            return
         if not issubclass(self._ELE_CLS, Serializable):
             raise ContainerError(
                 "%s is not Serializable" % self._ELE_CLS)

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -450,6 +450,9 @@ class VideoSemanticEntity(Serializable, TemporalEntityLike):
     def get_confidence(self):
         return self.confidence
 
+    def get_index(self):
+        return self.index;
+
     def get_label(self):
         return self.label
 
@@ -700,7 +703,7 @@ class VideoSemanticData(Serializable):
                         label=s.get_label(),
                         bounding_box=s.get_bounding_box(f),
                         confidence=s.get_confidence(),
-                        index=s.get_index,
+                        index=s.get_index(),
                         frame_number=f
                 )
                 for attr in s.get_attributes():

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -459,6 +459,17 @@ class VideoSemanticEntity(Serializable, TemporalLike):
         '''
         self.attrs.add(attr)
 
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs a VideoSemanticEntity from a JSON dictionary.'''
+        dd = defaultdict(lambda: None, d)
+        return cls(
+            label=dd["label"],
+            frames=dd["frames"],
+            attrs=AttributeContainer.from_dict(dd["attrs"]),
+            confidence=dd["confidence"]
+        )
+
 
 class VideoSemanticData(Serializable):
     '''Class encapsulating the semantic information for a video.
@@ -541,6 +552,20 @@ class VideoSemanticData(Serializable):
         deserialize.
         '''
         return super(VideoSemanticData, self).serialize(reflective=True)
+
+    def as_videolabels(self):
+        '''Interpret this class to a VideoLabels instance and return that.'''
+        pass
+
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs a VideoSemanticData from a JSON dictionary.'''
+        return cls(
+            video_attrs=d["video_attrs"],
+            temporals=TemporalEntityContainer.from_dict(d["temporals"]),
+            spatiotemporals=
+                SpatiotemporalEntityContainer.from_dict(d["spatiotemporals"])
+        )
 
 
 class VideoFrameLabels(Serializable):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -43,12 +43,13 @@ import numpy as np
 import scipy.interpolate as spi
 
 from eta.core.data import AttributeContainer, AttributeContainerSchema
+from eta.core.data import BooleanAttribute
 from eta.core.data import TemporalEntityLike, SpatiotemporalEntityLike
 from eta.core.data import TemporalEntityContainer
 from eta.core.data import SpatiotemporalEntityContainer
 from eta.core.geometry import BoundingBox
 import eta.core.image as etai
-from eta.core.objects import DetectedObjectContainer
+from eta.core.objects import DetectedObject, DetectedObjectContainer
 from eta.core.serial import Serializable
 import eta.core.utils as etau
 
@@ -453,11 +454,11 @@ class VideoSemanticEntity(Serializable, TemporalEntityLike):
         return self.label
 
     def get_frames(self):
-        return tuple(self._frames)
+        return tuple(self.frames)
 
     def get_frames_iterable(self):
         '''Exposes the frames of the entity as an iterable.'''
-        return range(*self._frames)
+        return range(*self.frames)
 
     def exists_at_frame(self, f):
         '''Returns True if this entity exists at the frame.'''
@@ -703,7 +704,7 @@ class VideoSemanticData(Serializable):
                         frame_number=f
                 )
                 for attr in s.get_attributes():
-                    do.add_attributes(attr)
+                    do.add_attribute(attr)
                 vl.add_object(do, f)
 
         return vl

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -43,6 +43,9 @@ import numpy as np
 import scipy.interpolate as spi
 
 from eta.core.data import AttributeContainer, AttributeContainerSchema
+from eta.core.data import TemporalLike, SpatiotemporalLike
+from eta.core.data import TemporalEntityContainer
+from eta.core.data import SpatiotemporalEntityContainer
 import eta.core.image as etai
 from eta.core.objects import DetectedObjectContainer
 from eta.core.serial import Serializable
@@ -400,60 +403,6 @@ class VideoMetadata(Serializable):
             x, y, kind="nearest", bounds_error=False, fill_value="extrapolate")
 
 
-class TemporalLike(object):
-    '''A mixin to establish a contract for temporal entities that can be stored
-    in containers.
-    '''
-
-    def exists_at_frame(frame_number):
-        # XXX
-        raise NotImplementedError("subclass must implement exists_at_frame")
-
-
-class SpatiotemporalLike(TemporalLike):
-    '''A mixin to establish a contract for temporal entities that can be stored
-    in containers.
-    '''
-
-    def overlaps_at_frame(frame_number, bounding_box):
-        # XXX
-        raise NotImplementedError("subclass must implement overlaps_at_frame")
-
-
-class SpatiotemporalEntityContainer(DataContainer):
-    '''A container for instances observing the SpatiotemporalLike contract.'''
-    # XXX maybe move this to data
-
-    _ELE_CLS = SpatiotemporalLike
-    _ELE_CLS_FIELD = "_SPATIOTEMPORALENTITY_CLS"
-    _ELE_ATTR = "entities"
-
-    def __init__(self, schema=None, **kwargs):
-        '''Creates a SpatiotemporalContainer instance.
-
-        Args:
-            **kwargs: valid keyword arguments for DataContainer()
-        '''
-        super(SpatiotemporalEntityContainer, self).__init__(**kwargs)
-        # XXX this constructor may not be needed
-
-
-class TemporalEntityContainer(DataContainer):
-    '''A container for instances observing the TemporalLike contract.'''
-    # XXX maybe move this to data
-
-    _ELE_CLS = TemporalLike
-    _ELE_CLS_FIELD = "_TEMPORALENTITY_CLS"
-    _ELE_ATTR = "entities"
-
-    def __init__(self, schema=None, **kwargs):
-        '''Creates a TemporalContainer instance.
-
-        Args:
-            **kwargs: valid keyword arguments for DataContainer()
-        '''
-        super(TemporalEntityContainer, self).__init__(**kwargs)
-        # XXX this constructor may not be needed
 
 
 class VideoSemanticData(Serializable):
@@ -509,12 +458,28 @@ class VideoSemanticData(Serializable):
         )
 
     def add_video_attribute(self, video_attr):
-        '''Adds the attribute to the video.
+        '''Adds the video-level attribute to the semantic metadata.
 
         Args:
             video_attr: an Attribute
         '''
         self.video_attrs.add(video_attr)
+
+    def add_temporal(self, temporal):
+        '''Adds the temporal entity to the semantic metadata
+
+        Args:
+            temporal: a TemporalLike instance
+        '''
+        self.temporals.add(temporal)
+
+    def add_spatiotemporal(self, spatiotemporal):
+        '''Adds the spatiotemporal entity to the semantic metadata
+
+        Args:
+            temporal: a SpatiotemporalLike instance
+        '''
+        self.spatiotemporals.add(spatiotemporal)
 
 
 class VideoFrameLabels(Serializable):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -400,6 +400,49 @@ class VideoMetadata(Serializable):
             x, y, kind="nearest", bounds_error=False, fill_value="extrapolate")
 
 
+class VideoSemanticData(Serializable):
+    '''Class encapsulating the semantic information for a video.
+
+    Captures the three canonical types of semantic information about a video
+    and represents them via the standard ETA Container and Attribute
+    mechanisms.
+    1. Video attributes, such as categorical labels describing the entire video
+    (e.g., "fast", "dark", etc.) or natural language sentences describing the
+    video.
+    2. Temporal entities, such as an event or frame-level label from frame t to
+    frame t+d (e.g., an "intersection" of a dash cam) with optional attributes
+    (e.g., "t-junction" or "four-way" intersections).  Full semantic
+    segmentations would be consider temporal entities with the Attribute
+    containing the mask.
+        XXX All Temporal entities support the YYY contract.
+    3. Spatiotemporal entities, such as an object, exist in a definable spatial
+    region that varies over time and potential only exists for a portion of the
+    full temporal extent of the video (e.g., a vehicle detection).
+    Spatiotemporal entities also have attributes to describe them (e.g., the
+    type and color of the vehicle).  While bounding-box-type entities are the
+    most obvious, these entities can be delineated by polygon regions or
+    arbitrary binary masks.  (Note support for all of this may not yet be
+    implemented.)
+        XXX All Spatiotemporal entities support the ZZZ contract.
+
+    Attributes:
+        video_attrs: An AttributeContainer describing the video-level
+            attributes
+
+    '''
+
+    def __init__(self, video_attrs=None):
+        self.video_attrs = video_attrs or AttributeContainer()
+
+    def add_video_attribute(self, video_attr):
+        '''Adds the attribute to the video.
+
+        Args:
+            video_attr: an Attribute
+        '''
+        self.video_attrs.add(video_attr)
+
+
 class VideoFrameLabels(Serializable):
     '''Class encapsulating labels for a frame of a video.
 


### PR DESCRIPTION
This PR is for discussion and not for review for merge yet; it makes concretes the ideas that have been discussed out of github on the project.

ETA has a frame-centric approach to representing extracted content.  Whereas it sufficient for most things have developed in ETA, it does not allow reasoning about temporal and spatiotemporal relationships without first performing some filtering, etc.  Frame-based representations are also wasteful in space.  My recommendation is that the frame-based representation remains in ETA as it is needed for very important things like initial object extraction and tracking as well as streaming visualization, but that we add this entity-centric code as a first-order representation of semantic content in ETA.

Classes and Mixins added:
- VideoSemanticData
- VideoSemanticEntity
- VideoObjectEntity
- TemporalEntityLike
- SpatiotemporalEntityLike
- TemporalEntityContainer
- SpatiotemporalEntityContainer
- IsAMixinForSerializables

Work to be done
1.  Conversion from VideoLabels to VideoSemanticData (opposite direction done).
2.  Add schema code to VideoSemanticData.