### PR TITLE
Infrastructure for deploying classifiers

### DIFF
--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -1,6 +1,10 @@
 '''
 Core utilities for rendering annotations on media.
 
+@todo support for rendering video-level attributes
+@todo support for rendering frame-level attributes
+@todo support for rendering object-level attributes
+
 Copyright 2019, Voxel51, Inc.
 voxel51.com
 
@@ -204,6 +208,8 @@ def annotate_video(
         if add_logo:
             logo.render_for(frame_size=p.output_frame_size)
 
+        # @todo support video-level attributes here
+
         for img in p:
             logger.debug("Annotating frame %d", p.frame_number)
             frame_labels = video_labels[p.frame_number]
@@ -263,7 +269,7 @@ def annotate_image(
         img = _annotate_object(
             img, obj, colormap, font, alpha, text_color, pad, linewidth)
 
-    # @todo support frame attributes
+    # @todo support frame attributes here
 
     # Add logo
     if add_logo:
@@ -282,6 +288,8 @@ def _annotate_object(
     else:
         index = 0
         msg = label
+
+    # @todo support object attributes here
 
     # Get box color
     color_index = label.__hash__() + index

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -30,6 +30,7 @@ import cv2
 import numpy as np
 
 from eta.core.config import Config, Configurable
+import eta.core.image as etai
 from eta.core.numutils import GrowableArray
 import eta.core.utils as etau
 import eta.core.video as etav
@@ -556,7 +557,7 @@ class VideoFramesFeaturizer(Featurizer):
 
     def _featurize(self, video_path, frames=None, returnX=True):
         frames = frames or self.config.frames
-        logger.debug("Featurizing frames %s" % frames)
+        logger.debug("Featurizing frames %s", frames)
 
         if returnX:
             X = None

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -1,7 +1,7 @@
 '''
 Core interfaces, data structures, and methods for feature extraction in images.
 
-Copyright 2017-2018, Voxel51, Inc.
+Copyright 2017-2019, Voxel51, Inc.
 voxel51.com
 
 Jason Corso, jason@voxel51.com
@@ -69,8 +69,10 @@ class Featurizer(Configurable):
     '''Base class for all featurizers.
 
     Subclasses of Featurizer must implement the `dim()` and `_featurize()`
-    methods, and if necessary, should also implement the `_start()` and
-    `_stop()` methods.
+    methods.
+
+    If setup/teardown is required, subclasses should also implement the
+    `_start()` and `_stop()` methods.
 
     Subclasses must call the superclass constructor defined by this base class.
 
@@ -188,6 +190,23 @@ class Featurizer(Configurable):
 class CanFeaturize(object):
     '''Mixin class that exposes the ability to featurize data just-in-time via
     a provided Featurizer instance.
