### PR TITLE
process method for Models

### DIFF
--- a/eta/core/learning.py
+++ b/eta/core/learning.py
@@ -302,7 +302,7 @@ class VideoFramesModel(Model):
             imgs: a list (or d x ny x nx x 3 tensor) of images to process
 
         Returns:
-            an `eta.core.image.VideoLabels` instance containing the labels
+            an `eta.core.video.VideoLabels` instance containing the labels
                 generated for the given tensor of images
         '''
         raise NotImplementedError("subclasses must implement process()")
@@ -502,7 +502,7 @@ class VideoFramesClassifier(Classifier, VideoFramesModel):
             imgs: a list (or d x ny x nx x 3 tensor) of images to process
 
         Returns:
-            an `eta.core.image.VideoLabels` instance containing the labels
+            an `eta.core.video.VideoLabels` instance containing the labels
                 generated for the given tensor of images
         '''
         labels = etav.VideoLabels()
@@ -724,7 +724,7 @@ class VideoFramesObjectDetector(Detector, VideoFramesModel):
             imgs: a list (or d x ny x nx x 3 tensor) of images to process
 
         Returns:
-            an `eta.core.image.VideoLabels` instance containing the labels
+            an `eta.core.video.VideoLabels` instance containing the labels
                 generated for the given tensor of images
         '''
         labels = etav.VideoLabels()

--- a/eta/core/learning.py
+++ b/eta/core/learning.py
@@ -466,7 +466,7 @@ class VideoFramesClassifierConfig(ClassifierConfig):
         self._validate_type(VideoFramesClassifier)
 
 
-class VideoFramesClassifier(Classifier):
+class VideoFramesClassifier(Classifier, VideoFramesModel):
     '''Base class for classifiers that operate directly on videos represented
     as tensors of images.
 
@@ -688,7 +688,7 @@ class VideoFramesObjectDetectorConfig(DetectorConfig):
         self._validate_type(VideoFramesObjectDetector)
 
 
-class VideoFramesObjectDetector(Detector):
+class VideoFramesObjectDetector(Detector, VideoFramesModel):
     '''Base class for detectors that operate directly on videos
     represented as tensors of images.
 

--- a/eta/core/learning.py
+++ b/eta/core/learning.py
@@ -21,8 +21,10 @@ from builtins import *
 import logging
 
 from eta.core.config import Config, ConfigError, Configurable
+import eta.core.image as etai
 import eta.core.models as etam
 import eta.core.utils as etau
+import eta.core.video as etav
 
 
 logger = logging.getLogger(__name__)
@@ -357,7 +359,7 @@ class ImageClassifierConfig(ClassifierConfig):
         self._validate_type(ImageClassifier)
 
 
-class ImageClassifier(Classifier):
+class ImageClassifier(Classifier, ImageModel):
     '''Base class for classifiers that operate on single images.
 
     `ImageClassifier`s may output single or multiple labels per image.
@@ -370,6 +372,11 @@ class ImageClassifier(Classifier):
     perform any necessary setup and teardown, e.g., operating a `Featurizer`
     that featurizes the input images.
     '''
+
+    def process(self, img):
+        labels = etai.ImageLabels()
+        labels.add_image_attributes(self.predict(img))
+        return labels
 
     def predict(self, img):
         '''Peforms prediction on the given image.
@@ -459,7 +466,7 @@ class VideoClassifierConfig(ClassifierConfig):
         self._validate_type(VideoClassifier)
 
 
-class VideoClassifier(Classifier):
+class VideoClassifier(Classifier, VideoModel):
     '''Base class for classifiers that operate on entire videos.
 
     `VideoClassifier`s may output single or multiple (video-level) labels per
@@ -471,6 +478,11 @@ class VideoClassifier(Classifier):
     perform any necessary setup and teardown, e.g., operating a `Featurizer`
     that featurizes the frames of the input video.
     '''
+
+    def process(self, img):
+        labels = etai.VideoLabels()
+        labels.add_video_attributes(self.predict(img))
+        return labels
 
     def predict(self, video_path):
         '''Peforms prediction on the given video.
@@ -537,7 +549,7 @@ class ObjectDetectorConfig(DetectorConfig):
         self._validate_type(ObjectDetector)
 
 
-class ObjectDetector(Detector):
+class ObjectDetector(Detector, ImageModel):
     '''Base class for detectors that operate on single images.
 
     `ObjectDetector`s may output single or multiple detections per image.
@@ -550,6 +562,11 @@ class ObjectDetector(Detector):
     perform any necessary setup and teardown, e.g., operating a `Featurizer`
     that featurizes the input images.
     '''
+
+    def process(self, img):
+        labels = etai.ImageLabels()
+        labels.add_objects(self.detect(img))
+        return labels
 
     def detect(self, img):
         '''Detects objects in the given image.

--- a/eta/core/learning.py
+++ b/eta/core/learning.py
@@ -507,8 +507,7 @@ class VideoFramesClassifier(Classifier, VideoFramesModel):
         '''
         labels = etav.VideoLabels()
         attrs = self.predict(imgs)
-        for idx, imgs in enumerate(imgs):
-            frame_number = idx + 1
+        for frame_number, imgs in enumerate(imgs, 1):
             frame_labels = etav.VideoFrameLabels(frame_number, attrs=attrs)
             labels.add_frame(frame_labels)
         return labels
@@ -728,11 +727,9 @@ class VideoFramesObjectDetector(Detector, VideoFramesModel):
                 generated for the given tensor of images
         '''
         labels = etav.VideoLabels()
-        attrs = self.detect(imgs)
-        for idx, imgs in enumerate(imgs):
-            frame_number = idx + 1
-            frame_labels = etav.VideoFrameLabels(frame_number, attrs=attrs)
-            labels.add_frame(frame_labels)
+        objects = self.detect(imgs)
+        for obj in objects:
+            labels.add_object(obj, obj.frame_number)
         return labels
 
 


### PR DESCRIPTION
DRAFT. Not ready for review.

Adds a concrete method `process` method to all abstract model types with an associated input data type (`video_path` i.e. `VideoModel`, `imgs` tensor/list i.e. `VideoFramesModel`, `img` i.e. `ImageModel`).

####  A detail of note:
A `VideoFrameModel`'s `process` method returns a `VideoLabels` with frames indexed by the order of the tensor/list. So, in most cases, the `VideoLabels` return by `VideoFrameLabels.process(imgs)` are more of an intermediate instance. Best I could come up with.