### PR TITLE
Data records fix

### DIFF
--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -853,19 +853,23 @@ class DataRecords(DataContainer):
         Args:
             d: a DataRecords dictionary
             record_cls: an optional records class to use when parsing the
-                records dictionary. If not provided, the DataRecord dictionary
-                must define it
+                records dictionary. If not provided, the DataRecords dictionary
+                you are loading must have been written in reflective mode
 
         Returns:
             a DataRecords instance
         '''
-        rc = record_cls or d.get(cls._ELE_CLS_FIELD, None)
-        if rc is None:
-            raise DataRecordsError(
-                "Need record_cls to parse the DataRecords dictionary")
+        if record_cls is None:
+            record_cls_str = d.get(cls._ELE_CLS_FIELD, None)
+            if record_cls_str is None:
+                raise DataRecordsError(
+                    "Your DataRecords does not have its '%s' attribute "
+                    "populated, so you must manually specify the `record_cls` "
+                    "to use when loading it" % cls._ELE_CLS_FIELD)
+            record_cls = etau.get_class(record_cls_str)
 
         return DataRecords(
-            record_cls=rc,
+            record_cls=record_cls,
             records=[rc.from_dict(r) for r in d[cls._ELE_ATTR]])
 
     @classmethod

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -870,7 +870,7 @@ class DataRecords(DataContainer):
 
         return DataRecords(
             record_cls=record_cls,
-            records=[rc.from_dict(r) for r in d[cls._ELE_ATTR]])
+            records=[record_cls.from_dict(r) for r in d[cls._ELE_ATTR]])
 
 
 class DataRecordsError(Exception):

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -872,21 +872,6 @@ class DataRecords(DataContainer):
             record_cls=record_cls,
             records=[rc.from_dict(r) for r in d[cls._ELE_ATTR]])
 
-    @classmethod
-    def from_json(cls, json_path, record_cls=None):
-        '''Constructs a DataRecords object from a JSON file.
-
-        Args:
-            json_path: the path to a DataRecords JSON file
-            record_cls: an optional records class to use when parsing the
-                records file. If not provided, the DataRecords JSON file must
-                define it
-
-        Returns:
-            a DataRecords instance
-        '''
-        return cls.from_dict(read_json(json_path), record_cls=record_cls)
-
 
 class DataRecordsError(Exception):
     '''Exception raised for invalid DataRecords invocations.'''


### PR DESCRIPTION
```py
import sys

import eta.core.data as etad

sys.path.insert(1, "/path/to/theta")
import core.vehicles as thev

dr = etad.DataRecords(thev.VehicleDataRecord)
vdr = thev.VehicleDataRecord("Honda", "Accord", "red", "2004", "sedan", "")
dr.add(vdr)

# this should work
str1 = dr.to_str()  # not reflective
dr1 = etad.DataRecords.from_str(str1, record_cls=thev.VehicleDataRecord)

# this previously didn't work, but now does work
str2 = dr.to_str(reflective=True)  # reflective
dr2 = etad.DataRecords.from_str(str2)
```