+
+    This class allows you to decorate methods that should featurize data if
+    necessary with one of the following strategies:
+        - `@CanFeaturize.featurize_if_needed`: the first function argument will
+            be featurized
+        - `@CanFeaturize.featurize_if_needed(arg_name="foo")`: the arg with the
+            specified name will be featurized
+        - `@CanFeaturize.featurize_if_needed("foo")`: the arg with the
+            specified name will be featurized
+        - `@CanFeaturize.featurize_if_needed(index)`: the arg in the specified
+            position will be featurized
+
+    Arguments are featurized if they are strings that point to a valid file(s)
+    on disk (including videos represented as sequences of frames).
+
+    Alternatively, when `force_featurize=True`, all arguments to the function
+    are automatically featurized.
     '''
 
     def __init__(self, featurizer=None, force_featurize=False):
@@ -227,29 +246,17 @@ class CanFeaturize(object):
         defined).
 
         The argument to featurize can be specified as either the numeric index
-        of the argument to featurize in *args or a named argument.  The code
-        tries to reconcile one of them, ultimately failing if it cannot find
-        one.
-
-        The method we use to tell if the argument needs to be featurized is by
-        checking if it is a string that points to a file on the disk, and if
-        that fails, if it is a string that points to a valid video.
-
-        You can decorate with either just `@CanFeaturize.featurize_if_needed`,
-        in which case
-        or by specifying specific names of arguments to operate on either as
-        `@CanFeaturize.featurize_if_needed(arg_name="foo")`
-        or just
-        `@CanFeaturize.featurize_if_needed("foo")` and this will be a name not
-        an index.
+        of the argument to featurize or a named argument. The code tries to
+        reconcile one of them, ultimately failing if it cannot find one.
 
         Args:
             arg_name ("X"): a string specifying the name of the argument
                 passed to the original function that you want to featurize
+                if necessary
 
             arg_index (0): an int specifying the index of the argument passed
-                to the original function that you want to featurize. If
-                `arg_name` is provided, it takes precedence over `arg_index`
+                to the original function that you want to featurize if
+                necessary
 
         Raises:
             CanFeaturizeError: if featurization failed or was not allowed
@@ -367,7 +374,7 @@ class FeaturizedFrameNotFoundError(OSError):
 
 
 class VideoFramesFeaturizerConfig(Config):
-    '''Specifies the configuration settings for the VideoFeaturizer class.'''
+    '''Configuration settings for a VideoFramesFeaturizer.'''
 
     def __init__(self, d):
         self.backing_path = self.parse_string(

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -32,7 +32,6 @@ import numpy as np
 from eta.core.config import Config, Configurable
 from eta.core.numutils import GrowableArray
 import eta.core.utils as etau
-import eta.core.types as etat
 import eta.core.video as etav
 
 
@@ -333,7 +332,7 @@ class CanFeaturize(object):
                             # a video, so we check if data is a valid video
                             # path.
                             #
-                            should_featurize = etat.Video.is_valid_path(data)
+                            should_featurize = etav.is_supported_video(data)
 
                 # Perform the actual featurization, if necessary.
                 if should_featurize:

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -631,6 +631,13 @@ class VideoFramesFeaturizer(Featurizer):
                 raise
 
 
+class ORBFeaturizerConfig(Config):
+    '''Configuration settings for an ORBFeaturizer.'''
+
+    def __init__(self, d):
+        self.num_keypoints = self.parse_number(d, "num_keypoints", default=128)
+
+
 class ORBFeaturizer(Featurizer):
     '''ORB (Oriented FAST and rotated BRIEF features) Featurizer.
 
@@ -638,25 +645,39 @@ class ORBFeaturizer(Featurizer):
         http://www.willowgarage.com/sites/default/files/orb_final.pdf
     '''
 
-    def __init__(self, num_keypoints=128):
-        '''Constructs a new ORB Featurizer instance.'''
+    def __init__(self, config=None):
+        '''Creates a new ORBFeaturizer instance.
+
+        Args:
+            config: an optional ORBFeaturizerConfig instance. If omitted, the
+                default ORBFeaturizerConfig is used
+        '''
+        if config is None:
+            config = ORBFeaturizerConfig.default()
+        self.num_keypoints = config.num_keypoints
         super(ORBFeaturizer, self).__init__()
-        self.num_keypoints = num_keypoints
 
         try:
             # OpenCV 3
-            self.orb = cv2.ORB_create(nfeatures=num_keypoints)
+            self._orb = cv2.ORB_create(nfeatures=self.num_keypoints)
         except AttributeError:
             # OpenCV 2
-            self.orb = cv2.ORB(nfeatures=num_keypoints)
+            self._orb = cv2.ORB(nfeatures=self.num_keypoints)
 
     def dim(self):
-        '''Return the dimension of the features.'''
+        '''Returns the dimension of the features.'''
         return 32 * self.num_keypoints
 
     def _featurize(self, img):
         gray = etai.rgb_to_gray(img)
-        return self.orb.detectAndCompute(gray, None)[1].flatten()
+        return self._orb.detectAndCompute(gray, None)[1].flatten()
+
+
+class RandFeaturizerConfig(Config):
+    '''Configuration settings for an RandFeaturizer.'''
+
+    def __init__(self, d):
+        self.dim = self.parse_number(d, "dim", default=1024)
 
 
 class RandFeaturizer(Featurizer):
@@ -664,19 +685,20 @@ class RandFeaturizer(Featurizer):
     entries regardless of the input data.
     '''
 
