### PR TITLE
Upgrading pylint version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ opencv-python-headless==4.1.0.25
 Pillow==4.2.1
 protobuf==3.6.1
 pycodestyle==2.3.1
-pylint==1.7.4
+pylint==2.3.1
 pysftp==0.2.9
 python-dateutil==2.6.1
 requests==2.21.0


### PR DESCRIPTION
With version 1.7.4 of `pylint`, I get the error message below.  Upgrading fixed the problem.

```python
Traceback (most recent call last):
  File "/path/to/virtual/env/bin/pylint", line 10, in <module>
    sys.exit(run_pylint())
  File "/path/to/virtual/env/lib/python3.6/site-packages/pylint/__init__.py", line 13, in run_pylint
    Run(sys.argv[1:])
  File "/path/to/virtual/env/lib/python3.6/site-packages/pylint/lint.py", line 1302, in __init__
    linter.check(args)
  File "/path/to/virtual/env/lib/python3.6/site-packages/pylint/lint.py", line 726, in check
    self._do_check(files_or_modules)
  File "/path/to/virtual/env/lib/python3.6/site-packages/pylint/lint.py", line 857, in _do_check
    self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
  File "/path/to/virtual/env/lib/python3.6/site-packages/pylint/lint.py", line 936, in check_astroid_module
    walker.walk(ast_node)
  File "/path/to/virtual/env/lib/python3.6/site-packages/pylint/utils.py", line 973, in walk
    self.walk(child)
  File "/path/to/virtual/env/lib/python3.6/site-packages/pylint/utils.py", line 970, in walk
    cb(astroid)
  File "/path/to/virtual/env/lib/python3.6/site-packages/pylint/checkers/variables.py", line 1153, in visit_importfrom
    self._check_module_attrs(node, module, name.split('.'))
  File "/path/to/virtual/env/lib/python3.6/site-packages/pylint/checkers/variables.py", line 1218, in _check_module_attrs
    if module is astroid.YES:
AttributeError: module 'astroid' has no attribute 'YES'
```