### PR TITLE
Visualize frame attributes in a video (visualize_labels module)

### DIFF
--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -314,17 +314,16 @@ def _annotate_object(
     cv2.rectangle(overlay, (bgtlx, bgtly), (bgbrx, bgbry), box_color, -1)
 
     # Construct attribute text
-    attr_msg = ""
-    for attr in obj.attrs.attrs:
-        attr_msg += attr.value.capitalize() + " "
+    attr_msg = ", ".join([attr.value for attr in obj.attrs.attrs])
+
+    attr_msg = attr_msg.strip()
     attr_text_size = font.getsize(attr_msg)
 
     # Draw attribute message background
     abgtlx = objtlx - linewidth + 1
     abgbrx = abgtlx + attr_text_size[0] + 2 * pad[0]
-    abgtly = objbry + linewidth - 1
+    abgtly = objtly + 1
     abgbry = abgtly + attr_text_size[1] + 2 * pad[1]
-    cv2.rectangle(overlay, (abgtlx, abgtly), (abgbrx, abgbry), box_color, -1)
 
     # Overlay translucent box
     img_anno = cv2.addWeighted(overlay, alpha, img, 1 - alpha, 0)

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -295,8 +295,8 @@ def _annotate_object(
 
     # Draw bounding box
     objtlx, objtly = obj.bounding_box.top_left.coords_in(img=img)
-    objbr = obj.bounding_box.bottom_right.coords_in(img=img)
-    cv2.rectangle(overlay, (objtlx, objtly), objbr, box_color, linewidth)
+    objbrx, objbry = obj.bounding_box.bottom_right.coords_in(img=img)
+    cv2.rectangle(overlay, (objtlx, objtly), (objbrx, objbry), box_color, linewidth)
 
     # Draw message background
     bgtlx = objtlx - linewidth + 1
@@ -305,14 +305,30 @@ def _annotate_object(
     bgtly = bgbry - text_size[1] - 2 * pad[1]
     cv2.rectangle(overlay, (bgtlx, bgtly), (bgbrx, bgbry), box_color, -1)
 
+    # Construct attribute text
+    attr_msg = ""
+    for attr in obj.attrs.attrs:
+        attr_msg += attr.value+" "
+    attr_text_size = font.getsize(msg)
+
+    # Draw attribute message background
+    abgtlx = objtlx - linewidth + 1
+    abgbrx = abgtlx + attr_text_size[0] + 2 * pad[0]
+    abgtly = objbry + linewidth - 1
+    abgbry = abgtly + attr_text_size[1] + 2 * pad[1]
+    cv2.rectangle(overlay, (abgtlx, abgtly), (abgbrx, abgbry), box_color, -1)
+
     # Overlay translucent box
     img_anno = cv2.addWeighted(overlay, alpha, img, 1 - alpha, 0)
 
-    # Draw message
+    # Draw messages
     img_pil = Image.fromarray(img_anno)
     draw = ImageDraw.Draw(img_pil)
     txttlx = bgtlx + pad[0]
     txttly = bgtly + pad[1] - 1
     draw.text((txttlx, txttly), msg, font=font, fill=text_color)
+    atxttlx = abgtlx + pad[0]
+    atxttly = abgtly + pad[1] - 1
+    draw.text((atxttlx, atxttly), attr_msg, font=font, fill=text_color)
 
     return np.asarray(img_pil)

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -316,8 +316,8 @@ def _annotate_object(
     # Construct attribute text
     attr_msg = ""
     for attr in obj.attrs.attrs:
-        attr_msg += attr.value+" "
-    attr_text_size = font.getsize(msg)
+        attr_msg += attr.value.capitalize() + " "
+    attr_text_size = font.getsize(attr_msg)
 
     # Draw attribute message background
     abgtlx = objtlx - linewidth + 1

--- a/eta/core/command.py
+++ b/eta/core/command.py
@@ -162,11 +162,14 @@ class BuildCommand(Command):
 
 
 class RunCommand(Command):
-    '''Command-line tool for running ETA modules and pipelines.
+    '''Command-line tool for running ETA pipelines and modules.
 
     Examples:
         # Run the pipeline defined by a PipelineConfig JSON file
         eta run '/path/to/pipeline-config.json'
+
+        # Run the pipeline and force existing module outputs to be overwritten
+        eta run --overwrite '/path/to/pipeline-config.json'
 
         # Run the specified module with the given ModuleConfig JSON file
         eta run --module <module-name> '/path/to/module-config.json'
@@ -181,6 +184,9 @@ class RunCommand(Command):
             "config", nargs="?",
             help="path to a PipelineConfig or ModuleConfig file")
         parser.add_argument(
+            "-o", "--overwrite", action="store_true",
+            help="force overwrite existing module outputs")
+        parser.add_argument(
             "-m", "--module", help="run the module with the given name")
         parser.add_argument(
             "-l", "--last", action="store_true",
@@ -194,19 +200,19 @@ class RunCommand(Command):
             return
 
         if args.config:
-            _run_pipeline(args.config)
+            _run_pipeline(args.config, args.overwrite)
 
         if args.last:
             config = etab.find_last_built_pipeline()
             if config:
-                _run_pipeline(config)
+                _run_pipeline(config, args.overwrite)
             else:
                 logger.info("No built pipelines found...")
 
 
-def _run_pipeline(config):
+def _run_pipeline(config, force_overwrite):
     logger.info("Running ETA pipeline '%s'", config)
-    etap.run(config)
+    etap.run(config, force_overwrite=force_overwrite)
 
     if etau.is_in_root_dir(config, eta.config.config_dir):
         logger.info(

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -928,7 +928,12 @@ class PickledModel(PublishedModel):
 
     def _load(self):
         with open(self.model_path, "rb") as f:
-            return pickle.load(f)
+            try:
+                return pickle.load(f)
+            except UnicodeDecodeError:
+                model = pickle.Unpickler(f, encoding="latin1").load()
+                return model
+                
 
 
 class NpzModelWeights(PublishedModel, dict):

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -49,24 +49,30 @@ PIPELINE_OUTPUT_NAME = "OUTPUT"
 
 def run(
         pipeline_config_path, pipeline_status=None, mark_as_complete=True,
-        rotate_logs=True):
+        rotate_logs=True, force_overwrite=False):
     '''Run the pipeline specified by the PipelineConfig.
 
     Args:
         pipeline_config_path: path to a PipelineConfig file
         pipeline_status: an optional PipelineStatus instance. By default, a
             PipelineStatus object is created that logs its status to the path
-            specified in the provided PipelineConfig (if specified)
+            specified in the provided PipelineConfig
         mark_as_complete: whether to mark the PipelineStatus as complete when
             the pipeline finishes. By default, this is True
         rotate_logs: whether to rotate any existing pipeline log(s) before
             running. By default, this is True
+        force_overwrite: whether to force the pipeline to overwrite any
+            existing outputs by setting the `overwrite` flag of the
+            PipelineConfig. By default, the PipelineConfig's `overwrite` flag
+            is used
 
     Returns:
         True/False whether the pipeline completed successfully
     '''
     # Load pipeline config
     pipeline_config = PipelineConfig.from_json(pipeline_config_path)
+    if force_overwrite:
+        pipeline_config.overwrite = True
 
     # Setup logging
     etal.custom_setup(pipeline_config.logging_config, rotate=rotate_logs)


### PR DESCRIPTION
Editing the `visualize_labels` module in `eta/core` to support frame-level attribute visualizations.