### PR TITLE
Formalizing Featurizer interfaces

### DIFF
--- a/docs/python_style_guide.md
+++ b/docs/python_style_guide.md
@@ -69,8 +69,8 @@ import eta.core.video as etav
 Long imports should be implemented with hanging indentation:
 
 ```python
-from eta.core.features import VideoFramesFeaturizer, \
-                              VideoFramesFeaturizerConfig
+from eta.core.features import CachingVideoFeaturizer, \
+                              CachingVideoFeaturizerConfig
 ```
 
 - Names should follow the conventions

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -768,7 +768,7 @@ class CachingVideoFeaturizer(Featurizer):
     frame number. The location of the files on disk is controlled by the
     `backing_manager`. By default, a `RandomBackingManager` is used that writes
     features to a randomly generated subdirectory of `/tmp`. Alternatively,
-    you can manually set the backing directory using `set_backing_dir()`.
+    you can manually set the backing directory with `set_manual_backing_dir()`.
 
     This class provides a `frame_preprocessor` property that allows a
     preprocessing function to be applied to each frame before featurizing it.

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -918,8 +918,14 @@ class CachingVideoFeaturizer(Featurizer):
         return os.path.isfile(path)
 
     def get_feature_paths(self):
-        '''Returns a list of absolute paths to the features on disk.'''
-        return etau.list_files(self.backing_dir, abs_paths=True)
+        '''Returns a list of absolute paths to the features on disk.
+
+        Returns:
+            a list of absolute paths to .npz files
+        '''
+        return [
+            p for p in etau.list_files(self.backing_dir, abs_paths=True)
+            if p.endswith(".npz")]
 
     def get_featurized_frame_path(self, frame_number):
         '''Returns the feature path on disk for the given frame number.

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -745,6 +745,7 @@ class CachingVideoFeaturizerConfig(Config):
             to use to embed the video frames
         backing_manager: a BackingManagerConfig specifying the backing manager
             to use
+        frames: a string specifying the specific frames to featurize
         delete_backing_directory: whether to delete the backing directory
             when the featurizer is stopped
     '''
@@ -756,6 +757,7 @@ class CachingVideoFeaturizerConfig(Config):
             d, "backing_manager", BackingManagerConfig, default=None)
         if self.backing_manager is None:
             self.backing_manager = BackingManagerConfig.default()
+        self.frames = self.parse_string(d, "frames", default=None)
         self.delete_backing_directory = self.parse_bool(
             d, "delete_backing_directory", default=True)
 
@@ -888,6 +890,9 @@ class CachingVideoFeaturizer(Featurizer):
             self.stop()
 
     def _featurize(self, video_path, frames):
+        if frames is None:
+            frames = self.config.frames
+
         self._backing_manager.set_video_path(video_path)
         with etav.FFmpegVideoReader(video_path, frames=frames) as vr:
             for img in vr:

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -766,11 +766,11 @@ class CachingVideoFeaturizer(Featurizer):
     '''Meta-featurizer that uses an ImageFeaturizer to maintain a cache of the
     feature vectors for the frames of a video.
 
-    Featurized frames are stored on disk as compressed pickle files indexed by
-    frame number. The location of the files on disk is controlled by the
-    `backing_manager`. By default, a `RandomBackingManager` is used that writes
-    features to a randomly generated subdirectory of `/tmp`. Alternatively,
-    you can manually set the backing directory with `set_manual_backing_dir()`.
+    Featurized frames are stored on disk as .npz files indexed by frame number.
+    The location of the files on disk is controlled by the `backing_manager`.
+    By default, a `RandomBackingManager` is used that writes features to a
+    randomly generated subdirectory of `/tmp`. Alternatively, you can manually
+    set the backing directory with `set_manual_backing_dir()`.
 
     This class provides a `frame_preprocessor` property that allows a
     preprocessing function to be applied to each frame before featurizing it.

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -635,6 +635,35 @@ class BackingManager(Configurable):
         etau.delete_dir(self.backing_dir)
 
 
+class ManualBackingManagerConfig(Config):
+    '''Configuration settings for a RandomBackingManager.
+
+    Attributes:
+        basedir: the base directory in which to store features
+    '''
+
+    def __init__(self, d):
+        self.basedir = self.parse_string(
+            d, "basedir", default="/tmp/eta.backing")
+
+
+class ManualBackingManager(BackingManager):
+    '''Backing manager that stores features directly in the base directory.'''
+
+    def __init__(self, config):
+        '''Creates the RandomBackingManager instance.
+
+        Args:
+            config: a RandomBackingManagerConfig instance.
+        '''
+        self.validate(config)
+        self.config = config
+
+    @property
+    def backing_dir(self):
+        return self.config.basedir
+
+
 class RandomBackingManagerConfig(Config):
     '''Configuration settings for a RandomBackingManager.
 
