### PR TITLE
Fixed bug in `__iter__()` method of Set class

### DIFF
--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -519,7 +519,8 @@ class Set(Serializable):
         return key in self.__elements__
 
     def __iter__(self):
-        return itervalues(self.__elements__)
+        for v in itervalues(self.__elements__):
+            yield v
 
     def __len__(self):
         return len(self.__elements__)

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -519,8 +519,7 @@ class Set(Serializable):
         return key in self.__elements__
 
     def __iter__(self):
-        for v in itervalues(self.__elements__):
-            yield v
+        return iter(itervalues(self.__elements__))
 
     def __len__(self):
         return len(self.__elements__)


### PR DESCRIPTION
`itervalues()` does not return an iterator.