-    def __init__(self, dim=1024):
-        '''Constructs a RandFeaturizer instance.
+    def __init__(self, config=None):
+        '''Creates a new RandFeaturizer instance.
 
         Args:
-            dim: the desired embedding dimension. The default value is 1024
+            config: an optional RandFeaturizerConfig instance. If omitted, the
+                default RandFeaturizerConfig is used
         '''
-        super(RandFeaturizer, self).__init__(self)
-        self._dim = dim
+        if config is None:
+            config = RandFeaturizerConfig.default()
+        self._dim = config.dim
+        super(RandFeaturizer, self).__init__()
 
     def dim(self):
-        '''Returns the dimension of the features extracted by this
-        Featurizer.
-        '''
+        '''Returns the dimension of the features.'''
         return self._dim
 
     def _featurize(self, _):

--- a/eta/core/learning.py
+++ b/eta/core/learning.py
@@ -20,6 +20,7 @@ from builtins import *
 # pragma pylint: enable=wildcard-import
 
 from eta.core.config import Config, Configurable
+import eta.core.data as etad
 
 
 class ClassifierConfig(Config):
@@ -50,21 +51,156 @@ class ClassifierConfig(Config):
 class Classifier(Configurable):
     '''Interface for classifiers.
 
-    Subclasses of Classifier must implement the `predict()` method.
+    Subclasses of `Classifier` must implement the `predict()` method.
+
+    Subclasses can optionally implement the context manager interface to
+    perform any necessary setup and teardown.
     '''
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
     def predict(self, arg):
-        '''Peforms prediction on the given input.
+        '''Peforms prediction on the given argument.
 
         Args:
-            arg: the input to classify. Depending on the classifier, this may
-                be an image, video, or embedding(s)
+            arg: the data to classify
 
         Returns:
             an `eta.core.data.AttributeContainer` describing the predictions
-                for the input
         '''
