### PR TITLE
Refactoring GPS-related utils into `eta.core.gps`

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -330,8 +330,13 @@ class VideoMetadata(Serializable):
             start_time = dateutil.parser.parse(start_time)
 
         gps_waypoints = d.get("gps_waypoints", None)
-        if gps_waypoints is not None:
+        if isinstance(gps_waypoints, dict):
             gps_waypoints = etag.GPSWaypoints.from_dict(gps_waypoints)
+        elif isinstance(gps_waypoints, list):
+            # this supports a list of GPSWaypoint instances rather than a
+            # serialized GPSWaypoints instance. for backwards compatability
+            points = [etag.GPSWaypoint.from_dict(p) for p in gps_waypoints]
+            gps_waypoints = etag.GPSWaypoints(points=points)
 
         return cls(
             start_time=start_time,

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -42,7 +42,7 @@ import cv2
 import numpy as np
 
 from eta.core.data import AttributeContainer, AttributeContainerSchema
-from eta.core.gps import GPSWaypoints
+import eta.core.gps as etag
 import eta.core.image as etai
 from eta.core.objects import DetectedObjectContainer
 from eta.core.serial import Serializable


### PR DESCRIPTION
This moves `GPSWaypoint` from `eta.core.video` to `eta.core.gps`. It also adds a `GPSWaypoints` class to encapsulate the interpolation functionality.

This PR changes the serialized representation of `VideoMetadata`. Previously, `gps_waypoints` was a list of serialized `GPSWaypoint` instances, and now it is a dict---a serialized `GPSWaypoints` instance. However, I made the `VideoMetadata.from_dict` method support both formats, so this PR is 100% backwards compatible.