### PR TITLE
Imagemetadata: fix for single channel images

### DIFF
--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -756,10 +756,10 @@ class ImageMetadata(Serializable):
         Returns:
             an ImageMetadata instance
         '''
-        img = read(filepath, include_alpha=True)
+        img = read(filepath)
         return cls(
             frame_size=to_frame_size(img=img),
-            num_channels=img.shape[2],
+            num_channels=img.shape[2] if len(img.shape) > 2 else 1,
             size_bytes=os.path.getsize(filepath),
             mime_type=etau.guess_mime_type(filepath),
         )

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -756,7 +756,7 @@ class ImageMetadata(Serializable):
         Returns:
             an ImageMetadata instance
         '''
-        img = read(filepath)
+        img = read(filepath, include_alpha=True)
         return cls(
             frame_size=to_frame_size(img=img),
             num_channels=img.shape[2] if len(img.shape) > 2 else 1,


### PR DESCRIPTION
Simple fix for single channel images returning the correct number of channels when shape is not 3D.