-        raise NotImplementedError("subclass must implement predict()")
+        raise NotImplementedError("subclasses must implement predict()")
+
+
+class ImageClassifier(Classifier):
+    '''Base class for all classifiers that operate on single images.
+
+    `ImageClassifier`s may output single or multiple labels per image.
+
+    Subclasses of `ImageClassifier` must implement the `predict()` method, and
+    they can optionally provide custom (efficient) implementations of the
+    `predict_all()` method.
+
+    Subclasses can optionally implement the context manager interface to
+    perform any necessary setup and teardown, e.g., operating a `Featurizer`
+    that featurizes the input images.
+    '''
+
+    def predict(self, img):
+        '''Peforms prediction on the given image.
+
+        Args:
+            img: the image to classify
+
+        Returns:
+            an `eta.core.data.AttributeContainer` instance containing the
+                predictions
+        '''
+        raise NotImplementedError("subclasses must implement predict()")
+
+    def predict_all(self, imgs):
+        '''Performs prediction on the given tensor of images.
+
+        Subclasses can override this method to increase efficiency, but, by
+        default, this method simply iterates over the images and predicts each.
+
+        Args:
+            imgs: a list (or d x ny x nx x 3 tensor) of images to classify
+
+        Returns:
+            a list of `eta.core.data.AttributeContainer` instances describing
+                the predictions for each image
+        '''
+        return [self.predict(img) for img in imgs]
+
+
+class VideoFramesClassifier(Classifier):
+    '''Base class for all classifiers that operate directly on videos
+    represented as tensors of images.
+
+    `VideoFramesClassifier`s may output single or multiple labels per video
+    clip.
+
+    Subclasses of `VideoFramesClassifier` must implement the `predict()` method.
+
+    Subclasses can optionally implement the context manager interface to
+    perform any necessary setup and teardown, e.g., operating a `Featurizer`
+    that featurizes the input frames.
+    '''
+
+    def predict(self, imgs):
+        '''Peforms prediction on the given video represented as a tensor of
+        images.
+
+        Args:
+            imgs: a list (or d x ny x nx x 3 tensor) of images defining the
+                video to classify
+
+        Returns:
+            an `eta.core.data.AttributeContainer` instance describing
+                the predictions for the input
+        '''
+        raise NotImplementedError("subclasses must implement predict()")
+
+
+class VideoFramesVotingClassifierConfig(Config):
+    '''Configuration settings for a VideoFramesVotingClassifier.'''
+
+    def __init__(self, d):
+        self.image_classifier = self.parse_object(
+            d, "image_classifier", ClassifierConfig)
+        self.confidence_weighted_vote = self.parse_bool(
+            d, "confidence_weighted_vote", default=False)
+
+
+class VideoFramesVotingClassifier(VideoFramesClassifier):
+    '''A video frames classifier that uses an `ImageClassifier` to classify
+    each image and then votes on each attribute to determine the predictions
+    for the video.
+
+    Note that all attributes are combined into a single vote. Thus, even if the
+    `ImageClassifier` is a multilabel classifier, each prediction will contain
+    the single most prevelant label.
+    '''
+
+    def __init__(self, config):
+        '''Creates a VideoFramesVotingClassifier instance.
+
+        Args:
+            config: a VideoFramesVotingClassifierConfig instance
+        '''
+        self.config = config
+        self.image_classifier = config.image_classifier.build()
+
+        if not issubclass(self.image_classifier, ImageClassifier):
+            raise ValueError("image_classifier must be a %s", ImageClassifier)
+
+    def __enter__(self):
+        self.image_classifier.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        self.image_classifier.__exit__(*args)
+
+    def predict(self, imgs):
+        '''Peforms prediction on the given video represented as a tensor of
+        images.
+
+        Args:
+            imgs: a list (or d x ny x nx x 3 tensor) of images defining the
+                video to classify
+
+        Returns:
+            an `eta.core.data.AttributeContainer` instance describing
+                the predictions for the input
+        '''
+        frame_attrs = self.image_classifier.predict_all(imgs)
+        return etad.majority_vote_categorical_attrs(
+            frame_attrs,
+            confidence_weighted=self.config.confidence_weighted_vote)
 
 
 class ObjectDetectorConfig(Config):

--- a/eta/core/learning.py
+++ b/eta/core/learning.py
@@ -23,13 +23,13 @@ from eta.core.config import Config, Configurable
 
 
 class ClassifierConfig(Config):
-    '''Configuration class that encapsulates the name of a Classifier and
+    '''Configuration class that encapsulates the name of a `Classifier` and
     an instance of its associated Config class.
 
     Attributes:
-        type: the fully-qualified class name of the Classifier
+        type: the fully-qualified class name of the `Classifier`
         config: an instance of the Config class associated with the specified
-            Classifier
+            `Classifier`
     '''
 
     def __init__(self, d):
@@ -48,7 +48,7 @@ class ClassifierConfig(Config):
 
 
 class Classifier(Configurable):
-    '''Base class for all classifiers.
+    '''Interface for classifiers.
 
     Subclasses of Classifier must implement the `predict()` method.
     '''
@@ -68,13 +68,13 @@ class Classifier(Configurable):
 
 
 class ObjectDetectorConfig(Config):
-    '''Configuration class that encapsulates the name of an ObjectDetector and
-    an instance of its associated Config class.
+    '''Configuration class that encapsulates the name of an `ObjectDetector`
+    and an instance of its associated Config class.
 
     Attributes:
-        type: the fully-qualified class name of the ObjectDetector
+        type: the fully-qualified class name of the `ObjectDetector`
         config: an instance of the Config class associated with the specified
-            Detector
+            detector
     '''
 
     def __init__(self, d):
@@ -86,7 +86,7 @@ class ObjectDetectorConfig(Config):
             self.config = config_cls.load_default()
 
     def build(self):
-        '''Factory method that builds the ObjectDetector instance from the
+        '''Factory method that builds the `ObjectDetector` instance from the
         config specified by this class.
         '''
         return self._detector_cls(self.config)