@@ -668,35 +697,6 @@ class RandomBackingManager(BackingManager):
     def _set_video_path(self, video_path):
         self._backing_dir = tempfile.mkdtemp(
             dir=self.config.basedir, prefix="eta.backing.")
-
-
-class ManualBackingManagerConfig(Config):
-    '''Configuration settings for a RandomBackingManager.
-
-    Attributes:
-        basedir: the base directory in which to store features
-    '''
-
-    def __init__(self, d):
-        self.basedir = self.parse_string(
-            d, "basedir", default="/tmp/eta.backing")
-
-
-class ManualBackingManager(BackingManager):
-    '''Backing manager that stores features directly in the base directory.'''
-
-    def __init__(self, config):
-        '''Creates the RandomBackingManager instance.
-
-        Args:
-            config: a RandomBackingManagerConfig instance.
-        '''
-        self.validate(config)
-        self.config = config
-
-    @property
-    def backing_dir(self):
-        return self.config.basedir
 
 
 class PatternBackingManagerConfig(Config):

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -99,7 +99,7 @@ class Featurizer(Configurable):
 
     ```
     with <My>Featurizer(...) as f:
-        f.featurize(data)
+        v = f.featurize(data)
     ```
     '''
 
@@ -119,24 +119,24 @@ class Featurizer(Configurable):
         '''Returns the dimension of the features extracted by this
         Featurizer.
         '''
-        raise NotImplementedError("subclass must implement dim().")
+        raise NotImplementedError("subclass must implement dim()")
 
     def start(self, warn_on_restart=True, keep_alive=True):
         '''Start method that handles any necessary setup to prepare the
         Featurizer for use.
 
         This method can be explicitly called by users. If it is not called
-        manually, it will be called each time `featurize` is called.
+        manually, it will be called each time `featurize()` is called.
 
         Args:
-            warn_on_restart: whether to generate a warning if `start` is
+            warn_on_restart: whether to generate a warning if `start()` is
                 called when the Featurizer is already started. The default
                 value is True
             keep_alive: whether to keep the Featurizer alive (i.e. not to call
-                `stop`) after a each `featurize` call
+                `stop()`) after a each `featurize()` call
         '''
         if warn_on_restart and self._is_started:
-            logger.warning("Featurizer.start() called when already started.")
+            logger.warning("Featurizer.start() called when already started")
 
         if self._is_started:
             return
@@ -146,9 +146,11 @@ class Featurizer(Configurable):
         self._start()
 
     def _start(self):
-        '''The backend implementation that is called when the public `start`
-        method is called. Subclasses that require startup configuration should
-        override this method.
+        '''The backend implementation that is called when the public `start()`
+        method is called.
+
+        Subclasses that require startup configuration should implement this
+        method.
         '''
         pass
 
@@ -157,9 +159,9 @@ class Featurizer(Configurable):
         is complete.
 
         This method can be explicitly called by users, and, in fact, it must
