### PR TITLE
Fixing falsey parameter bug when building pipelines

### DIFF
--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -428,6 +428,8 @@ class PipelineBuilder(object):
         # Populate module parameters
         for param in itervalues(pmeta.parameters):
             val = _get_param_value(param, self.request)
+            # We specifically omit any parameters that are set to `None` so
+            # that the module's default parameter will be used
             if val is not None:
                 self.module_parameters[param.module][param.name] = val
 

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -428,7 +428,7 @@ class PipelineBuilder(object):
         # Populate module parameters
         for param in itervalues(pmeta.parameters):
             val = _get_param_value(param, self.request)
-            if val:
+            if val is not None:
                 self.module_parameters[param.module][param.name] = val
 
         # Set execution order


### PR DESCRIPTION
This fixes a bug wherein it was not possible to set a parameter to a `falsey` value in a pipeline request. 

The culprit was the difference between `if val` and `if val is not None`...