### PR TITLE
Adding copy for BuilderDataRecord

### DIFF
--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1273,8 +1273,8 @@ class BuilderImageDataset(BuilderDataset):
 class BuilderVideoDataset(BuilderDataset):
     '''A BuilderDataset for videos.'''
 
-    def __init__(self, schema=None):
-        super(BuilderVideoDataset, self).__init__(BuilderVideoRecord, schema)
+    def __init__(self, record_cls=BuilderVideoRecord, schema=None):
+        super(BuilderVideoDataset, self).__init__(record_cls, schema)
 
 
 class DatasetTransformer(object):


### PR DESCRIPTION
I'm proposing that we only use a `record.copy()` method within transformations when creating new records (from old ones). This allows for greater flexibility in `BuilderRecord` subclasses.