-        be called by users who called `start` themselves. If `start` was not
-        called manually or `keep_alive` was set to False, then this method will
-        be invoked at the end of each call to `featurize`.
+        be called by users who called `start()` themselves. If `start()` was
+        not called manually or `keep_alive` was set to False, then this method
+        will be invoked at the end of each call to `featurize()`.
         '''
         if not self._is_started:
             return
@@ -169,9 +171,11 @@ class Featurizer(Configurable):
         self._keep_alive = False
 
     def _stop(self):
-        '''The backend implementation that is called when the public `stop`
-        method is called. Subclasses that require cleanup after featurization
-        should override this method.
+        '''The backend implementation that is called when the public `stop()`
+        method is called.
+
+        Subclasses that require cleanup after featurization should implement
+        this method.
         '''
         pass
 
@@ -185,11 +189,11 @@ class Featurizer(Configurable):
             the feature vector
         '''
         self.start(warn_on_restart=False, keep_alive=False)
-        fv = self._featurize(data)
+        v = self._featurize(data)
         if self._keep_alive is False:
             self.stop()
 
-        return fv
+        return v
 
     def _featurize(self, data):
         '''The backend implementation of the feature extraction routine.

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -696,6 +696,7 @@ class RandomBackingManager(BackingManager):
         return self._backing_dir
 
     def _set_video_path(self, video_path):
+        etau.ensure_dir(self.config.basedir)
         self._backing_dir = tempfile.mkdtemp(
             dir=self.config.basedir, prefix="eta.backing.")
 

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -937,7 +937,7 @@ class CachingVideoFeaturizer(Featurizer):
     def _read_feature(path):
         try:
             return np.load(path)["v"]
-        except OSError:
+        except (IOError, OSError):
             raise FeaturizedFrameNotFoundError(
                 "Feature vector not found at '%s'" % path)
 

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -632,6 +632,7 @@ class BackingManager(Configurable):
 
     def flush(self):
         '''Deletes the backing directory.'''
+        logger.info("Deleting backing directory '%s'", self.backing_dir)
         etau.delete_dir(self.backing_dir)
 
 
@@ -783,7 +784,11 @@ class CachingVideoFeaturizer(Featurizer):
         super(CachingVideoFeaturizer, self).__init__()
 
         self._frame_featurizer = self.config.frame_featurizer.build()
+        logger.info("Loaded featurizer %s", type(self._frame_featurizer))
+
         self._backing_manager = self.config.backing_manager.build()
+        logger.info("Loaded backing manager %s", type(self._backing_manager))
+
         self._frame_preprocessor = None
         self._frame_string = "%08d.npz"
 
@@ -815,9 +820,6 @@ class CachingVideoFeaturizer(Featurizer):
     def _stop(self):
         self._frame_featurizer.stop()
         if self.config.delete_backing_directory:
-            logger.info(
-                "Deleting backing directory '%s'",
-                self.config.delete_backing_directory)
             self._backing_manager.flush()
 
     def featurize(self, video_path, frames=None):

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -530,7 +530,7 @@ class RandFeaturizerConfig(Config):
         self.dim = self.parse_number(d, "dim", default=1024)
 
 
-class RandFeaturizer(ImageFeaturizer):
+class RandFeaturizer(ImageFeaturizer, VideoFramesFeaturizer, VideoFeaturizer):
     '''Featurizer that returns a feature vector with uniformly random entries
     regardless of the input data.
     '''

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -563,6 +563,7 @@ class FeaturizedFrameNotFoundError(OSError):
     pass
 
 
+# @todo rename this
 class VideoFramesFeaturizerConfig(Config):
     '''Configuration settings for a VideoFramesFeaturizer.'''
 
@@ -580,6 +581,7 @@ class VideoFramesFeaturizerConfig(Config):
         self.frames = self.parse_string(d, "frames", default="*")
 
 
