### PR TITLE
Division by zero: frame_number_to_timestamp

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -167,7 +167,10 @@ def frame_number_to_timestamp(frame_number, total_frame_count, duration):
     Returns:
         the timestamp (in seconds) of the given frame number in the video
     '''
-    alpha = (frame_number - 1) / (total_frame_count - 1)
+    if total_frame_count == 1:
+        alpha = 0
+    else:
+        alpha = (frame_number - 1) / (total_frame_count - 1)
     return alpha * duration
 
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -168,9 +168,8 @@ def frame_number_to_timestamp(frame_number, total_frame_count, duration):
         the timestamp (in seconds) of the given frame number in the video
     '''
     if total_frame_count == 1:
-        alpha = 0
-    else:
-        alpha = (frame_number - 1) / (total_frame_count - 1)
+        return 0
+    alpha = (frame_number - 1) / (total_frame_count - 1)
     return alpha * duration
 
 


### PR DESCRIPTION
Division by zero is occurring for single frame videos in`frame_number_to_timestamp`. I do not see any other cases of division like this (at least in `video.py`).

It's odd to even be processing single frame videos, but they're there. Who knew.