### PR TITLE
Adding -vsync 0 to default ffmpeg options

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1328,52 +1328,40 @@ def get_stream_info(inpath):
         raise FFprobeError("Unable to get stream info for '%s'" % inpath)
 
 
-def get_encoding_str(inpath, use_ffmpeg=True):
+def get_encoding_str(inpath):
     '''Get the encoding string of the input video.
 
     Args:
         inpath: video path
-        use_ffmpeg: whether to use ffmpeg (True) or OpenCV (False)
     '''
-    r = FFmpegVideoReader(inpath) if use_ffmpeg else OpenCVVideoReader(inpath)
-    with r:
-        return r.encoding_str
+    return VideoMetadata.build_for(inpath).encoding_str
 
 
-def get_frame_rate(inpath, use_ffmpeg=True):
+def get_frame_rate(inpath):
     '''Get the frame rate of the input video.
 
     Args:
         inpath: video path
-        use_ffmpeg: whether to use ffmpeg (True) or OpenCV (False)
     '''
-    r = FFmpegVideoReader(inpath) if use_ffmpeg else OpenCVVideoReader(inpath)
-    with r:
-        return r.frame_rate
+    return VideoMetadata.build_for(inpath).frame_rate
 
 
-def get_frame_size(inpath, use_ffmpeg=True):
+def get_frame_size(inpath):
     '''Get the frame (width, height) of the input video.
 
     Args:
         inpath: video path
-        use_ffmpeg: whether to use ffmpeg (True) or OpenCV (False)
     '''
-    r = FFmpegVideoReader(inpath) if use_ffmpeg else OpenCVVideoReader(inpath)
-    with r:
-        return r.frame_size
+    return VideoMetadata.build_for(inpath).frame_size
 
 
-def get_frame_count(inpath, use_ffmpeg=True):
+def get_frame_count(inpath):
     '''Get the number of frames in the input video.
 
     Args:
         inpath: video path
-        use_ffmpeg: whether to use ffmpeg (True) or OpenCV (False)
     '''
-    r = FFmpegVideoReader(inpath) if use_ffmpeg else OpenCVVideoReader(inpath)
-    with r:
-        return r.total_frame_count
+    return VideoMetadata.build_for(inpath).total_frame_count
 
 
 def get_raw_frame_number(raw_frame_rate, raw_frame_count, fps, sampled_frame):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1423,7 +1423,7 @@ def extract_clip(
     # frames of the clip will be exactly the same as those encountered via
     # other clip-based methods in ETA?
     #
-    in_opts = []
+    in_opts = ["-vsync", "0"]
     if start_time is not None:
         if not isinstance(start_time, six.string_types):
             start_time = "%.3f" % start_time
@@ -1453,7 +1453,7 @@ def extract_clip(
         # Clean up fast output by re-encoding the extracted clip
         # Note that this may not exactly correspond to the slow, accurate
         # implementation above
-        ffmpeg = FFmpeg(in_opts=[], out_opts=[])
+        ffmpeg = FFmpeg(in_opts=["-vsync", "0"], out_opts=[])
         ffmpeg.run(tmp_path, output_path)
 
 
@@ -1501,7 +1501,9 @@ def sample_select_frames(video_path, frames, output_patt=None, fast=False):
         # Sample frames to disk temporarily
         tmp_patt = os.path.join(d, "frame-%d" + ext)
         ss = "+".join(["eq(n\,%d)" % (f - 1) for f in frames])
-        ffmpeg = FFmpeg(out_opts=["-vf", "select='%s'" % ss, "-vsync", "0"])
+        ffmpeg = FFmpeg(
+            in_opts=["-vsync", "0"],
+            out_opts=["-vf", "select='%s'" % ss, "-vsync", "0"])
         ffmpeg.run(video_path, tmp_patt)
 
         if output_patt is not None:
@@ -1975,7 +1977,7 @@ class FFmpegVideoReader(VideoReader):
         if keyframes_only:
             in_opts = ["-skip_frame", "nokey", "-vsync", "0"]
         else:
-            in_opts = None
+            in_opts = ["-vsync", "0"]
 
         self._stream_info = VideoStreamInfo.build_for(inpath)
         self._ffmpeg = FFmpeg(


### PR DESCRIPTION
I haven't been able to find a video that doesn't work without `-vsync 0` , but I went ahead and added it as a default option anyway.

The ffmpeg on my laptop has no problem with a 60fps BDD video before or after this change.

Addresses https://github.com/voxel51/eta/issues/220.