+# @todo rename this
 class VideoFramesFeaturizer(Featurizer):
     '''Class that encapsulates featurizing the frames of a video.
 
@@ -615,10 +617,6 @@ class VideoFramesFeaturizer(Featurizer):
 
         "manual"
             the provided `backing_path` is used verbatim
-
-    @todo Refactor the backing managers into standalone Configurable classes
-
-    @todo: Generalize to allow non npz-able features
     '''
 
     def __init__(self, config):

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -637,7 +637,7 @@ class BackingManager(Configurable):
 
 
 class ManualBackingManagerConfig(Config):
-    '''Configuration settings for a RandomBackingManager.
+    '''Configuration settings for a ManualBackingManager.
 
     Attributes:
         backing_dir: the backing directory in which to store features
@@ -652,10 +652,10 @@ class ManualBackingManager(BackingManager):
     '''Backing manager that stores features directly in the base directory.'''
 
     def __init__(self, config):
-        '''Creates the RandomBackingManager instance.
+        '''Creates the ManualBackingManager instance.
 
         Args:
-            config: a RandomBackingManagerConfig instance.
+            config: a ManualBackingManager instance.
         '''
         self.validate(config)
         self.config = config

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -767,7 +767,8 @@ class CachingVideoFeaturizer(Featurizer):
     Featurized frames are stored on disk as compressed pickle files indexed by
     frame number. The location of the files on disk is controlled by the
     `backing_manager`. By default, a `RandomBackingManager` is used that writes
-    features to a randomly generated subdirectory of `/tmp`.
+    features to a randomly generated subdirectory of `/tmp`. Alternatively,
+    you can manually set the backing directory using `set_backing_dir()`.
 
     This class provides a `frame_preprocessor` property that allows a
     preprocessing function to be applied to each frame before featurizing it.
@@ -799,6 +800,7 @@ class CachingVideoFeaturizer(Featurizer):
 
         self._backing_manager = self.config.backing_manager.build()
         logger.info("Loaded backing manager %s", type(self._backing_manager))
+        self._manual_backing_dir = None
 
         self._frame_preprocessor = None
         self._frame_string = "%08d.npz"
@@ -826,8 +828,30 @@ class CachingVideoFeaturizer(Featurizer):
 
     @property
     def backing_dir(self):
-        '''Returns the current backing directory.'''
+        '''The current backing directory.
+
+        If a manual backing directory was set via `set_manual_backing_dir`, it
+        will be returned here.
+        '''
+        if self._manual_backing_dir is not None:
+            return self._manual_backing_dir
         return self._backing_manager.backing_dir
+
+    def set_manual_backing_dir(self, manual_backing_dir):
+        '''Manually sets the backing directory.
+
+        If a manual backing directory is set, it will take precedence over the
+        backing manager's directory. To remove this manual setting, call
+        `clear_manual_backing_dir()`.
+
+        Args:
+            manual_backing_dir: the manual backing directory to use
+        '''
+        self._manual_backing_dir = manual_backing_dir
+
+    def clear_manual_backing_dir(self):
+        '''Clears the manual backing directory, if necessary.'''
+        self._manual_backing_dir = None
 
     @property
     def frame_preprocessor(self):

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -640,12 +640,12 @@ class ManualBackingManagerConfig(Config):
     '''Configuration settings for a RandomBackingManager.
 
     Attributes:
-        basedir: the base directory in which to store features
+        backing_dir: the backing directory in which to store features
     '''
 
     def __init__(self, d):
-        self.basedir = self.parse_string(
-            d, "basedir", default="/tmp/eta.backing")
+        self.backing_dir = self.parse_string(
+            d, "backing_dir", default="/tmp/eta.backing")
 
 
 class ManualBackingManager(BackingManager):
@@ -662,7 +662,7 @@ class ManualBackingManager(BackingManager):
 
     @property
     def backing_dir(self):
-        return self.config.basedir
+        return self.config.backing_dir
 
 
 class RandomBackingManagerConfig(Config):

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -382,8 +382,25 @@ class ImageLabels(Serializable):
         return _attrs
 
     @classmethod
+    def from_video_frame_labels(
+            cls, video_frame_labels, filename=None, metadata=None):
+        '''Constructs an ImageLabels from a VideoFrameLabels.
+
+        Args:
+            video_frame_labels: a VideoFrameLabels instance
+            filename: an optional filename for the image
+            metadata: an optional ImageMetadata instance for the image
+
+        Returns:
+            a VideoFrameLabels instance
+        '''
+        return cls(
+            filename=filename, metadata=metadata,
+            attrs=video_frame_labels.attrs, objects=video_frame_labels.objects)
+
+    @classmethod
     def from_dict(cls, d):
-        '''Constructs a ImageLabels from a JSON dictionary.'''
+        '''Constructs an ImageLabels from a JSON dictionary.'''
         filename = d.get("filename", None)
 
         metadata = d.get("metadata", None)

--- a/eta/core/learning.py
+++ b/eta/core/learning.py
@@ -187,6 +187,9 @@ class ModelConfig(Config):
     def build(self):
         '''Factory method that builds the Model instance from the config
         specified by this class.
+
+        Returns:
+            a Model instance
         '''
         return self._model_cls(self.config)
 

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -327,9 +327,8 @@ class VideoFeaturizer(Featurizer):
             return False
 
 
-# @todo rename this
-class VideoFramesFeaturizer(Featurizer):
-    '''Configuration for an `eta.core.features.VideoFramesFeaturizer`.'''
+class CachingVideoFeaturizer(Featurizer):
+    '''Configuration for an `eta.core.features.CachingVideoFeaturizer`.'''
     pass
 
 

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -327,11 +327,6 @@ class VideoFeaturizer(Featurizer):
             return False
 
 
-class CachingVideoFeaturizer(Featurizer):
-    '''Configuration for an `eta.core.features.CachingVideoFeaturizer`.'''
-    pass
-
-
 class Model(Config):
     '''Configuration for an `eta.core.learning.Model`.
 

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -269,12 +269,67 @@ class Featurizer(Config):
             return False
 
 
-class VideoFramesFeaturizer(Featurizer):
-    '''Configuration for an `eta.core.features.VideoFramesFeaturizer`.
+class ImageFeaturizer(Featurizer):
+    '''Configuration of an `eta.core.features.ImageFeaturizer`.
 
-    This type is implemented in ETA by the `eta.core.learning.FeaturizerConfig`
-    class.
+    This types is implemented in ETA by the
+    `eta.core.features.ImageFeaturizerConfig` class.
     '''
+
+    @staticmethod
+    def is_valid_value(val):
+        try:
+            etaf.ImageFeaturizerConfig(val)
+            return True
+        except Exception as e:
+            logger.error(
+                "An error occured while parsing the ImageFeaturizer value")
+            logger.error(e, exc_info=True)
+            return False
+
+
+class VideoFramesFeaturizer(Featurizer):
+    '''Configuration of an `eta.core.features.VideoFramesFeaturizer`.
+
+    This types is implemented in ETA by the
+    `eta.core.features.VideoFramesFeaturizerConfig` class.
+    '''
+
+    @staticmethod
+    def is_valid_value(val):
+        try:
+            etaf.VideoFramesFeaturizerConfig(val)
+            return True
+        except Exception as e:
+            logger.error(
+                "An error occured while parsing the VideoFramesFeaturizer "
+                "value")
+            logger.error(e, exc_info=True)
+            return False
+
+
+class VideoFeaturizer(Featurizer):
+    '''Configuration of an `eta.core.features.VideoFeaturizer`.
+
+    This types is implemented in ETA by the
+    `eta.core.features.VideoFeaturizerConfig` class.
+    '''
+
+    @staticmethod
+    def is_valid_value(val):
+        try:
+            etaf.VideoFeaturizerConfig(val)
+            return True
+        except Exception as e:
+            logger.error(
+                "An error occured while parsing the VideoFeaturizer value")
+            logger.error(e, exc_info=True)
+            return False
+
+
+# @todo rename this
+class VideoFramesFeaturizer(Featurizer):
+    '''Configuration for an `eta.core.features.VideoFramesFeaturizer`.'''
     pass
 
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -943,20 +943,29 @@ def multiglob(*patterns, **kwargs):
         glob.iglob(root + pattern) for pattern in patterns)
 
 
-def list_files(dir_path):
+def list_files(dir_path, abs_paths=False):
     '''Lists the files in the given directory, sorted alphabetically and
     excluding directories and hidden files.
 
     Args:
         dir_path: the path to the directory to list
