### PR TITLE
Only including top-level reflective attributes in Containers

### DIFF
--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -846,6 +846,29 @@ class DataRecords(DataContainer):
         '''
         return self.extract_inds(indices)
 
+    def attributes(self):
+        '''Returns a list of class attributes to be serialized.'''
+        return [self._ELE_ATTR, self._ELE_CLS_FIELD]
+
+    def serialize(self, reflective=False):
+        '''Serializes the DataRecords into a dictionary.
+
+        Note that the top-level reflective attributes of `DataRecords` are
+        always included in the serialized JSON. This implies that all
+        `DataRecords` can be read via `DataRecords.from_json` without
+        manually specifying their `record_cls`.
+
+        Args:
+            reflective: whether to include reflective attributes when
+                serializing the records in the Container. By default, this is
+                False
+
+        Returns:
+            a JSON dictionary representation of the container
+        '''
+        return super(DataRecords, self).serialize(
+            reflective=reflective, reflective_container=True)
+
     @classmethod
     def from_dict(cls, d, record_cls=None):
         '''Constructs a DataRecords instance from a dictionary.

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -723,8 +723,16 @@ class DataFileSequenceError(Exception):
 class DataRecords(DataContainer):
     '''Container class for data records.
 
-    DataRecords is a generic container of records each having a value for
-    a certain set of fields.
+    `DataRecords` is a generic container of records each having a value for
+    a certain set of fields. When creating `DataRecords` instances, you must
+    provide a `record_cls` that specifies the subclass of `BaseDataRecord`
+    that you plan to store in the container.
+
+    When `DataRecords` instances are serialized, they always populate their
+    reflective `_CLS` and `_RECORD_CLS` attributes. Thus `DataRecords` can be
+    read from disk via `DataRecords.from_json("/path/to/records.json")` and
+    the class of the records in the container will be automatically inferred
+    while loading.
     '''
 
     _ELE_ATTR = "records"

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -730,9 +730,9 @@ class DataRecords(DataContainer):
 
     When `DataRecords` instances are serialized, they can optionally have their
     reflective `_CLS` and `_RECORD_CLS` attributes set by passing
-    `reflective_container=True`. When this is done, `DataRecords` can be
-    read from disk via `DataRecords.from_json("/path/to/records.json")` and
-    the class of the records in the container will be inferred while loading.
+    `reflective=True`. When this is done, `DataRecords` can be read from disk
+    via `DataRecords.from_json("/path/to/records.json")` and the class of the
+    records in the container will be inferred while loading.
     '''
 
     _ELE_ATTR = "records"
@@ -866,8 +866,7 @@ class DataRecords(DataContainer):
             d: a DataRecords dictionary
             record_cls: an optional records class to use when parsing the
                 records dictionary. If not provided, the DataRecords dictionary
-                you are loading must have been serialized with either
-                `reflective=True` or `reflective_container=True`
+                must have been serialized with `reflective=True`
 
         Returns:
             a DataRecords instance

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -856,26 +856,7 @@ class DataRecords(DataContainer):
 
     def attributes(self):
         '''Returns a list of class attributes to be serialized.'''
-        return [self._ELE_ATTR, self._ELE_CLS_FIELD]
-
-    def serialize(self, reflective=False):
-        '''Serializes the DataRecords into a dictionary.
-
-        Note that the top-level reflective attributes of `DataRecords` are
-        always included in the serialized JSON. This implies that all
-        `DataRecords` can be read via `DataRecords.from_json` without
-        manually specifying their `record_cls`.
-
-        Args:
-            reflective: whether to include reflective attributes when
-                serializing the records in the Container. By default, this is
-                False
-
-        Returns:
-            a JSON dictionary representation of the container
-        '''
-        return super(DataRecords, self).serialize(
-            reflective=reflective, reflective_container=True)
+        return [self._ELE_ATTR]
 
     @classmethod
     def from_dict(cls, d, record_cls=None):

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -728,11 +728,11 @@ class DataRecords(DataContainer):
     provide a `record_cls` that specifies the subclass of `BaseDataRecord`
     that you plan to store in the container.
 
-    When `DataRecords` instances are serialized, they always populate their
-    reflective `_CLS` and `_RECORD_CLS` attributes. Thus `DataRecords` can be
+    When `DataRecords` instances are serialized, they can optionally have their
+    reflective `_CLS` and `_RECORD_CLS` attributes set by passing
+    `reflective_container=True`. When this is done, `DataRecords` can be
     read from disk via `DataRecords.from_json("/path/to/records.json")` and
-    the class of the records in the container will be automatically inferred
-    while loading.
+    the class of the records in the container will be inferred while loading.
     '''
 
     _ELE_ATTR = "records"
