### PR TITLE
Fixing attribute order for ModelManager

### DIFF
--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -994,6 +994,10 @@ class ModelManager(Configurable, Serializable):
         raise NotImplementedError(
             "subclass must implement _download_model()")
 
+    def attributes(self):
+        '''Returns a list of attributes to be serialized.'''
+        return ["type", "config"]
+
     @classmethod
     def from_dict(cls, d):
         '''Builds the ModelManager subclass from a JSON dictionary.'''


### PR DESCRIPTION
This PR will serialize the attributes of `ModelManager` in deterministic order so that we don't have large changes to model manifest files when adding a new model.