### PR TITLE
ImageMetadata.build_for() fix for single channel images

### DIFF
--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -759,7 +759,7 @@ class ImageMetadata(Serializable):
         img = read(filepath, include_alpha=True)
         return cls(
             frame_size=to_frame_size(img=img),
-            num_channels=img.shape[2],
+            num_channels=img.shape[2] if len(img.shape) > 2 else 1,
             size_bytes=os.path.getsize(filepath),
             mime_type=etau.guess_mime_type(filepath),
         )


### PR DESCRIPTION
The shape tuple does not have a 3rd parameter when it is just a 2D matrix, as is the case for single channel images.
Returns 1 in this case to correctly report the number of channels.