@@ -866,7 +866,8 @@ class DataRecords(DataContainer):
             d: a DataRecords dictionary
             record_cls: an optional records class to use when parsing the
                 records dictionary. If not provided, the DataRecords dictionary
-                you are loading must have been written in reflective mode
+                you are loading must have been serialized with either
+                `reflective=True` or `reflective_container=True`
 
         Returns:
             a DataRecords instance

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -267,6 +267,14 @@ class Serializable(object):
 
         Subclasses must implement this method if they intend to support being
         read from disk.
+
+        Args:
+            d: a JSON dictionary representation of a Serializable object
+            *args: optional class-specific positional arguments
+            **kwargs: optional class-specific keyword arguments
+
+        Returns:
+            an instance of the Serializable class
         '''
         if "_CLS" in d:
             #
@@ -289,6 +297,14 @@ class Serializable(object):
         Subclasses may override this method, but, by default, this method
         simply parses the string and calls from_dict(), which subclasses must
         implement.
+
+        Args:
+            s: a JSON string representation of a Serializable object
+            *args: optional positional arguments for `self.from_dict()`
+            **kwargs: optional keyword arguments for `self.from_dict()`
+
+        Returns:
+            an instance of the Serializable class
         '''
         return cls.from_dict(json.loads(s), *args, **kwargs)
 
@@ -299,6 +315,14 @@ class Serializable(object):
         Subclasses may override this method, but, by default, this method
         simply reads the JSON and calls from_dict(), which subclasses must
         implement.
+
+        Args:
+            path: the path to the JSON file on disk
+            *args: optional positional arguments for `self.from_dict()`
+            **kwargs: optional keyword arguments for `self.from_dict()`
+
+        Returns:
+            an instance of the Serializable class
         '''
         return cls.from_dict(read_json(path), *args, **kwargs)
 

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -522,18 +522,22 @@ class Container(Serializable):
         '''Returns the list of class attributes that will be serialized.'''
         return [self._ELE_ATTR]
 
-    def serialize(self, reflective=False):
+    def serialize(self, reflective=False, reflective_container=False):
         '''Serializes the container into a dictionary.
 
         Args:
             reflective: whether to include reflective attributes when
-                serializing the object. By default, this is False
+                serializing the object. This applies recursively to all
+                Container elements. By default, this is False
+            reflective_container: whether to include reflective attributes for
+                the top-level Container. This is always True when `reflective`
+                is True, but it can be selectively turned on if desired
 
         Returns:
             a JSON dictionary representation of the container
         '''
         d = OrderedDict()
-        if reflective:
+        if reflective or reflective_container:
             d["_CLS"] = self.get_class_name()
             d[self._ELE_CLS_FIELD] = etau.get_class_name(self._ELE_CLS)
         d[self._ELE_ATTR] = _recurse(self.__elements__, reflective)

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -233,31 +233,32 @@ class Serializable(object):
             d["_CLS"] = self.get_class_name()
         return d
 
-    def to_str(self, reflective=False, pretty_print=True):
+    def to_str(self, pretty_print=True, **kwargs):
         '''Returns a string representation of this object.
 
         Args:
-            reflective: whether to include reflective attributes when
-                serializing the object. By default, this is False
             pretty_print: if True (default), the string will be formatted to be
                 human readable; when False, it will be compact with no extra
                 spaces or newline characters
+            **kwargs: optional keyword arguments for `self.serialize()`
+
+        Returns:
+            a string representation of the object
         '''
-        obj = self.serialize(reflective=reflective)
+        obj = self.serialize(**kwargs)
         return json_to_str(obj, pretty_print=pretty_print)
 
-    def write_json(self, path, reflective=False, pretty_print=True):
+    def write_json(self, path, pretty_print=True, **kwargs):
         '''Serializes the object and writes it to disk.
 
         Args:
             path: the output path
-            reflective: whether to include reflective attributes when
-                serializing the object. By default, this is False
             pretty_print: when True (default), the resulting JSON will be
                 outputted to be human readable; when False, it will be compact
                 with no extra spaces or newline characters
