### PR TITLE
Adding VideoSetLabels class to encapsulate VideoLabels for a set of videos

### DIFF
--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -976,7 +976,7 @@ class BaseDataRecord(Serializable):
             KeyError: if a required attribute was not found in the input
                 dictionary
         '''
-        kwargs = {k: d[k] for k in cls.required()}                  # required
+        kwargs = {k: d[k] for k in cls.required()}  # required
         kwargs.update({k: d[k] for k in cls.optional() if k in d})  # optional
         return cls(**kwargs)
 

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -188,9 +188,9 @@ class ImageSetLabels(Serializable):
     def _validate_image_labels(self, image_labels):
         if self.has_schema:
             for image_attr in image_labels.attrs:
-                self.schema.validate_image_attribute(image_attr)
+                self._validate_image_attribute(image_attr)
             for obj in image_labels.objects:
-                self.schema.validate_object(obj)
+                self._validate_object(obj)
 
     def _validate_image_attribute(self, image_attr):
         if self.has_schema:

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -496,6 +496,10 @@ class ImageLabelsSchema(Serializable):
             for obj_attr in obj.attrs:
                 self.validate_object_attribute(obj.label, obj_attr)
 
+    def attributes(self):
+        '''Returns the list of class attributes that will be serialized.'''
+        return ["attrs", "objects"]
+
     @classmethod
     def build_active_schema(cls, image_labels):
         '''Builds a ImageLabelsSchema that describes the active schema of

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -109,6 +109,8 @@ class ImageSetLabels(Serializable):
         return self.images[idx]
 
     def __setitem__(self, idx, image_labels):
+        if self.has_schema:
+            self._validate_image_labels(image_labels)
         self.images[idx] = image_labels
 
     def __delitem__(self, idx):

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -143,7 +143,6 @@ class ImageSetLabels(Serializable):
         '''
         if self.has_schema:
             self._validate_image_labels(image_labels)
-
         self.images.append(image_labels)
 
     def get_schema(self):

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -807,6 +807,18 @@ class VideoLabels(JSONFile):
     pass
 
 
+class VideoSetLabels(JSONFile):
+    '''A description of the labeled contents of a set of videos.
+
+    This type is implemented in ETA by the `eta.core.video.VideoSetLabels`
+    class.
+
+    Examples:
+        /path/to/video_set_labels.json
+    '''
+    pass
+
+
 class Features(FileSequence, ConcreteData):
     '''A sequence of features indexed by one numeric parameter.
 

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -771,6 +771,30 @@ class DetectedObjectsSequence(JSONFileSequence):
     pass
 
 
+class ImageLabels(JSONFile):
+    '''A description of the labeled contents of an image.
+
+    This type is implemented in ETA by the `eta.core.image.ImageLabels`
+    class.
+
+    Examples:
+        /path/to/image_labels.json
+    '''
+    pass
+
+
+class ImageSetLabels(JSONFile):
+    '''A description of the labeled contents of a set of images.
+
+    This type is implemented in ETA by the `eta.core.image.ImageSetLabels`
+    class.
+
+    Examples:
+        /path/to/image_set_labels.json
+    '''
+    pass
+
+
 class VideoLabels(JSONFile):
     '''A description of the labeled contents of a video.
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1099,6 +1099,10 @@ class VideoLabelsSchema(Serializable):
             for obj_attr in obj.attrs:
                 self.validate_object_attribute(obj.label, obj_attr)
 
+    def attributes(self):
+        '''Returns the list of class attributes that will be serialized.'''
+        return ["attrs", "frames", "objects"]
+
     @classmethod
     def build_active_schema_for_frame(cls, frame_labels):
         '''Builds a VideoLabelsSchema that describes the active schema of

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -683,6 +683,8 @@ class VideoLabels(Serializable):
 
     def _validate_schema(self):
         if self.has_schema:
+            for video_attr in self.attrs:
+                self._validate_video_attribute(video_attr)
             for frame_labels in itervalues(self.frames):
                 self._validate_frame_labels(frame_labels)
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -559,8 +559,8 @@ class VideoFrameLabels(Serializable):
 class VideoLabels(Serializable):
     '''Class encapsulating labels for a video.
 
-    Note that any falsey fields of this class (except `frames`) will be omitted
-    during serialization.
+    Note that any falsey fields of this class will be omitted during
+    serialization.
 
     Note that when VideoLabels objects are serialized, the keys of the `frames`
     dict will be converted to strings, because all JSON object keys _must_ be
@@ -776,7 +776,8 @@ class VideoLabels(Serializable):
             _attrs.append("schema")
         if self.attrs:
             _attrs.append("attrs")
-        _attrs.append("frames")
+        if self.frames:
+            _attrs.append("frames")
         return _attrs
 
     def _validate_video_attribute(self, video_attr):
@@ -839,10 +840,12 @@ class VideoLabels(Serializable):
         if attrs is not None:
             attrs = AttributeContainer.from_dict(attrs)
 
-        frames = OrderedDict(
-            (int(fn), VideoFrameLabels.from_dict(vfl))
-            for fn, vfl in iteritems(d["frames"])
-        )
+        frames = d.get("frames", None)
+        if frames is not None:
+            frames = OrderedDict(
+                (int(fn), VideoFrameLabels.from_dict(vfl))
+                for fn, vfl in iteritems(frames)
+            )
 
         schema = d.get("schema", None)
         if schema is not None:


### PR DESCRIPTION
Also adds optional `filename` and `metadata` fields to `VideoLabels` to make it even more robust.

Verification that `VideoSetLabels` works:

```py
import eta.core.data as etad
import eta.core.geometry as etag
import eta.core.video as etav
import eta.core.objects as etao
from eta.core.serial import Serializable

# Video attributes
vattr1 = etad.CategoricalAttribute("weather", "rain", confidence=0.95)
vattr2 = etad.NumericAttribute("fps", 30)
vattr3 = etad.BooleanAttribute("daytime", True)

# Frame attributes
fattr1 = etad.CategoricalAttribute("scene", "intersection", confidence=0.9)
fattr2 = etad.NumericAttribute("quality", 0.5)
fattr3 = etad.BooleanAttribute("on_road", True)

# Create some objects
tl = etag.RelativePoint(0, 0)
br = etag.RelativePoint(1, 1)
bb = etag.BoundingBox(tl, br)
obj1 = etao.DetectedObject("car", bb, confidence=0.9, index=1)
obj1.add_attribute(etad.CategoricalAttribute("make", "Honda"))
obj2 = etao.DetectedObject("person", bb, index=2)
obj2.add_attribute(etad.NumericAttribute("age", 42, confidence=0.99))

#
# Populate VideoSetLabels
#

video_labels1 = etav.VideoLabels(filename="video1.mp4")
video_labels2 = etav.VideoLabels(filename="video2.mov")

vattrs = etad.AttributeContainer()
vattrs.add(vattr2)
vattrs.add(vattr3)
video_labels1.add_video_attribute(vattr1)
video_labels2.add_video_attributes(vattrs)

# Add a frame
frame_labels1 = etav.VideoFrameLabels(1)
frame_labels1.add_frame_attribute(fattr1)
frame_labels1.add_object(obj1)
video_labels1.add_frame(frame_labels1)

frame_labels2 = etav.VideoFrameLabels(1)
frame_labels2.add_frame_attribute(fattr2)
video_labels2.add_frame(frame_labels2)

# Add another frame a different way
video_labels1.add_frame_attribute(fattr3, 2)
video_labels2.add_object(obj2, 2)

video_set_labels = etav.VideoSetLabels()
video_set_labels.add_video_labels(video_labels1)
video_set_labels.add_video_labels(video_labels2)

# Test serialization
etav.VideoSetLabels.from_str(str(video_set_labels))
Serializable.from_str(video_set_labels.to_str(reflective=True))

# Test schema
print(video_set_labels)
video_set_labels.freeze_schema()
print(video_set_labels)
video_set_labels.remove_schema()
print(video_set_labels)
video_set_labels.freeze_schema()

#
# Try to violate the schema
#

schema1 = video_set_labels[0].get_active_schema()
video_set_labels.set_schema(schema1)
# AttributeContainerSchemaError: Attribute 'fps' is not allowed by the schema

video_labels3 = etav.VideoLabels()
video_labels3.add_video_attribute(etad.NumericAttribute("weather", 100.0))
video_set_labels.add_video_labels(video_labels3)
# AttributeSchemaError: Expected attribute 'weather' to have type 'eta.core.data.CategoricalAttribute'; found 'eta.core.data.NumericAttribute'

video_labels4 = etav.VideoLabels()
video_labels4.add_video_attribute(etad.CategoricalAttribute("weather", "bad"))
video_set_labels.add_video_labels(video_labels4)
# AttributeContainerSchemaError: Value 'bad' of attribute 'weather' is not allowed by the schema
```