### PR TITLE
Support for Container slicing

### DIFF
--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -821,6 +821,11 @@ class Container(Serializable):
     '''Abstract base class for flexible containers that store homogeneous lists
     of elements of a `Serializable` class.
 
+    Containers provide native support for all common array operations like
+    getting, setting, deleting, length, and slicing. So, for example,
+    `container[:5]` will return a `Container` that contains the first 5
+    elements of `container`.
+
     This class cannot be instantiated directly. Instead a subclass should
     be created for each type of element to be stored. Subclasses MUST set the
     following members:
@@ -1199,6 +1204,13 @@ class BigContainer(Container):
     objects. The elements are stored on disk in a backing directory; accessing
     any element in the list causes an immediate READ from disk, and
     adding/setting an element causes an immediate WRITE to disk.
+
+    BigContainers provide native support for all common array operations like
+    getting, setting, deleting, length, and slicing. In the case of slicing,
+    a BigContainer slice will be returned as an in-memory instance of the
+    corresponding `Container` version of the `BigContainer` class. So, for
+    example, `big_container[:5]` will return a `Container` that contains the
+    first 5 elements of `big_container`.
 
     BigContainers store a `backing_dir` attribute that specifies the path on
     disk to the serialized elements. The container also maintains a list of

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -641,16 +641,19 @@ class Set(Serializable):
         setattr(self, self._ELE_ATTR, elements)
 
     def extract_keys(self, keys):
-        '''Creates a new set having only the elements with the given keys.
+        '''Returns a new set having only the elements with the given keys.
+
+        The elements are passed by reference, not copied.
 
         Args:
             keys: an iterable of keys of the elements to keep
 
         Returns:
-            a Set
+            a Set with the requested elements
         '''
-        new_set = self.copy()
-        new_set.keep_keys(keys)
+        new_set = self.empty()
+        for key in keys:
+            new_set.add(self[key])
         return new_set
 
     def count_matches(self, filters, match=any):
@@ -672,7 +675,9 @@ class Set(Serializable):
         return len(elements)
 
     def get_matches(self, filters, match=any):
-        '''Gets elements matching the given filters.
+        '''Returns a set of elements matching the given filters.
+
+        The elements are passed by reference, not copied.
 
         Args:
             filters: a list of functions that accept elements and return
@@ -683,11 +688,11 @@ class Set(Serializable):
                 `any`
 
         Returns:
-            a copy of the set containing only the elements that match the
-                filters
+            a Set with elements matching the filters
         '''
-        new_set = self.copy()
-        new_set.filter_elements(filters, match=match)
+        new_set = self.empty()
+        elements = self._filter_elements(filters, match)
+        new_set.add_iterable(elements)
         return new_set
 
     def sort_by(self, attr, reverse=False):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1589,6 +1589,31 @@ class BigContainer(Container):
 
         return container
 
+    def to_container(self):
+        '''Loads a BigContainer into an in-memory Container of the associated
+        class.
+
+        Returns:
+            a Container
+        '''
+        return self[:]
+
+    @classmethod
+    def from_container(cls, container, backing_dir):
+        '''Creates a BigContainer with the given Container's elements.
+
+        Args:
+            container: a Container
+            backing_dir: backing directory to use for the new container.
+                Must be empty or non-existent
+
+        Returns:
+            a BigContainer
+        '''
+        big_container = cls(backing_dir)
+        big_container.add_container(container)
+        return big_container
+
     @classmethod
     def from_paths(cls, backing_dir, paths):
         '''Creates a BigContainer from a list of `_ELE_CLS` JSON files.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -567,6 +567,17 @@ class Set(Serializable):
         '''
         return copy.deepcopy(self)
 
+    def empty(self):
+        '''Returns an empty copy of the set.
+
+        Subclasses may override this method, but, by default, this method
+        constructs an empty set via `self.__class__()`
+
+        Returns:
+            an empty Set
+        '''
+        return self.__class__()
+
     def get_keys(self):
         '''Returns the set of keys for the elements of the set.'''
         return set(self.__elements__)
@@ -928,6 +939,17 @@ class Container(Serializable):
             a Container
         '''
         return copy.deepcopy(self)
+
+    def empty(self):
+        '''Returns an empty copy of the container.
+
+        Subclasses may override this method, but, by default, this method
+        constructs an empty container via `self.__class__()`
+
+        Returns:
+            an empty Container
+        '''
+        return self.__class__()
 
     def add(self, element):
         '''Adds an element to the container.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1320,8 +1320,8 @@ class BigContainer(Container):
     @property
     def container_cls(self):
         '''Returns the Container class associated with this BigContainer.'''
-        module, _, big_cls = etau.get_class_name(self).rpartition(".")
-        cls_name = module + "." + big_cls[len("Big"):]
+        module, dot, big_cls = etau.get_class_name(self).rpartition(".")
+        cls_name = module + dot + big_cls[len("Big"):]
         return etau.get_class(cls_name)
 
     def clear(self):


### PR DESCRIPTION
This PR adds support for slicing `Containers` and `BigContainers`. So, for example, `container[:5]` will return a `Container`, not a `list`.

Note that slicing a `BigContainer` will _also_ return an in-memory `Container`. So writing `big_container[1:]` is not advisable on large `BigContainers`, for example.

I also updated methods like `extract_inds` and `get_matches` to return elements by reference, not by value. Previously deep copies were being made, which is not how other container types in Python work. Now things will be more efficient.

Tests:

```py
#
# Testing BigContainer slicing
#

import eta.core.geometry as etag

origin = etag.LabeledPoint("origin", etag.RelativePoint(0, 0))

points = etag.BigLabeledPointContainer("/tmp/aaa")
for idx in range(5):
    points.add(etag.LabeledPoint(str(idx), etag.RelativePoint(0, 0)))

print(points)
print(points[0])
print(points[:2])
print(points[-1])
print(points[3:])

del points[-1]
del points[:2]
print(points)

points2 = etag.LabeledPointContainer()
points2.add_iterable([origin, origin])
print(points2)

print(points)
points[1:3] = points2
print(points)

points3 = points.to_container()
print(points3)

points4 = etag.BigLabeledPointContainer.from_container(points3, "/tmp/bbb")
print(points4)

#
# Testing Container slicing
#

import eta.core.geometry as etag

origin = etag.LabeledPoint("origin", etag.RelativePoint(0, 0))

points = etag.LabeledPointContainer()
for idx in range(5):
    points.add(etag.LabeledPoint(str(idx), etag.RelativePoint(0, 0)))

print(points)
print(points[0])
print(points[:2])
print(points[-1])
print(points[3:])

del points[-1]
del points[:2]
print(points)

points2 = etag.LabeledPointContainer()
points2.add_iterable([origin, origin])
print(points2)

print(points)
points[1:3] = points2
print(points)
```