+            **kwargs: optional keyword arguments for `self.serialize()`
         '''
-        obj = self.serialize(reflective=reflective)
+        obj = self.serialize(**kwargs)
         write_json(obj, path, pretty_print=pretty_print)
 
     @classmethod

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -385,8 +385,8 @@ def _recurse(v, reflective):
 
 
 class Container(Serializable):
-    '''Abstract base class for flexible containers that store lists of
-    `Serializable` elements.
+    '''Abstract base class for flexible containers that store homogeneous lists
+    of elements of a `Serializable` class.
 
     Container subclasses embed their class names and underlying element class
     names in their JSON representations, so they can be read reflectively from
@@ -396,12 +396,12 @@ class Container(Serializable):
 
     This class currently has only two direct subclasses, which bifurcate the
     container implementation into two distinct categories:
-        - `eta.core.data.DataContainer`: base class for containers that store
-            lists of `Serializable` data instances
         - `eta.core.config.ConfigContainer`: base class for containers that
             store lists of `Config` instances
+        - `eta.core.data.DataContainer`: base class for containers that store
+            lists of arbitrary `Serializable` data instances
 
-    See `DataContainer` and `ConfigContainer` for concrete usage examples.
+    See `ConfigContainer` and `DataContainer` for concrete usage examples.
     '''
 
     #

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -591,25 +591,21 @@ class Container(Serializable):
         '''Returns the list of class attributes that will be serialized.'''
         return [self._ELE_ATTR]
 
-    def serialize(self, reflective=False, reflective_container=False):
+    def serialize(self, reflective=False):
         '''Serializes the container into a dictionary.
 
         Args:
             reflective: whether to include reflective attributes when
-                serializing the object. This applies recursively to all
-                Container elements. By default, this is False
-            reflective_container: whether to include reflective attributes for
-                the top-level Container. This is always True when `reflective`
-                is True, but it can be selectively turned on if desired
+                serializing the object. By default, this is False
 
         Returns:
             a JSON dictionary representation of the container
         '''
         d = OrderedDict()
-        if reflective or reflective_container:
+        if reflective:
             d["_CLS"] = self.get_class_name()
             d[self._ELE_CLS_FIELD] = etau.get_class_name(self._ELE_CLS)
-        d[self._ELE_ATTR] = _recurse(self.__elements__, reflective)
+        d[self._ELE_ATTR] = _recurse(self.__elements__, False)
         return d
 
     @classmethod

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -153,10 +153,54 @@ class Picklable(object):
 
 
 class Serializable(object):
-    '''Base class for objects that can be serialized.
+    '''Base class for objects that can be serialized in JSON format.
 
     Subclasses must implement `from_dict()`, which defines how to construct a
     serializable object from a JSON dictionary.
+
+    Serializable objects can be easily converted read and written from any of
+    the following formats:
+        - JSON files on disk
+        - JSON dictionaries
+        - JSON strings
+
+    For example, you can do the following with any class `SerializableClass`
+    that is a subclass of `Serializable`:
+
+    ```
+    json_path = "/path/to/data.json"
+
+    obj = SerializableClass(...)
+
+    s = obj.to_str()
+    obj1 = SerializableClass.from_str(s)
+
+    d = obj.serialize()
+    obj2 = SerializableClass.from_dict(d)
+
+    obj.write_json(json_path)
+    obj3 = SerializableClass.from_json(json_path)
+    ```
+
+    Serializable objects can optionally be serialized in "reflective" mode,
+    in which case their class names are embedded in their JSON representations.
+    This allows for reading Serializable JSON instances of arbitrary types
+    polymorphically via the Serializable interface. For example:
+
+    ```
+    json_path = "/path/to/data.json"
+
+    obj = SerializableClass(...)
+
+    s = obj.to_str(reflective=True)
+    obj1 = Serializable.from_str(s)  # returns a SerializableClass
+
+    d = obj.serialize(reflective=True)
+    obj2 = Serializable.from_dict(d)  # returns a SerializableClass
+
+    obj.write_json(json_path, reflective=True)
+    obj3 = Serializable.from_json(json_path)  # returns a SerializableClass
+    ```
     '''
 
     def __str__(self):


### PR DESCRIPTION
Previously the "reflective" option for Containers embedded the reflective attributes recursively for all Container elements. However, this is unnecessary as Containers store homogeneous lists of elements. Therefore, I updated the `reflective=True` option to only include the `_ELE_CLS` once at the top-level. This saves space while maintaining generality.

Example:

```py
import eta.core.data as etad

dr = etad.DataRecords(record_cls)

print(dr.to_str())

'''
{
    "records": []
}
'''

print(dr.to_str(reflective=True))
'''
{
    "_CLS": "eta.core.data.DataRecords",
    "_RECORD_CLS": "<record_cls>",
    "records": []
}
'''
```