### PR TITLE
Omitting falsey attributes field from DetectedObject

### DIFF
--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -65,7 +65,7 @@ class DetectedObject(Serializable, HasBoundingBox):
         self.score = score
         self.frame_number = frame_number
         self.index_in_frame = index_in_frame
-        self.attrs = attrs
+        self.attrs = attrs or AttributeContainer()
         self._meta = None  # Usable by clients to store temporary metadata
 
     @property
@@ -79,28 +79,22 @@ class DetectedObject(Serializable, HasBoundingBox):
 
     def add_attribute(self, attr):
         '''Adds the Attribute to the object.'''
-        if not self.has_attributes:
-            self.attrs = AttributeContainer()
         self.attrs.add(attr)
 
     def add_attributes(self, attrs):
         '''Adds the AttributeContainer of attributes to the object.'''
-        if not self.has_attributes:
-            self.attrs = AttributeContainer()
         self.attrs.add_container(attrs)
 
     def attributes(self):
-        '''Returns the list of attributes to serialize.
-
-        Optional attributes that were not provided (e.g. are None) are omitted
-        from this list.
-        '''
-        _attrs = [
-            "label", "bounding_box", "confidence", "index", "score",
-            "frame_number", "index_in_frame", "attrs"
-        ]
-        # Exclude attributes that are None
-        return [a for a in _attrs if getattr(self, a) is not None]
+        '''Returns the list of attributes to serialize.'''
+        _attrs = ["label", "bounding_box"]
+        _optional_attrs = [
+            "confidence", "index", "score", "frame_number", "index_in_frame"]
+        _attrs.extend(
+            [a for a in _optional_attrs if getattr(self, a) is not None])
+        if self.attrs:
+            _attrs.append("attrs")
+        return _attrs
 
     @classmethod
     def from_dict(cls, d):


### PR DESCRIPTION
This is cosmetic, but now the `attrs` field will be omitted when serializing `DetectedObject`s that do not contain any attributes.

This follows a design principle of omitting falsey fields when serializing to save disk space.