+        abs_paths: whether to return the absolute paths to the files. By
+            default, this is False
 
     Returns:
-        a sorted list of the non-hidden files in the directory
+        a sorted list of the non-hidden filenames (or filepaths) in the
+            directory
     '''
-    return sorted(
+    files = sorted(
         f for f in os.listdir(dir_path)
         if os.path.isfile(os.path.join(dir_path, f)) and not f.startswith(".")
     )
+
+    if abs_paths:
+        basedir = os.path.abspath(os.path.realpath(dir_path))
+        files = [os.path.join(basedir, f) for f in files]
+
+    return files
 
 
 def parse_pattern(patt):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2006,7 +2006,7 @@ class VideoReader(object):
                 frames = "1-%d" % self.total_frame_count
             self.frames = frames
             self._ranges = FrameRanges.from_str(frames)
-        elif isinstance(frames, list):
+        elif isinstance(frames, (list, tuple)):
             # Frames list
             self._ranges = FrameRanges.from_list(frames)
             self.frames = self._ranges.to_str()
@@ -2830,7 +2830,7 @@ class FrameRanges(object):
             FrameRangesError: if the frames string is invalid
         '''
         ranges = []
-        for r in frames_str.split(','):
+        for r in frames_str.split(","):
             if r:
                 fr = FrameRange.from_str(r)
                 ranges.append((fr.first, fr.last))