@@ -95,17 +95,26 @@ class ObjectDetectorConfig(Config):
 class ObjectDetector(Configurable):
     '''Base class for all object detectors.
 
-    Subclasses of ObjectDetctor must implement the `detect()` method.
+    Subclasses of `ObjectDetctor` must implement the `detect()` method.
+
+    Subclasses can optionally implement the context manager interface to
+    perform any necessary setup and teardown.
     '''
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
     def detect(self, img):
-        '''Performs object detection on the input image.
+        '''Detects objects in the given image.
 
         Args:
             img: an image
 
         Returns:
-            an `eta.core.objects.DetectedObjectContainer` describing the
-                detected objects in the image
+            an `eta.core.objects.DetectedObjectContainer` instance describing
+                the detected objects
         '''
         raise NotImplementedError("subclass must implement detect()")

--- a/eta/core/learning.py
+++ b/eta/core/learning.py
@@ -175,7 +175,7 @@ class VideoFramesVotingClassifier(VideoFramesClassifier):
         self.config = config
         self.image_classifier = config.image_classifier.build()
 
-        if not issubclass(self.image_classifier, ImageClassifier):
+        if not isinstance(self.image_classifier, ImageClassifier):
             raise ValueError("image_classifier must be a %s", ImageClassifier)
 
     def __enter__(self):

--- a/eta/core/numutils.py
+++ b/eta/core/numutils.py
@@ -1,10 +1,11 @@
 '''
 Core numeric and computational utilities.
 
-Copyright 2017, Voxel51, Inc.
+Copyright 2017-2019, Voxel51, Inc.
 voxel51.com
 
-Jason Corso, jjc@voxel51.com
+Jason Corso, jason@voxel51.com
+Brian Moore, brian@voxel51.com
 '''
 # pragma pylint: disable=redefined-builtin
 # pragma pylint: disable=unused-wildcard-import

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -83,6 +83,12 @@ class DetectedObject(Serializable, HasBoundingBox):
             self.attrs = AttributeContainer()
         self.attrs.add(attr)
 
+    def add_attributes(self, attrs):
+        '''Adds the AttributeContainer of attributes to the object.'''
+        if not self.has_attributes:
+            self.attrs = AttributeContainer()
+        self.attrs.add_container(attrs)
+
     def attributes(self):
         '''Returns the list of attributes to serialize.
 

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -26,7 +26,9 @@ import numbers
 import os
 
 import eta
+import eta.core.features as etaf
 import eta.core.image as etai
+import eta.core.learning as etal
 import eta.core.tfutils as etat
 import eta.core.utils as etau
 import eta.core.video as etav
@@ -236,6 +238,88 @@ class ObjectArray(Array):
             Array.is_valid_value(val) and
             all(Object.is_valid_value(o) for o in val)
         )
+
+
+class Config(Object):
+    '''Base class for objects that are serialized instances of
+    `eta.core.config.Config` classes.
+    '''
+    pass
+
+
+class Featurizer(Config):
+    '''Configuration of an `eta.core.features.Featurizer`.
+
+    This types is implemented in ETA by the
+    `eta.core.features.FeaturizerConfig` class.
+    '''
+
+    @staticmethod
+    def is_valid_value(val):
+        try:
+            etaf.FeaturizerConfig(val)
+            return True
+        except:
+            return False
+
+
+class VideoFramesFeaturizer(Featurizer):
+    '''Configuration for an `eta.core.features.VideoFramesFeaturizer`.
+
+    This type is implemented in ETA by the `eta.core.learning.FeaturizerConfig`
+    class.
+    '''
+    pass
+
+
+class Classifier(Config):
+    '''Configuration for an `eta.core.learning.Classifier`.
+
+    This type is implemented in ETA by the `eta.core.learning.ClassifierConfig`
+    class.
+    '''
+
+    @staticmethod
+    def is_valid_value(val):
+        try:
+            etal.ClassifierConfig(val)
+            return True
+        except:
+            return False
+
+
+class ImageClassifier(Classifier):
+    '''Configuration for an `eta.core.learning.ImageClassifier`.
+
+    This type is implemented in ETA by the `eta.core.learning.ClassifierConfig`
+    class.
+    '''
+    pass
+
+
+class VideoFramesClassifier(Classifier):
+    '''Configuration for an `eta.core.learning.VideoFramesClassifier`.
+
+    This type is implemented in ETA by the `eta.core.learning.ClassifierConfig`
+    class.
+    '''
+    pass
+
+
+class ObjectDetector(Config):
+    '''Configuration for an `eta.core.learning.ObjectDetector`.
+
+    This type is implemented in ETA by the
+    `eta.core.learning.ObjectDetectorConfig` class.
+    '''
+
+    @staticmethod
+    def is_valid_value(val):
+        try:
+            etal.ObjectDetectorConfig(val)
+            return True
+        except:
+            return False
 
 
 ###### Data types #############################################################

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -57,33 +57,61 @@ SUPPORTED_VIDEO_FILE_FORMATS = [
 ]
 
 
-def is_supported_video_file(path):
-    '''Determines whether the given file has a supported video type.
-
-    This method does not support videos represented as image sequences (i.e.,
-    it will return False for them).
+def is_supported_video(path):
+    '''Determines whether the given filepath points to a supported video.
 
     Args:
-        path: the path to a video file
+        path: the path to a video, like `/path/to/video.mp4` or
+            `/path/to/frames-%05d.jpg`
 
     Returns:
-        True/False if the file has a supported video type
+        True/False if the path refers to a supported video type
+    '''
+    return is_supported_video_file(path) or is_supported_image_sequence(path)
+
+
+def is_supported_video_file(path):
+    '''Determines whether the given filepath points to a supported video file
+    type.
+
+    Args:
+        path: the path to a video file, like `/path/to/video.mp4`
+
+    Returns:
+        True/False if the path refers to a supported video file type
     '''
     return os.path.splitext(path)[1] in SUPPORTED_VIDEO_FILE_FORMATS
+
+
+def is_supported_image_sequence(path):
+    '''Determines whether the given filepath points to a supported image
+    sequence type.
+
+    Args:
+        path: the path to an image sequence, like `/path/to/frames-%05d.jpg`
+
+    Returns:
+        True/False if the path refers to a supported video file type
+    '''
+    try:
+        _ = path % 1
+        return etai.is_supported_image(path)
+    except TypeError:
+        return False
 
 
 def is_same_video_file_format(path1, path2):
     '''Determines whether the video files have the same supported format.
 
-    This method does not support videos represented as image sequences (i.e.,
-    it will return False for them).
-
     Args:
-        path1: the path to a video file
-        path2: the path to a video file
+        path1: the path to a video
+        path2: the path to a video
+
+    Returns:
+        True/False
     '''
     return (
-        is_supported_video_file(path1) and
+        is_supported_video(path1) and
         os.path.splitext(path1)[1] == os.path.splitext(path2)[1]
     )
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -736,7 +736,7 @@ class VideoLabels(Serializable):
             for frame_attr in frame_attrs:
                 self._validate_frame_attribute(frame_attr)
         self._ensure_frame(frame_number)
-        self.frames[str(frame_number)].add_frame_attributes(frame_attrs)
+        self.frames[frame_number].add_frame_attributes(frame_attrs)
 
     def add_object(self, obj, frame_number):
         '''Adds the object to the video.


### PR DESCRIPTION
This PR does the following things:
- generalizes the interface for classifiers in `eta.core.learning`
- improves the documentation in `eta.core.features`
- fixes some broken windows that I found in the code along the way

Two new classifier interfaces are declared:
- `eta.core.learning.ImageClassifier`: a classifier that classifies single images (or processes an image tensor but returns predictions for each image)
- `eta.core.learning.VideoFramesClassifier`: a classifier that takes a tensor of images and returns a single prediction for the tensor

These abstractions were necessary in order to be concrete enough that modules can know what to do with the classifiers that they are provided (e.g., does the classifier predict on tensors directly or does it classify each image individually?.

In addition, a meta-classifier called `VideoFramesVotingClassifier` that uses an `ImageClassifier` to classify each frame of a video tensor and then majority votes on each attribute to determine the final prediction for the tensor.