@@ -2918,7 +2918,7 @@ class FrameRange(object):
             FrameRangeError: if the frame range string is invalid
         '''
         try:
-            v = list(map(int, frames_str.split('-')))
+            v = list(map(int, frames_str.split("-")))
             return cls(v[0], v[-1])
         except ValueError:
             raise FrameRangeError(

--- a/eta/modules/embed_vgg16.json
+++ b/eta/modules/embed_vgg16.json
@@ -10,23 +10,30 @@
         {
             "name": "video_path",
             "type": "eta.core.types.Video",
-            "description": "The input video",
+            "description": "the input video",
             "required": true
         }
     ],
     "outputs": [
         {
-            "name": "backing_path",
+            "name": "backing_dir",
             "type": "eta.core.types.Directory",
-            "description": "The directory in which to write the embeddings",
+            "description": "the directory to write the embeddings",
             "required": true
         }
     ],
     "parameters": [
         {
+            "name": "vgg16",
+            "type": "eta.core.types.Config",
+            "description": "an optional VGG16FeaturizerConfig describing the VGG16Featurizer to use",
+            "required": false,
+            "default": null
+        },
+        {
             "name": "crop_box",
-            "type": "eta.core.types.Object",
-            "description": "A region of interest of each frame to extract before embedding",
+            "type": "eta.core.types.Config",
+            "description": "an optional region of interest to extract from each frame before embedding",
             "required": false,
             "default": null
         }

--- a/examples/README.md
+++ b/examples/README.md
@@ -101,7 +101,7 @@ python embed_image_direct.py
 # Image embedding using `eta.core.vgg16.VGG16Featurizer`
 python embed_image.py
 
-# Video embedding using `eta.core.features.VideoFramesFeaturizer`
+# Video embedding using `eta.core.features.CachingVideoFeaturizer`
 python embed_video.py
 
 # Video embedding using the `embed_vgg16` module

--- a/examples/demo_embed_vgg16/README.md
+++ b/examples/demo_embed_vgg16/README.md
@@ -10,8 +10,8 @@ capabilities supported in ETA.
     VGG-16 feature space using a `VGG16Featurizer`
 - `embed_image_direct.py`: another example showing how to manually embed an
     image into the VGG-16 feature space using the `VGG16` class itself
-- `embed_video.py`: an example of using `VGG16Featurizer` to embed each frame
-    of a video
+- `embed_video.py`: an example of using `CachingVideoFeaturizer` to embed each
+    frame of a video via `VGG16Featurizer`
 - `embed_vgg16_module-config.json`: an example module config file to execute
     the `embed_vgg16` ETA module
 - `embed_vgg16_module.bash`: a bash script to run the `embed_vgg16` module

--- a/examples/demo_embed_vgg16/embed_vgg16_module-config.json
+++ b/examples/demo_embed_vgg16/embed_vgg16_module-config.json
@@ -1,11 +1,11 @@
 {
     "data": [
         {
-            "backing_path": "out/eta-backing/embed/1",
+            "backing_dir": "out/eta-backing/embed/1",
             "video_path": "../data/water-20frames/%05d.png"
         },
         {
-            "backing_path": "out/eta-backing/embed/2",
+            "backing_dir": "out/eta-backing/embed/2",
             "video_path": "../data/water-20frames/%05d.png"
         }
     ],

--- a/examples/demo_embed_vgg16/embed_video-config.json
+++ b/examples/demo_embed_vgg16/embed_video-config.json
@@ -1,11 +1,15 @@
 {
     "video_path": "../data/water-20frames/%05d.png",
-    "video_frames_featurizer": {
-        "backing_path": "out/eta-backing",
-        "backing_manager": "manual",
+    "caching_video_featurizer": {
         "frame_featurizer": {
-            "type": "eta.core.vgg16.VGG16Featurizer",
-            "config": {}
-        }
+            "type": "eta.core.vgg16.VGG16Featurizer"
+        },
+        "backing_manager": {
+            "type": "eta.core.features.ManualBackingManager",
+            "config": {
+                "backing_dir": "out/eta-backing"
+            }
+        },
+        "delete_backing_directory": false
     }
 }

--- a/examples/demo_embed_vgg16/embed_video.py
+++ b/examples/demo_embed_vgg16/embed_video.py
@@ -30,11 +30,9 @@ import sys
 
 from eta.core.config import Config
 import eta.core.features as etaf
-import eta.core.log as etal
 
 
 logger = logging.getLogger(__name__)
-etal.basic_setup(level=logging.DEBUG)
 
 
 class EmbedVideoConfig(Config):


### PR DESCRIPTION
This PR addresses https://github.com/voxel51/eta/issues/235.

Change log
- Adding `ImageFeaturizer`, `VideoFramesFeaturizer`, and `VideoFeaturizer` interfaces to `eta.core.features` that encapsulate the various image/tensor/video contracts that featurizers can use
- replacing the old `eta.core.features.VideoFramesFeaturizer` with a new ` eta.core.features.CachingVideoFeaturizer` class. `CachingVideoFeaturizer` has the same basic functionality as the former `VideoFramesFeaturizer` class with the addition of improved functionality for accessing the features on disk. Also formalizes the `BackingManager` interface
- updating all existing featurizers in ETA to use the appropriate `ImageFeaturizer`, `VideoFramesFeaturizer`, and `VideoFeaturizer` interfaces
- updating the video embedding examples in `examples/demo_embed_vgg16` to use the new `CachingVideoFeaturizer` class
