### PR TITLE
BigSet, BigContainer, BigImageSetLabels, and BigVideoSetLabels!

### DIFF
--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -20,7 +20,7 @@ from builtins import *
 # pragma pylint: enable=wildcard-import
 
 import eta.core.numutils as etan
-from eta.core.serial import BigContainer, Container, Serializable, Set
+from eta.core.serial import BigContainer, Container, Serializable, Set, BigSet
 
 
 class BoundingBox(Serializable):
@@ -320,6 +320,15 @@ class LabeledPointSet(Set):
     _ELE_CLS = LabeledPoint
     _ELE_ATTR = "points"
     _ELE_KEY_ATTR = "label"
+
+
+class BigLabeledPointSet(BigSet, LabeledPointSet):
+    '''Big set for points in an image that each have an associated label.
+
+    As a BigSet, each LabeledPoint is stored individually on disk.
+    '''
+
+    pass
 
 
 def _to_frame_size(frame_size=None, shape=None, img=None):

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -305,7 +305,7 @@ class LabeledPointContainer(Container):
         return set(p.label for p in self)
 
 
-class BigLabeledPointContainer(BigContainer, LabeledPointContainer):
+class BigLabeledPointContainer(LabeledPointContainer, BigContainer):
     '''Big container for points in an image that each have an associated label.
 
     As a BigContainer, each LabeledPoint is stored individually on disk.
@@ -321,8 +321,12 @@ class LabeledPointSet(Set):
     _ELE_ATTR = "points"
     _ELE_KEY_ATTR = "label"
 
+    def get_labels(self):
+        '''Returns a set containing the labels of the LabeledPoints.'''
+        return set(p.label for p in self)
 
-class BigLabeledPointSet(BigSet, LabeledPointSet):
+
+class BigLabeledPointSet(LabeledPointSet, BigSet):
     '''Big set for points in an image that each have an associated label.
 
     As a BigSet, each LabeledPoint is stored individually on disk.

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -459,12 +459,10 @@ class ImageLabelsSchemaError(Exception):
 
 
 class ImageSetLabels(Set):
-    '''Abstract class encapsulating labels for a set of images.
+    '''Class encapsulating labels for a set of images.
 
-    ImageSetLabels and BigImageSetLabels are the concrete implementations.
-
-    ImageSetLabels subclasses support item indexing by the `filename` of the
-    ImageLabels instances in the set.
+    ImageSetLabels support item indexing by the `filename` of the ImageLabels
+    instances in the set.
 
     ImageSetLabels instances behave like defaultdicts: new ImageLabels
     instances are automatically created if a non-existent filename is accessed.
@@ -474,7 +472,7 @@ class ImageSetLabels(Set):
 
     Attributes:
         images: an OrderedDict of ImageLabels with filenames as keys
-        schema: an ImageLabelsSchema describing the schema of the image labels
+        schema: an ImageLabelsSchema describing the schema of the labels
     '''
 
     _ELE_ATTR = "images"

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -503,7 +503,7 @@ class ImageSetLabels(Set):
         if self.has_schema:
             self._validate_labels(image_labels)
 
-        super(ImageSetLabels, self).__setitem__(filename, image_labels)
+        return super(ImageSetLabels, self).__setitem__(filename, image_labels)
 
     @property
     def has_schema(self):
@@ -528,6 +528,7 @@ class ImageSetLabels(Set):
         '''
         if self.has_schema:
             self._validate_labels(image_labels)
+
         super(ImageSetLabels, self).add(image_labels)
 
     def get_filenames(self):

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -678,14 +678,26 @@ class BigImageSetLabels(ImageSetLabels, BigSet):
         self.schema = schema
         BigSet.__init__(self, backing_dir=backing_dir, images=images)
 
-    @classmethod
-    def from_dict(cls, d):
-        '''Constructs a BigImageSetLabels from a JSON dictionary.'''
-        schema = d.pop("schema", None)
-        if schema is not None:
-            schema = ImageLabelsSchema.from_dict(schema)
+    def empty_set(self):
+        '''Returns an empty in-memory ImageSetLabels version of this
+        BigImageSetLabels.
 
-        return BigSet.from_dict(d, schema=schema)
+        Returns:
+            an empty ImageSetLabels
+        '''
+        return ImageSetLabels(schema=self.schema)
+
+    def filter_by_schema(self, schema):
+        '''Removes objects/attributes from the ImageLabels in the set that are
+        not compliant with the given schema.
+
+        Args:
+            schema: an ImageLabelsSchema
+        '''
+        for key in self.keys():
+            image_labels = self[key]
+            image_labels.filter_by_schema(schema)
+            self[key] = image_labels
 
 
 ###### Image I/O ##############################################################

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -656,21 +656,40 @@ class ImageSetLabels(Set):
 
 
 class BigImageSetLabels(ImageSetLabels, BigSet):
-    '''A BigSet of ImageSetLabels.'''
+    '''A BigSet of ImageLabels.
+
+    Behaves identically to ImageSetLabels except that each ImageLabels is
+    stored on disk.
+
+    Attributes:
+        backing_dir: the backing directory in which the ImageLabels
+                are/will be stored
+        images: an OrderedDict whose keys are filenames and whose values are
+            uuids for locating ImageLabels on disk
+        schema: a ImageLabelsSchema describing the schema of the labels
+    '''
+
+    def __init__(self, backing_dir, images=None, schema=None):
+        '''Creates a BigImageSetLabels instance.
+
+        Args:
+            backing_dir: the backing directory in which the ImageLabels
+                are/will be stored
+            images: an optional list of uuids for elements in the set
+            schema: an optional ImageLabelsSchema to enforce on the object.
+                By default, no schema is enforced
+        '''
+        self.schema = schema
+        BigSet.__init__(self, backing_dir, images=images)
 
     @classmethod
     def from_dict(cls, d):
         '''Constructs a BigImageSetLabels from a JSON dictionary.'''
-
-        schema = d.get("schema", None)
+        schema = d.pop("schema", None)
         if schema is not None:
             schema = ImageLabelsSchema.from_dict(schema)
 
-        images = d.pop("images", [])
-
-        set_ = cls(**d)
-        setattr(set_, cls._ELE_ATTR, OrderedDict(images))
-        return set_
+        return super(BigImageSetLabels, cls).from_dict(d, schema=schema)
 
 
 ###### Image I/O ##############################################################

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -651,26 +651,35 @@ class BigImageSetLabels(ImageSetLabels, BigSet):
     Behaves identically to ImageSetLabels except that each ImageLabels is
     stored on disk.
 
+    BigImageSetLabels store a `backing_dir` attribute that specifies the path
+    on disk to the serialized elements. If a backing directory is explicitly
+    provided, the directory will be maintained after the BigImageSetLabels
+    object is deleted; if no backing directory is specified, a temporary
+    backing directory is used and is deleted when the BigImageSetLabels
+    instance is garbage collected.
+
     Attributes:
-        backing_dir: the backing directory in which the ImageLabels
-                are/will be stored
         images: an OrderedDict whose keys are filenames and whose values are
             uuids for locating ImageLabels on disk
         schema: a ImageLabelsSchema describing the schema of the labels
+        backing_dir: the backing directory in which the ImageLabels
+            are/will be stored
     '''
 
-    def __init__(self, backing_dir, images=None, schema=None):
+    def __init__(self, images=None, schema=None, backing_dir=None):
         '''Creates a BigImageSetLabels instance.
 
         Args:
-            backing_dir: the backing directory in which the ImageLabels
-                are/will be stored
-            images: an optional list of uuids for elements in the set
+            images: an optional dictionary or list of (key, uuid) tuples for
+                elements in the set
             schema: an optional ImageLabelsSchema to enforce on the object.
                 By default, no schema is enforced
+            backing_dir: an optional backing directory in which the ImageLabels
+                are/will be stored. If omitted, a temporary backing directory
+                is used
         '''
         self.schema = schema
-        BigSet.__init__(self, backing_dir, images=images)
+        BigSet.__init__(self, backing_dir=backing_dir, images=images)
 
     @classmethod
     def from_dict(cls, d):
@@ -679,7 +688,7 @@ class BigImageSetLabels(ImageSetLabels, BigSet):
         if schema is not None:
             schema = ImageLabelsSchema.from_dict(schema)
 
-        return super(BigImageSetLabels, cls).from_dict(d, schema=schema)
+        return BigSet.from_dict(cls, d, schema=schema)
 
 
 ###### Image I/O ##############################################################

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -26,9 +26,8 @@ from future.utils import iteritems
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import colorsys
-import copy
 import errno
 import os
 import operator
@@ -481,7 +480,7 @@ class ImageSetLabels(Set):
     _ELE_CLS = ImageLabels
     _ELE_CLS_FIELD = "_LABELS_CLS"
 
-    def __init__(self, images=[], schema=None):
+    def __init__(self, **kwargs):
         '''Constructs an ImageSetLabels instance.
 
         Args:
@@ -490,8 +489,8 @@ class ImageSetLabels(Set):
             schema: an optional ImageLabelsSchema to enforce on the object.
                 By default, no schema is enforced
         '''
-        self.schema = schema
-        super(ImageSetLabels, self).__init__(images=images)
+        self.schema = kwargs.pop("schema", None)
+        super(ImageSetLabels, self).__init__(**d)
 
     def __getitem__(self, filename):
         if filename not in self:
@@ -682,7 +681,7 @@ class ImageSetLabels(Set):
         if schema is not None:
             schema = ImageLabelsSchema.from_dict(schema)
 
-        images = d.get("schema", None)
+        images = d.get("images", None)
         if images is not None:
             images = [ImageLabels.from_dict(il) for il in images]
 
@@ -690,7 +689,7 @@ class ImageSetLabels(Set):
 
 
 class BigImageSetLabels(BigSet, ImageSetLabels):
-    '''A BigSet version of ImageSetLabels.'''
+    '''A BigSet of ImageSetLabels.'''
 
     @classmethod
     def from_dict(cls, d):
@@ -700,11 +699,10 @@ class BigImageSetLabels(BigSet, ImageSetLabels):
         if schema is not None:
             schema = ImageLabelsSchema.from_dict(schema)
 
-        images = d.get("images", [])
+        images = d.pop("images", [])
 
         set_ = cls(**d)
-        set_.set_schema = schema
-        set_._init_dict(images)
+        setattr(set_, cls._ELE_ATTR, OrderedDict(images))
         return set_
 
 

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -458,7 +458,7 @@ class ImageLabelsSchemaError(Exception):
     pass
 
 
-class AbstractImageSetLabels(object):
+class ImageSetLabels(Set):
     '''Abstract class encapsulating labels for a set of images.
 
     ImageSetLabels and BigImageSetLabels are the concrete implementations.
@@ -492,14 +492,14 @@ class AbstractImageSetLabels(object):
                 By default, no schema is enforced
         '''
         self.schema = kwargs.pop("schema", None)
-        super(ImageSetLabelsMixin, self).__init__(**kwargs)
+        super(ImageSetLabels, self).__init__(**kwargs)
 
     def __getitem__(self, filename):
         if filename not in self:
             image_labels = ImageLabels(filename=filename)
             self.add_image_labels(image_labels)
 
-        return super(ImageSetLabelsMixin, self).__getitem__(filename)
+        return super(ImageSetLabels, self).__getitem__(filename)
 
     def __setitem__(self, filename, image_labels):
         image_labels.filename = filename
@@ -507,7 +507,7 @@ class AbstractImageSetLabels(object):
         if self.has_schema:
             self._validate_image_labels(image_labels)
 
-        super(ImageSetLabelsMixin, self).__setitem__(filename, image_labels)
+        super(ImageSetLabels, self).__setitem__(filename, image_labels)
 
     @property
     def has_schema(self):
@@ -675,15 +675,6 @@ class AbstractImageSetLabels(object):
             for image_labels in self:
                 self._validate_image_labels(image_labels)
 
-
-class ImageSetLabels(ImageSetLabelsMixin, Set):
-    '''ImageSetLabels.
-
-    Attributes:
-        images: an OrderedDict of ImageLabels with filenames as keys
-        schema: an ImageLabelsSchema describing the schema of the image labels
-    '''
-
     @classmethod
     def from_dict(cls, d):
         '''Constructs an ImageSetLabels from a JSON dictionary.'''
@@ -700,14 +691,7 @@ class ImageSetLabels(ImageSetLabelsMixin, Set):
 
 
 class BigImageSetLabels(ImageSetLabels, BigSet):
-    '''A BigSet of ImageSetLabels.
-
-
-    Attributes:
-        images: an OrderedDict of ImageLabels with filenames as keys and BigSet
-            uuids for storage.
-        schema: an ImageLabelsSchema describing the schema of the image labels
-    '''
+    '''A BigSet of ImageSetLabels.'''
 
     @classmethod
     def from_dict(cls, d):

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -530,14 +530,6 @@ class ImageSetLabels(Set):
             self._validate_labels(image_labels)
         super(ImageSetLabels, self).add(image_labels)
 
-    def add_set(self, image_set_labels):
-        '''Merges the ImageSetLabels into the set.
-
-        Args:
-            image_set_labels: an ImageSetLabels instance
-        '''
-        self.add_iterable(image_set_labels)
-
     def get_filenames(self):
         '''Returns the set of filenames of ImageLabels in the set.
 

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -26,7 +26,7 @@ from future.utils import iteritems
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 import colorsys
 import errno
 import os

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -500,8 +500,6 @@ class ImageSetLabels(Set):
         return super(ImageSetLabels, self).__getitem__(filename)
 
     def __setitem__(self, filename, image_labels):
-        image_labels.filename = filename
-
         if self.has_schema:
             self._validate_labels(image_labels)
 

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -480,17 +480,17 @@ class ImageSetLabels(Set):
     _ELE_CLS = ImageLabels
     _ELE_CLS_FIELD = "_LABELS_CLS"
 
-    def __init__(self, **kwargs):
+    def __init__(self, images=None, schema=None):
         '''Constructs an ImageSetLabels instance.
 
         Args:
-            images: an optional list of ImageLabels instances. By default, an
-                empty list is created
+            images: an optional iterable of ImageLabels. By default, an empty
+                set is created
             schema: an optional ImageLabelsSchema to enforce on the object.
                 By default, no schema is enforced
         '''
-        self.schema = kwargs.pop("schema", None)
-        super(ImageSetLabels, self).__init__(**kwargs)
+        self.schema = schema
+        super(ImageSetLabels, self).__init__(images=images)
 
     def __getitem__(self, filename):
         if filename not in self:

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -688,7 +688,7 @@ class BigImageSetLabels(ImageSetLabels, BigSet):
         if schema is not None:
             schema = ImageLabelsSchema.from_dict(schema)
 
-        return BigSet.from_dict(cls, d, schema=schema)
+        return BigSet.from_dict(d, schema=schema)
 
 
 ###### Image I/O ##############################################################

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -540,14 +540,12 @@ class ImageSetLabels(Set):
         return set(il.filename for il in self if il.filename)
 
     def get_schema(self):
-        '''Gets the current enforced schema for the image set, or None if no
-        schema is enforced.
-        '''
+        '''Gets the schema for the set, or None if no schema is enforced.'''
         return self.schema
 
     def get_active_schema(self):
-        '''Returns an ImageLabelsSchema describing the active schema of the
-        image set.
+        '''Gets the ImageLabelsSchema describing the active schema of the
+        set.
         '''
         schema = ImageLabelsSchema()
         for image_labels in self:
@@ -556,18 +554,18 @@ class ImageSetLabels(Set):
         return schema
 
     def set_schema(self, schema, filter_by_schema=False):
-        '''Sets the enforced schema to the given ImageLabelsSchema.
+        '''Sets the schema to the given ImageLabelsSchema.
 
         Args:
             schema: the ImageLabelsSchema to use
             filter_by_schema: whether to filter any invalid objects/attributes
-                from this object after changing the schema. By default, this is
+                from the set after changing the schema. By default, this is
                 False
 
         Raises:
-            ImageLabelsSchemaError: if `filter_by_schema` was False and this
-                object contains attributes/objects that are not compliant with
-                the schema
+            ImageLabelsSchemaError: if `filter_by_schema` was False and the
+                set contains attributes/objects that are not compliant with the
+                schema
         '''
         self.schema = schema
         if not self.has_schema:
@@ -579,8 +577,8 @@ class ImageSetLabels(Set):
             self._validate_schema()
 
     def filter_by_schema(self, schema):
-        '''Removes objects/attributes from the ImageLabels in this object that
-        are not compliant with the given schema.
+        '''Removes objects/attributes from the ImageLabels in the set that are
+        not compliant with the given schema.
 
         Args:
             schema: an ImageLabelsSchema
@@ -589,13 +587,11 @@ class ImageSetLabels(Set):
             image_labels.filter_by_schema(schema)
 
     def freeze_schema(self):
-        '''Sets the enforced schema for the image set to the current active
-        schema.
-        '''
+        '''Sets the schema for the set to the current active schema.'''
         self.set_schema(self.get_active_schema())
 
     def remove_schema(self):
-        '''Removes the enforced schema from the image set.'''
+        '''Removes the schema from the set.'''
         self.schema = None
 
     def sort_by_filename(self, reverse=False):

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -490,7 +490,7 @@ class ImageSetLabels(Set):
                 By default, no schema is enforced
         '''
         self.schema = kwargs.pop("schema", None)
-        super(ImageSetLabels, self).__init__(**d)
+        super(ImageSetLabels, self).__init__(**kwargs)
 
     def __getitem__(self, filename):
         if filename not in self:

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -823,7 +823,8 @@ class BigMixin(object):
     on disk rather than in-memory.
 
     Subclasses must call BigMixin's constructor to properly initialize the
-    Big object.
+    Big object, and they must implement the `add_by_path()` and
+    `add_iterable()` methods.
 
     `backing_dir` is an optional keyword argument for any methods that require
     initializing a new instance of a Big iterable. When `backing_dir` is

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -860,7 +860,7 @@ class BigMixin(object):
         return self._uses_temporary_storage
 
     def add_by_path(self, path):
-        '''Add an element by via its path on disk.
+        '''Adds an element to the Big iterable via its path on disk.
 
         Args:
             path: the path to the element JSON file on disk
@@ -1127,15 +1127,12 @@ class BigSet(BigMixin, Set):
         return etau.get_class(cls_name)
 
     def add_by_path(self, path, key=None):
-        '''Add an element via its path on disk.
-
-        No validation is done. Subclasses may choose to implement this method
-        for suchs purposes, etc.
+        '''Adds an element to the BigSet via its path on disk.
 
         Args:
             path: the path to the element JSON file on disk
             key: optional key value to the element. If not provided, the
-                element is loaded and the key is read.
+                element is loaded and the key is read
         '''
         if key is None:
             # Must load element to get key

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -860,7 +860,7 @@ class BigMixin(object):
         return self._uses_temporary_storage
 
     def add_by_path(self, path):
-        '''Add a an element by its absolute path on disk.
+        '''Add an element by via its path on disk.
 
         Args:
             path: the path to the element JSON file on disk
@@ -1127,7 +1127,7 @@ class BigSet(BigMixin, Set):
         return etau.get_class(cls_name)
 
     def add_by_path(self, path, key=None):
-        '''Add a an element by its absolute path on disk.
+        '''Add an element via its path on disk.
 
         No validation is done. Subclasses may choose to implement this method
         for suchs purposes, etc.
@@ -1891,7 +1891,7 @@ class BigContainer(BigMixin, Container):
         return etau.get_class(cls_name)
 
     def add_by_path(self, path):
-        '''Add a an element by its absolute path on disk.
+        '''Add an element via its path on disk.
 
         No validation is done. Subclasses may choose to implement this method
         for suchs purposes, etc.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1046,7 +1046,7 @@ class BigSet(Set):
             d[self._ELE_CLS_FIELD] = etau.get_class_name(self._ELE_CLS)
 
         #
-        # Note that we serialize the dictionary into list of (key, value)
+        # Note that we serialize the dictionary into a list of (key, value)
         # tuples
         #
         d[self._ELE_ATTR] = _recurse(list(self.__elements__.items()), False)

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1135,25 +1135,6 @@ class BigSet(BigMixin, Set):
         cls_name = module + dot + big_cls[len("Big"):]
         return etau.get_class(cls_name)
 
-    def add_by_path(self, path, key=None):
-        '''Adds an element to the BigSet via its path on disk.
-
-        Args:
-            path: the path to the element JSON file on disk
-            key: optional key value to the element. If not provided, the
-                element is loaded and the key is read
-        '''
-        if key is None:
-            # Must load element to get key
-            self.add(self._load_ele(path))
-            return
-
-        if key not in self:
-            # Must add key to set
-            self.__elements__[key] = self._make_uuid()
-
-        etau.copy_file(path, self._ele_path(key))
-
     def empty_set(self):
         '''Returns an empty in-memory Set version of this BigSet.
 
@@ -1174,6 +1155,25 @@ class BigSet(BigMixin, Set):
         key = self.get_key(element) or str(uuid4())
         self[key] = element
 
+    def add_by_path(self, path, key=None):
+        '''Adds an element to the BigSet via its path on disk.
+
+        Args:
+            path: the path to the element JSON file on disk
+            key: optional key value to the element. If not provided, the
+                element is loaded and the key is read
+        '''
+        if key is None:
+            # Must load element to get key
+            self.add(self._load_ele(path))
+            return
+
+        if key not in self:
+            # Must add key to set
+            self.__elements__[key] = self._make_uuid()
+
+        etau.copy_file(path, self._ele_path(key))
+
     def add_set(self, set_):
         '''Adds the given set's elements to the set.
 
@@ -1187,6 +1187,15 @@ class BigSet(BigMixin, Set):
                 self.add_by_path(path, key=key)
         else:
             self.add_iterable(set_)
+
+    def add_iterable(self, elements):
+        '''Adds the elements in the given iterable to the set.
+
+        Args:
+            elements: an iterable of `_ELE_CLS` objects
+        '''
+        for element in elements:
+            self.add(element)
 
     def filter_elements(self, filters, match=any):
         '''Removes elements that don't match the given filters from the set.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -589,15 +589,16 @@ class Set(Serializable):
             element: an instance of `_ELE_CLS`
         '''
         key = self.get_key(element) or str(uuid4())
-        self.__elements__[key] = element
+        self[key] = element
 
     def add_set(self, set_):
         '''Adds the elements in the given set to this set.
 
         Args:
-            set_: a Set
+            set_: a Set of `_ELE_CLS` objects
         '''
-        self.__elements__.update(set_.__elements__)
+        for key in set_.keys():
+            self[key] = set_[key]
 
     def add_iterable(self, elements):
         '''Adds the elements in the given iterable to the set.
@@ -629,7 +630,7 @@ class Set(Serializable):
             keys: an iterable of keys of the elements to delete
         '''
         for key in keys:
-            del self.__elements__[key]
+            del self[key]
 
     def keep_keys(self, keys):
         '''Keeps only the elements in the set with the given keys.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -955,6 +955,17 @@ class BigSet(Set):
         '''
         return self.__class__(backing_dir=backing_dir)
 
+    def empty_set(self):
+        '''Returns an empty in-memory Set version of this BigSet.
+
+        Subclasses may override this method, but, by default, this method makes
+        the empty Set via `self.set_cls()`
+
+        Returns:
+            an empty Set
+        '''
+        return self.set_cls()
+
     def move(self, backing_dir=None):
         '''Moves the backing directory of the set to the given location.
 
@@ -1029,7 +1040,7 @@ class BigSet(Set):
         '''
         if not big:
             # Return results in a Set
-            new_set = self.set_cls()
+            new_set = self.empty_set()
             for key in keys:
                 new_set.add(self[key])
             return new_set
@@ -1192,7 +1203,7 @@ class BigSet(Set):
         Returns:
             a Set
         '''
-        set_ = self.set_cls()
+        set_ = self.empty_set()
         set_.add_set(self)
         return set_
 
@@ -1882,6 +1893,17 @@ class BigContainer(Container):
         '''
         return self.__class__(backing_dir=backing_dir)
 
+    def empty_container(self):
+        '''Returns an empty in-memory Container version of this BigContainer.
+
+        Subclasses may override this method, but, by default, this method makes
+        the empty Container via `self.container_cls()`
+
+        Returns:
+            an empty Container
+        '''
+        return self.container_cls()
+
     def move(self, backing_dir=None):
         '''Moves the backing directory of the container to the given location.
 
@@ -1968,7 +1990,7 @@ class BigContainer(Container):
         '''
         if not big:
             # Return results in a Container
-            new_container = self.container_cls()
+            new_container = self.empty_container()
             for idx in inds:
                 new_container.add(self[idx])
             return new_container
@@ -2105,7 +2127,9 @@ class BigContainer(Container):
         Returns:
             a Container
         '''
-        return self[:]
+        new_container = self.empty_container()
+        new_container.add_container(self)
+        return new_container
 
     @classmethod
     def from_container(cls, container, backing_dir=None):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -941,7 +941,7 @@ class BigSet(Set):
         '''
         new_ele_set = self._filter_elements(filters, match)
         keys = [key for key in self.__elements__ if key not in new_ele_set]
-        self.delete_inds(keys)
+        self.delete_keys(keys)
 
     def delete_keys(self, keys):
         '''Deletes the elements from the set with the given keys.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -867,6 +867,14 @@ class BigMixin(object):
         '''
         raise NotImplementedError("subclasses must implement add_by_path()")
 
+     def add_iterable(self, elements):
+        '''Adds the elements in the given iterable to the Big iterable.
+
+         Args:
+            elements: an iterable of elements
+        '''
+        raise NotImplementedError("subclasses must implement add_iterable()")
+
     def clear(self):
         '''Deletes all elements from the Big iterable.'''
         super(BigSet, self).clear()

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1531,7 +1531,7 @@ class Container(Serializable):
             inds: an iterable of indices of the elements to delete
         '''
         for idx in sorted(inds, reverse=True):
-            del self.__elements__[idx]
+            del self[idx]
 
     def keep_inds(self, inds):
         '''Keeps only the elements in the container with the given indices.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1903,6 +1903,14 @@ class BigContainer(BigMixin, Container):
         self.__elements__.append(uuid)
         etau.copy_file(path, self._ele_path_by_uuid(uuid))
 
+    def add_iterable(self, elements):
+        '''Adds the elements in the given iterable to the Big iterable.
+
+        Args:
+            elements: an iterable of elements
+        '''
+        raise NotImplementedError("subclasses must implement add_iterable()")
+
     def empty_container(self):
         '''Returns an empty in-memory Container version of this BigContainer.
 

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -2096,8 +2096,8 @@ class BigContainer(BigMixin, Container):
             raise IndexError("Container index %d out of bounds" % idx)
         return "%s.json" % self.__elements__[idx]
 
-    def _ele_path(self, key):
-        return os.path.join(self.backing_dir, self._ele_filename(key))
+    def _ele_path(self, idx):
+        return os.path.join(self.backing_dir, self._ele_filename(idx))
 
     def _ele_path_by_uuid(self, uuid):
         return os.path.join(self.backing_dir, "%s.json" % uuid)

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1051,7 +1051,7 @@ class BigSet(Set):
             # in `from_archive`), but we set it relative to the root of the
             # archive, for completeness.
             #
-            container._backing_dir = "./" + self._ELE_ATTR
+            set_._backing_dir = "./" + self._ELE_ATTR
             set_.write_json(index_path)
             set_._backing_dir = full_backing_dir
             etau.make_archive(rootdir, archive_path)
@@ -1130,7 +1130,9 @@ class BigSet(Set):
             an instance of the BigSet class
         '''
         cls = cls._validate_dict(d)
-        return cls(**d)
+        uuid_list = d.get(self._ELE_ATTR, [])
+        set_ = cls(**d)
+        set_._init_dict(uuid_list)
 
     def _filter_elements(self, filters, match):
         def run_filters(uuid):
@@ -1171,6 +1173,12 @@ class BigSet(Set):
 
     def _add_by_path(self, path):
         self.add(self._load_ele(path))
+
+    def _init_dict(self, uuid_list):
+        for uuid in uuid_list:
+            ele = set_._load_ele_by_uuid(uuid)
+            key = cls.get_key(ele)
+            set_.__elements__[key] = uuid
 
 
 class SetError(Exception):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -868,7 +868,7 @@ class BigMixin(object):
         '''
         raise NotImplementedError("subclasses must implement add_by_path()")
 
-     def add_iterable(self, elements):
+    def add_iterable(self, elements):
         '''Adds the elements in the given iterable to the Big iterable.
 
          Args:

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -822,11 +822,11 @@ class BigMixin(object):
     '''Mixin class for BigContainer and BigSet.
 
     `backing_dir` is an optional keyword argument for any methods that require
-    initializing a new instance of a Big object. When a `backing_dir` is not
-    provided, a tmp directory is used and is deleted upon the Big object's
-    destruction.
+    initializing a new instance of a Big iterable. When a `backing_dir` is not
+    provided, a tmp directory is used and is deleted when the Big iterable is
+    garbage collected.
 
-    `move()` can be used to move the Big object between a set (persistent)
+    `move()` can be used to move the Big iterable between a set (persistent)
     backing directory and a temporary backing directory.
 
     See BigSet and BigContainer for full class implementations and
@@ -842,7 +842,7 @@ class BigMixin(object):
 
     @property
     def backing_dir(self):
-        '''The backing directory for this Big object.'''
+        '''The backing directory for this Big iterable.'''
         if self._backing_dir is not None:
             return self._backing_dir
         return self._tempdir
@@ -853,52 +853,54 @@ class BigMixin(object):
         return self._uses_temporary_storage
 
     def clear(self):
-        '''Deletes all elements from the Big object.'''
+        '''Deletes all elements from the Big iterable.'''
         super(BigSet, self).clear()
         etau.delete_dir(self.backing_dir)
         etau.ensure_dir(self.backing_dir)
 
     def copy(self, backing_dir=None):
-        '''Creates a deep copy of this Big object backed by the given directory.
+        '''Creates a deep copy of this Big iterable backed by the given
+        directory.
 
         Args:
-            backing_dir: optional backing directory to use for the new set.
-                If provided, it must be empty or non-existent
+            backing_dir: optional backing directory to use for the new big
+                iterable. If provided, it must be empty or non-existent
 
         Returns:
-            a Big object
+            a Big iterable
         '''
         new_big = self.empty(backing_dir=backing_dir)
         new_big.add_iterable(self)
         return new_big
 
     def empty(self, backing_dir=None):
-        '''Returns an empty copy of the container backed by the given
+        '''Returns an empty copy of the Big iterable backed by the given
         directory.
 
         Subclasses may override this method, but, by default, this method
-        constructs an empty Big object via
+        constructs an empty Big iterable via
         `self.__class__(backing_dir=backing_dir)`
 
         Args:
             backing_dir: optional backing directory to use for the new Big
-                object. If provided, it must be empty or non-existent
+                iterable. If provided, it must be empty or non-existent
 
         Returns:
-            an empty Big object
+            an empty Big iterable
         '''
         return self.__class__(backing_dir=backing_dir)
 
     def move(self, backing_dir=None):
-        '''Moves the backing directory of the Big object to the given location.
+        '''Moves the backing directory of the Big iterable to the given
+        location.
 
-        When backing_dir is not provided, it is moved to a new tmp directory.
-        This approach can be used to move a Big object out of the current
-        backing_dir and into a tmp storage state.
+        When `backing_dir` is not provided, it is moved to a new tmp directory.
+        Therefore, this method can be used to move a Big iterable out of the
+        current `backing_dir` and into a tmp storage state.
 
         Args:
-            backing_dir: optional backing directory to use for the new set. If
-                provided, it must be empty or non-existent
+            backing_dir: optional backing directory to use for the new Big
+                iterable. If provided, it must be empty or non-existent
         '''
         if backing_dir is not None:
             etau.ensure_empty_dir(backing_dir)
@@ -907,7 +909,7 @@ class BigMixin(object):
         etau.move_dir(orig_backing_dir, self.backing_dir)
 
     def to_archive(self, archive_path, delete_backing_dir=False):
-        '''Writes the Big object to a self-contained archive file.
+        '''Writes the Big iterable to a self-contained archive file.
 
         The archive contains both a JSON index and the raw element JSON files
         organized in the directory structure shown below. The filename (without
@@ -922,7 +924,7 @@ class BigMixin(object):
 
         Note that deleting the backing directory is a more efficient way to
         create the archive because it avoids data duplication, but it also
-        invalidates the current Big object.
+        invalidates the current Big iterable.
 
         Args:
             archive_path: the path + extension to write the output archive
@@ -956,17 +958,17 @@ class BigMixin(object):
     @classmethod
     def from_archive(cls, archive_path, backing_dir=None,
                      delete_archive=False):
-        '''Loads a Big object from an archive created by `to_archive()`.
+        '''Loads a Big iterable from an archive created by `to_archive()`.
 
         Args:
             archive_path: the path to the archive to load
             backing_dir: optional backing directory to use for the new Big
-                object. If provided, it must be empty or non-existent
+                iterable. If provided, it must be empty or non-existent
             delete_archive: whether to delete the archive after unpacking it.
                 By default, this is False
 
         Returns:
-            a Big object
+            a Big iterable
         '''
         with etau.TempDir() as tmp_dir:
             name = os.path.splitext(os.path.basename(archive_path))[0]
@@ -984,15 +986,15 @@ class BigMixin(object):
 
     @classmethod
     def from_paths(cls, paths, backing_dir=None):
-        '''Creates a Big object from a list of `_ELE_CLS` JSON files.
+        '''Creates a Big iterable from a list of `_ELE_CLS` JSON files.
 
         Args:
-            backing_dir: optional backing directory to use for the Big object.
+            backing_dir: optional backing directory to use for the Big iterable.
                 If provided, it must be empty or non-existent
             paths: an iterable of paths to `_ELE_CLS` JSON files
 
         Returns:
-            a Big object
+            a Big iterable
         '''
         big = cls(backing_dir=backing_dir)
         for path in paths:
@@ -1001,18 +1003,18 @@ class BigMixin(object):
 
     @classmethod
     def from_dir(cls, source_dir, backing_dir=None):
-        '''Creates a Big object from an unstructured directory of `_ELE_CLS`
+        '''Creates a Big iterable from an unstructured directory of `_ELE_CLS`
         JSON files on disk.
 
         The source directory is traversed recursively.
 
         Args:
             backing_dir: optional backing directory to use for the new Big
-                object. If provied, it must be empty or non-existent
+                iterable. If provided, it must be empty or non-existent
             source_dir: the source directory from which to ingest elements
 
         Returns:
-            a Big object
+            a Big iterable
         '''
         paths = etau.multiglob(".json", root=source_dir + "/**/*")
         return cls.from_paths(paths, backing_dir=backing_dir)

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1900,14 +1900,6 @@ class BigContainer(BigMixin, Container):
         self.__elements__.append(uuid)
         etau.copy_file(path, self._ele_path_by_uuid(uuid))
 
-    def add_iterable(self, elements):
-        '''Adds the elements in the given iterable to the Big iterable.
-
-        Args:
-            elements: an iterable of elements
-        '''
-        raise NotImplementedError("subclasses must implement add_iterable()")
-
     def empty_container(self):
         '''Returns an empty in-memory Container version of this BigContainer.
 

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -30,7 +30,6 @@ import numbers
 import os
 import pickle as _pickle
 import pprint
-import tempfile
 from uuid import uuid4
 
 import numpy as np
@@ -532,6 +531,10 @@ class Set(Serializable):
     def __elements__(self):
         return getattr(self, self._ELE_ATTR)
 
+    def keys(self):
+        '''Returns an iterator over the keys of the elements in the set.'''
+        return iter(self.__elements__)
+
     @classmethod
     def get_element_class(cls):
         '''Gets the class of elements stored in this set.'''
@@ -578,10 +581,6 @@ class Set(Serializable):
             an empty Set
         '''
         return self.__class__()
-
-    def get_keys(self):
-        '''Returns the set of keys for the elements of the set.'''
-        return set(self.__elements__)
 
     def add(self, element):
         '''Adds an element to the set.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1271,7 +1271,9 @@ class BigSet(Set):
             an instance of the BigSet class
         '''
         cls = cls._validate_dict(d)
-        return cls(**etau.join_dicts(d, kwargs))
+        backing_dir = d.get("backing_dir", None)
+        kwargs[cls._ELE_ATTR] = d[cls._ELE_ATTR]
+        return cls(backing_dir=backing_dir, **kwargs)
 
     def _filter_elements(self, filters, match):
         def run_filters(uuid):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -927,7 +927,7 @@ class BigSet(Set):
                 Must be empty or non-existent
         '''
         old_backing_dir = self.backing_dir
-        self._set_backing_dir(None)
+        self._set_backing_dir(new_backing_dir)
         etau.move_dir(old_backing_dir, self.backing_dir)
 
     def add_set(self, set_):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -744,7 +744,7 @@ class Set(Serializable):
         return d
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d, **kwargs):
         '''Constructs a Set from a JSON dictionary.
 
         If the dictionary has the `"_CLS"` and `cls._ELE_CLS_FIELD`
@@ -757,13 +757,15 @@ class Set(Serializable):
 
         Args:
             d: a JSON dictionary representation of a Set object
+            **kwargs: an optional set of keyword arguments that have already
+                been parsed by a subclass
 
         Returns:
             an instance of the Set class
         '''
         cls = cls._validate_dict(d)
         elements = [cls._ELE_CLS.from_dict(dd) for dd in d[cls._ELE_ATTR]]
-        return cls(**{cls._ELE_ATTR: elements})
+        return cls(**etau.join_dicts({cls._ELE_ATTR: elements}, kwargs))
 
     def _get_elements(self, keys):
         if isinstance(keys, six.string_types):
@@ -1155,17 +1157,19 @@ class BigSet(Set):
         return cls.from_paths(paths, backing_dir)
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d, **kwargs):
         '''Creates a BigSet from a JSON dictionary.
 
         Args:
             d: a JSON dictionary representation of a BigSet object
+            **kwargs: optional keyword arguments that have already been parsed
+                by a subclass
 
         Returns:
             an instance of the BigSet class
         '''
         cls = cls._validate_dict(d)
-        return cls(**d)
+        return cls(**etau.join_dicts(d, kwargs))
 
     def _filter_elements(self, filters, match):
         def run_filters(uuid):
@@ -1533,7 +1537,7 @@ class Container(Serializable):
         return d
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d, **kwargs):
         '''Constructs a Container from a JSON dictionary.
 
         If the dictionary has the `"_CLS"` and `cls._ELE_CLS_FIELD`
@@ -1546,13 +1550,15 @@ class Container(Serializable):
 
         Args:
             d: a JSON dictionary representation of a Container object
+            **kwargs: optional keyword arguments that have already been parsed
+                by a subclass
 
         Returns:
             an instance of the Container class
         '''
         cls = cls._validate_dict(d)
         elements = [cls._ELE_CLS.from_dict(dd) for dd in d[cls._ELE_ATTR]]
-        return cls(**{cls._ELE_ATTR: elements})
+        return cls(**etau.join_dicts({cls._ELE_ATTR: elements}, kwargs))
 
     def _get_elements(self, inds):
         if isinstance(inds, numbers.Integral):
@@ -2063,17 +2069,19 @@ class BigContainer(Container):
         return cls.from_paths(backing_dir, paths)
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d, **kwargs):
         '''Creates a BigContainer from a JSON dictionary.
 
         Args:
             d: a JSON dictionary representation of a BigContainer object
+            **kwargs: optional keyword arguments that have already been parsed
+                by a subclass
 
         Returns:
             an instance of the BigContainer class
         '''
         cls = cls._validate_dict(d)
-        return cls(**d)
+        return cls(**etau.join_dicts(d, kwargs))
 
     def _filter_elements(self, filters, match):
         def run_filters(uuid):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -909,16 +909,16 @@ class BigSet(Set):
         set_.add_set(self)
         return set_
 
-    def move(self, new_backing_dir):
+    def move(self, new_backing_dir=None):
         '''Moves the backing directory of the set to the given location.
 
         Args:
             new_backing_dir: backing directory to use for the new set.
                 Must be empty or non-existent
         '''
-        etau.ensure_empty_dir(new_backing_dir)
-        etau.move_dir(self.backing_dir, new_backing_dir)
-        self._set_backing_dir(new_backing_dir)
+        old_backing_dir = self.backing_dir
+        self._set_backing_dir(None)
+        etau.move_dir(old_backing_dir, self.backing_dir)
 
     def add_set(self, set_):
         '''Adds the elements in the given set to this set.
@@ -949,7 +949,7 @@ class BigSet(Set):
         Args:
             keys: an iterable of keys of the elements to delete
         '''
-        for key in keys:
+        for key in self:
             del self[key]
 
     def keep_keys(self, keys):
@@ -1121,7 +1121,7 @@ class BigSet(Set):
         Returns:
             a BigSet
         '''
-        set_ = cls(backing_dir)
+        set_ = cls(backing_dir=backing_dir)
         for path in paths:
             set_._add_by_path(path)
         return set_
@@ -1142,7 +1142,7 @@ class BigSet(Set):
             a BigSet
         '''
         paths = etau.multiglob(".json", root=source_dir + "/**/*")
-        return cls.from_paths(backing_dir, paths)
+        return cls.from_paths(paths, backing_dir)
 
     @classmethod
     def from_dict(cls, d):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -590,7 +590,7 @@ class Set(Serializable):
             element: an instance of `_ELE_CLS`
         '''
         key = self.get_key(element) or str(uuid4())
-        self[key] = element
+        self.__elements__[key] = element
 
     def add_set(self, set_):
         '''Adds the elements in the given set to this set.

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -717,7 +717,8 @@ class Set(Serializable):
 
     def attributes(self):
         '''Returns the list of class attributes that will be serialized.'''
-        return [self._ELE_ATTR]
+        # `_ELE_ATTR` is omitted here because it is serialized manually
+        return []
 
     def serialize(self, reflective=False):
         '''Serializes the set into a dictionary.
@@ -734,8 +735,10 @@ class Set(Serializable):
             d["_CLS"] = self.get_class_name()
             d[self._ELE_CLS_FIELD] = etau.get_class_name(self._ELE_CLS)
 
+        d.update(super(Set, self).serialize(reflective=False))
+
         #
-        # Note that we serialize the dictionary into a list; the keys are
+        # Note that we serialize the elements as a list; the keys are
         # re-generated during de-serialization
         #
         elements_list = list(itervalues(self.__elements__))

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1212,12 +1212,6 @@ class BigSet(Set):
     def _add_by_path(self, path):
         self.add(self._load_ele(path))
 
-    def _init_dict(self, uuid_list):
-        for uuid in uuid_list:
-            ele = self._load_ele_by_uuid(uuid)
-            key = self.get_key(ele)
-            self.__elements__[key] = uuid
-
 
 class SetError(Exception):
     '''Exception raised when an invalid Set is encountered.'''

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -829,7 +829,8 @@ class BigMixin(object):
     `move()` can be used to move the Big object between a set (persistent)
     backing directory and a temporary backing directory.
 
-    See BigSet and BigContainer for concrete implementations.
+    See BigSet and BigContainer for full class implementations and
+    BigLabeledPointContainer BigLabeledPointSet for concrete implementations.
     '''
 
     def __init__(self):
@@ -1022,7 +1023,7 @@ class BigMixin(object):
             self._backing_dir = os.path.abspath(backing_dir)
         else:
             self._temp_storage = True
-            self._backing_dir = tempfile.mkdtemp()
+            self._backing_dir = etau.make_temp_dir()
 
     @staticmethod
     def _make_uuid():

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -769,7 +769,7 @@ class Set(Serializable):
 
     def _get_elements(self, keys):
         if isinstance(keys, six.string_types):
-            logger.debug("Wrapping single filename as a list")
+            logger.debug("Wrapping single key as a list")
             keys = [keys]
 
         return OrderedDict(

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -496,7 +496,7 @@ class Set(Serializable):
             raise SetError(
                 "Expected elements to be provided in keyword argument '%s'; "
                 "found keys %s" % (self._ELE_ATTR, list(kwargs.keys())))
-        elements = kwargs.get(self._ELE_ATTR, [])
+        elements = kwargs.get(self._ELE_ATTR, None) or []
 
         for e in elements:
             if not isinstance(e, self._ELE_CLS):
@@ -1294,7 +1294,7 @@ class Container(Serializable):
             raise ContainerError(
                 "Expected elements to be provided in keyword argument '%s'; "
                 "found keys %s" % (self._ELE_ATTR, list(kwargs.keys())))
-        elements = kwargs.get(self._ELE_ATTR, [])
+        elements = kwargs.get(self._ELE_ATTR, None) or []
 
         for e in elements:
             if not isinstance(e, self._ELE_CLS):

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -1434,6 +1434,15 @@ class MD5FileHasher(FileHasher):
             return str(hashlib.md5(f.read()).hexdigest())
 
 
+def make_temp_dir():
+    '''Makes a temporary directory.
+
+    Returns:
+        the path to the temporary directory
+    '''
+    return tempfile.mkdtemp()
+
+
 class TempDir(object):
     '''Context manager that creates and destroys a temporary directory.'''
 
@@ -1441,7 +1450,7 @@ class TempDir(object):
         self._name = None
 
     def __enter__(self):
-        self._name = tempfile.mkdtemp()
+        self._name = make_temp_dir()
         return self._name
 
     def __exit__(self, *args):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1364,7 +1364,7 @@ class VideoSetLabels(Set):
 
 
 class BigVideoSetLabels(VideoSetLabels, BigSet):
-    '''A BigSet of ImageSetLabels.
+    '''A BigSet of VideoSetLabels.
 
      Attributes:
         videos: an OrderedDict of VideoLabels with filenames as keys and BigSet

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1180,8 +1180,6 @@ class VideoSetLabels(Set):
         return super(VideoSetLabels, self).__getitem__(filename)
 
     def __setitem__(self, filename, video_labels):
-        video_labels.filename = filename
-
         if self.has_schema:
             self._apply_schema_to_video(video_labels)
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1297,7 +1297,7 @@ class VideoSetLabels(Set):
             video_labels.remove_schema()
 
     def _apply_schema(self):
-        for video_labels in self.videos:
+        for video_labels in self:
             self._apply_schema_to_video(video_labels)
 
     @classmethod

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1346,14 +1346,32 @@ class BigVideoSetLabels(VideoSetLabels, BigSet):
         self.schema = schema
         BigSet.__init__(self, backing_dir=backing_dir, videos=videos)
 
-    @classmethod
-    def from_dict(cls, d):
-        '''Constructs a BigVideoSetLabels from a JSON dictionary.'''
-        schema = d.pop("schema", None)
-        if schema is not None:
-            schema = VideoLabelsSchema.from_dict(schema)
+    def empty_set(self):
+        '''Returns an empty in-memory VideoSetLabels version of this
+        BigVideoSetLabels.
 
-        return BigSet.from_dict(d, schema=schema)
+        Returns:
+            an empty VideoSetLabels
+        '''
+        return VideoSetLabels(schema=self.schema)
+
+    def filter_by_schema(self, schema):
+        '''Removes objects/attributes from the VideoLabels in the set that are
+        not compliant with the given schema.
+
+        Args:
+            schema: a VideoLabelsSchema
+        '''
+        for key in self.keys():
+            video_labels = self[key]
+            video_labels.filter_by_schema(schema)
+            self[key] = video_labels
+
+    def _apply_schema(self):
+        for key in self.keys():
+            video_labels = self[key]
+            self._apply_schema_to_video(video_labels)
+            self[key] = video_labels
 
 
 class VideoStreamInfo(Serializable):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1210,14 +1210,6 @@ class VideoSetLabels(Set):
             self._apply_schema_to_video(video_labels)
         super(VideoSetLabels, self).add(video_labels)
 
-    def add_set(self, video_set_labels):
-        '''Merges the VideoSetLabels into the set.
-
-        Args:
-            video_set_labels: a VideoSetLabels instance
-        '''
-        self.add_iterable(video_set_labels)
-
     def get_filenames(self):
         '''Returns the set of filenames of VideoLabels in the set.
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1325,27 +1325,40 @@ class VideoSetLabels(Set):
 
 
 class BigVideoSetLabels(VideoSetLabels, BigSet):
-    '''A BigSet of VideoSetLabels.
+    '''A BigSet of VideoLabels.
 
-     Attributes:
-        videos: an OrderedDict of VideoLabels with filenames as keys and BigSet
-            uuids for storage.
-        schema: an VideoLabelsSchema describing the schema of the video labels
+    Behaves identically to VideoSetLabels except that each VideoLabels is
+    stored on disk.
+
+    Attributes:
+        backing_dir: the backing directory in which the VideoLabels
+            are/will be stored
+        videos: an OrderedDict whose keys are filenames and whose values are
+            uuids for locating VideoLabels on disk
+        schema: a VideoLabelsSchema describing the schema of the labels
     '''
+
+    def __init__(self, backing_dir, videos=None, schema=None):
+        '''Creates a BigVideoSetLabels instance.
+
+        Args:
+            backing_dir: the backing directory in which the VideoLabels
+                are/will be stored
+            videos: an optional list of uuids for elements in the set
+            schema: an optional VideoLabelsSchema to enforce on the object.
+                By default, no schema is enforced
+        '''
+        self.schema = schema
+        BigSet.__init__(self, backing_dir, videos=videos)
 
     @classmethod
     def from_dict(cls, d):
         '''Constructs a BigVideoSetLabels from a JSON dictionary.'''
-
-        schema = d.get("schema", None)
+        schema = d.pop("schema", None)
         if schema is not None:
             schema = VideoLabelsSchema.from_dict(schema)
 
-        videos = d.pop("videos", [])
-
-        set_ = cls(**d)
-        setattr(set_, cls._ELE_ATTR, OrderedDict(videos))
-        return set_
+        return super(BigVideoSetLabels, cls).from_dict(d, schema=schema)
 
 
 class VideoStreamInfo(Serializable):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1151,21 +1151,26 @@ class VideoSetLabels(Set):
     accessed by `filename`-based lookup.
 
     Attributes:
-        videos: a list of VideoLabels instances
-        schema: a VideoLabelsSchema describing the schema of the video labels
+        videos: an OrderedDict of VideoLabels with filenames as keys
+        schema: a VideoLabelsSchema describing the schema of the labels
     '''
 
-    def __init__(self, **kwargs):
+    _ELE_ATTR = "videos"
+    _ELE_KEY_ATTR = "filename"
+    _ELE_CLS = VideoLabels
+    _ELE_CLS_FIELD = "_LABELS_CLS"
+
+    def __init__(self, videos=None, schema=None):
         '''Constructs a VideoSetLabels instance.
 
         Args:
-            videos: an optional list of VideoLabels instances. By default, an
-                empty list is created
+            videos: an optional iterable of VideoLabels. By default, an empty
+                set is created
             schema: an optional VideoLabelsSchema to enforce on the object.
                 By default, no schema is enforced
         '''
-        self.schema = kwargs.pop("schema", None)
-        super(VideoSetLabels, self).__init__(**kwargs)
+        self.schema = schema
+        super(VideoSetLabels, self).__init__(videos=videos)
 
     def __getitem__(self, filename):
         if filename not in self:

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1219,14 +1219,12 @@ class VideoSetLabels(Set):
         return set(vl.filename for vl in self if vl.filename)
 
     def get_schema(self):
-        '''Gets the current enforced schema for the video set, or None if no
-        schema is enforced.
-        '''
+        '''Gets the schema for the set, or None if no schema is enforced.'''
         return self.schema
 
     def get_active_schema(self):
         '''Returns a VideoLabelsSchema describing the active schema of the
-        video set.
+        set.
         '''
         schema = VideoLabelsSchema()
         for video_labels in self:
@@ -1235,18 +1233,18 @@ class VideoSetLabels(Set):
         return schema
 
     def set_schema(self, schema, filter_by_schema=False):
-        '''Sets the enforced schema to the given VideoLabelsSchema.
+        '''Sets the schema to the given VideoLabelsSchema.
 
         Args:
             schema: the VideoLabelsSchema to use
             filter_by_schema: whether to filter any invalid objects/attributes
-                from this object after changing the schema. By default, this is
+                from the set after changing the schema. By default, this is
                 False
 
         Raises:
-            VideoLabelsSchemaError: if `filter_by_schema` was False and this
-                object contains attributes/objects that are not compliant with
-                the schema
+            VideoLabelsSchemaError: if `filter_by_schema` was False and the
+                set contains attributes/objects that are not compliant with the
+                schema
         '''
         self.schema = schema
 
@@ -1256,8 +1254,8 @@ class VideoSetLabels(Set):
         self._apply_schema()
 
     def filter_by_schema(self, schema):
-        '''Removes objects/attributes from the VideoLabels in this object that
-        are not compliant with the given schema.
+        '''Removes objects/attributes from the VideoLabels in the set that are
+        not compliant with the given schema.
 
         Args:
             schema: a VideoLabelsSchema
@@ -1266,13 +1264,11 @@ class VideoSetLabels(Set):
             video_labels.filter_by_schema(schema)
 
     def freeze_schema(self):
-        '''Sets the enforced schema for the video set to the current active
-        schema.
-        '''
+        '''Sets the schema for the set to the current active schema.'''
         self.set_schema(self.get_active_schema())
 
     def remove_schema(self):
-        '''Removes the enforced schema from the video set.'''
+        '''Removes the schema from the set.'''
         self.schema = None
         self._apply_schema()
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1175,7 +1175,7 @@ class VideoSetLabels(Set):
     def __getitem__(self, filename):
         if filename not in self:
             video_labels = VideoLabels(filename=filename)
-            self.add_video_labels(video_labels)
+            self.add(video_labels)
 
         return super(VideoSetLabels, self).__getitem__(filename)
 
@@ -1185,7 +1185,7 @@ class VideoSetLabels(Set):
         if self.has_schema:
             self._apply_schema_to_video(video_labels)
 
-        super(VideoLabels, self).__setitem__(filename, video_labels)
+        super(VideoSetLabels, self).__setitem__(filename, video_labels)
 
     @property
     def has_schema(self):
@@ -1202,20 +1202,23 @@ class VideoSetLabels(Set):
         '''
         return self.__class__(schema=self.schema)
 
-    def add_video_labels(self, video_labels):
+    def add(self, video_labels):
         '''Adds the VideoLabels to the set.
 
         Args:
-            video_labels: an VideoLabels instance
+            video_labels: a VideoLabels instance
         '''
         if self.has_schema:
             self._apply_schema_to_video(video_labels)
-        self.add(video_labels)
+        super(VideoSetLabels, self).add(video_labels)
 
-    def merge_video_set_labels(self, video_set_labels):
-        '''Merges the given VideoSetLabels into this labels.'''
-        for video_labels in video_set_labels:
-            self.add_video_labels(video_labels)
+    def add_set(self, video_set_labels):
+        '''Merges the VideoSetLabels into the set.
+
+        Args:
+            video_set_labels: a VideoSetLabels instance
+        '''
+        self.add_iterable(video_set_labels)
 
     def get_filenames(self):
         '''Returns the set of filenames of VideoLabels in the set.
@@ -1232,7 +1235,7 @@ class VideoSetLabels(Set):
         return self.schema
 
     def get_active_schema(self):
-        '''Returns an VideoLabelsSchema describing the active schema of the
+        '''Returns a VideoLabelsSchema describing the active schema of the
         video set.
         '''
         schema = VideoLabelsSchema()
@@ -1283,49 +1286,6 @@ class VideoSetLabels(Set):
         self.schema = None
         self._apply_schema()
 
-    def filter_video_labels(self, filters, match=any):
-        '''Removes VideoLabels that don't match the given filters from the set.
-
-        Args:
-            filters: a list of functions that accept VideoLabels and return
-                True/False
-            match: a function (usually `any` or `all`) that accepts an iterable
-                and returns True/False. Used to aggregate the outputs of each
-                filter to decide whether a match has occurred. The default is
-                `any`
-        '''
-        self.filter_elements(filters, match=match)
-
-    def delete_video_labels(self, filenames):
-        '''Deletes VideoLabels from the set with the given filenames.
-
-        Args:
-            filenames: an iterable of filenames to delete
-        '''
-        self.delete_keys(filenames)
-
-    def keep_video_labels(self, filenames):
-        '''Keeps only the VideoLabels in the set with the given filenames.
-
-        Args:
-            filenames: an iterable of filenames to keep
-        '''
-        self.keep_keys(filenames)
-
-    def extract_video_labels(self, filenames):
-        '''Returns a new VideoSetLabels having only the VideoLabels with the
-        given filenames.
-
-        The VideoLabels are passed by reference, not copied.
-
-        Args:
-            filenames: an iterable of filenames to keep
-
-        Returns:
-            a VideoSetLabels with the requested labels
-        '''
-        return self.extract_keys(filenames)
-
     def sort_by_filename(self, reverse=False):
         '''Sorts the VideoLabels in this instance by filename.
 
@@ -1356,16 +1316,12 @@ class VideoSetLabels(Set):
 
     @classmethod
     def from_dict(cls, d):
-        '''Constructs an VideoSetLabels from a JSON dictionary.'''
-        videos = d.get("videos", None)
-        if videos is not None:
-            videos = [VideoLabels.from_dict(vl) for vl in videos]
-
-        schema = d.get("schema", None)
+        '''Constructs a VideoSetLabels from a JSON dictionary.'''
+        schema = d.pop("schema", None)
         if schema is not None:
             schema = VideoLabelsSchema.from_dict(schema)
 
-        return cls(videos=videos, schema=schema)
+        return super(VideoSetLabels, cls).from_dict(d, schema=schema)
 
 
 class BigVideoSetLabels(VideoSetLabels, BigSet):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1320,26 +1320,35 @@ class BigVideoSetLabels(VideoSetLabels, BigSet):
     Behaves identically to VideoSetLabels except that each VideoLabels is
     stored on disk.
 
+    BigVideoSetLabels store a `backing_dir` attribute that specifies the path
+    on disk to the serialized elements. If a backing directory is explicitly
+    provided, the directory will be maintained after the BigVideoSetLabels
+    object is deleted; if no backing directory is specified, a temporary
+    backing directory is used and is deleted when the BigVideoSetLabels
+    instance is garbage collected.
+
     Attributes:
-        backing_dir: the backing directory in which the VideoLabels
-            are/will be stored
         videos: an OrderedDict whose keys are filenames and whose values are
             uuids for locating VideoLabels on disk
         schema: a VideoLabelsSchema describing the schema of the labels
+        backing_dir: the backing directory in which the VideoLabels
+            are/will be stored
     '''
 
-    def __init__(self, backing_dir, videos=None, schema=None):
+    def __init__(self, videos=None, schema=None, backing_dir=None):
         '''Creates a BigVideoSetLabels instance.
 
         Args:
-            backing_dir: the backing directory in which the VideoLabels
-                are/will be stored
-            videos: an optional list of uuids for elements in the set
+            videos: an optional dictionary or list of (key, uuid) tuples for
+                elements in the set
             schema: an optional VideoLabelsSchema to enforce on the object.
                 By default, no schema is enforced
+            backing_dir: an optional backing directory in which the VideoLabels
+                are/will be stored. If omitted, a temporary backing directory
+                is used
         '''
         self.schema = schema
-        BigSet.__init__(self, backing_dir, videos=videos)
+        BigSet.__init__(self, backing_dir=backing_dir, videos=videos)
 
     @classmethod
     def from_dict(cls, d):
@@ -1348,7 +1357,7 @@ class BigVideoSetLabels(VideoSetLabels, BigSet):
         if schema is not None:
             schema = VideoLabelsSchema.from_dict(schema)
 
-        return super(BigVideoSetLabels, cls).from_dict(d, schema=schema)
+        return BigSet.from_dict(d, schema=schema)
 
 
 class VideoStreamInfo(Serializable):


### PR DESCRIPTION
This PR builds on top of commit https://github.com/voxel51/eta/pull/279/commits/e20096867226c80e9a3d0aea01059d2a461ccb5f of the outstanding `big-set` PR.

@benjaminpkane While I was working on this, I noticed that you started working on `BigMixin` in the `big-set` branch... Oops!! My plan was to merge this into `big-set`, but there are now nasty merge conflicts. Perhaps you can port your `BigMixin` ideas into this branch? It should be straightforward now that this branch is fully functional.

This PR does the following:
- Adds a completely functional `BigSet` with options for manual or automatic temporary backing directories
- Adds support for automatic temporary backing directories to `BigContainer`
- Adds `BigLabeledPointContainer` and `BigLabeledPointSet` classes to `eta.core.geometry` to facilitate easy testing
- Finishes the implementations of `BigImageSetLabels` and `BigVideoSetLabels`

Observations
- `BigLabeledPointContainer` and `BigLabeledPointSet` confirm that `BigContainer` and `BigSet` are working as expected: one can create `Big` versions of existing `Set/Container` classes with no method overrides!! 
- The presence of the additional `schema` field of  `ImageSetLabels` and `VideoSetLabels` makes the situation a little more complicated. Some additional methods needed to be overridden, and tracing the superclass calls makes my brain hurt... But, the tests below verify that things are working!

Tests
```py
################################################################################
# Test BigSet
################################################################################

# rm -rf /tmp/zzz*

import eta.core.geometry as etag
import eta.core.utils as etau

points = etag.BigLabeledPointSet(backing_dir="/tmp/zzz")
points.add_iterable([
    etag.LabeledPoint("bl", etag.RelativePoint(0, 0)),
    etag.LabeledPoint("br", etag.RelativePoint(1, 0)),
    etag.LabeledPoint("tr", etag.RelativePoint(1, 1)),
    etag.LabeledPoint("tl", etag.RelativePoint(0, 1)),
])

print(points["bl"])
print(points)

points.to_archive("/tmp/zzz.tar.gz")
points2 = etag.BigLabeledPointSet.from_archive("/tmp/zzz.tar.gz", backing_dir="/tmp/zzz2")
print(points2)

points2.move(backing_dir="/tmp/zzz2b")
print(points2)

points2.add_set(points)
print(points2)
print(points2.to_set())

points2.to_archive("/tmp/zzz2.zip")
points2c = etag.BigLabeledPointSet.from_archive("/tmp/zzz2.zip", backing_dir="/tmp/zzz2c")
print(points2c)

points2.delete_keys(["br", "tl"])
print(points2)

points2.keep_keys(["bl"])
print(points2)

points2.add_set(points)
print(points2)

points3 = points2.extract_keys(["br", "tl"], backing_dir="/tmp/zzz3")
print(points3)

paths = list(points3._ele_paths)
points4 = etag.BigLabeledPointSet.from_paths(paths, backing_dir="/tmp/zzz4")
print(points4)

points5 = etag.BigLabeledPointSet.from_dir("/tmp/zzz4", backing_dir="/tmp/zzz5")
print(points5)

points6 = etag.BigLabeledPointSet.from_str(points.to_str())
print(points6)

# Test automatic temporary directory handling
points7 = etag.BigLabeledPointSet()
points7.add_set(points)
backing_dir7 = points7.backing_dir
print(etau.list_files(backing_dir7))
del points7
print(etau.list_files(backing_dir7))

################################################################################
# Test BigContainer
################################################################################

# rm -rf /tmp/zzz*

import eta.core.geometry as etag
import eta.core.utils as etau

point = etag.LabeledPoint("origin", etag.RelativePoint(0, 0))

points = etag.BigLabeledPointContainer(backing_dir="/tmp/zzz")
points.add(point)

print(points[0])
print(points)

points.to_archive("/tmp/zzz.tar.gz")
points2 = etag.BigLabeledPointContainer.from_archive("/tmp/zzz.tar.gz", backing_dir="/tmp/zzz2")
print(points2)

points2.move(backing_dir="/tmp/zzz2b")
print(points2)

points2.add(point)
points2.add_container(points)
print(points2)
print(points2.to_container())

points2.to_archive("/tmp/zzz2.zip")
points2c = etag.BigLabeledPointContainer.from_archive("/tmp/zzz2.zip", backing_dir="/tmp/zzz2c")
print(points2c)

points2.delete_inds([0])
print(points2)

points2.keep_inds([1])
print(points2)

points2.add_container(points)
print(points2)

points3 = points2.extract_inds([0, 1], backing_dir="/tmp/zzz3")
print(points3)

paths = list(points3._ele_paths)
points4 = etag.BigLabeledPointContainer.from_paths(paths, backing_dir="/tmp/zzz4")
print(points4)

points5 = etag.BigLabeledPointContainer.from_dir("/tmp/zzz4", backing_dir="/tmp/zzz5")
print(points5)

points6 = etag.BigLabeledPointContainer.from_str(points.to_str())
print(points6)

# Test automatic temporary directory handling
points7 = etag.BigLabeledPointContainer()
points7.add_container(points)
backing_dir7 = points7.backing_dir
print(etau.list_files(backing_dir7))
del points7
print(etau.list_files(backing_dir7))

################################################################################
# Test BigVideoSetLabels
################################################################################

import eta.core.data as etad
import eta.core.geometry as etag
import eta.core.video as etav
import eta.core.objects as etao
from eta.core.serial import Serializable

# Video attributes
vattr1 = etad.CategoricalAttribute("weather", "rain", confidence=0.95)
vattr2 = etad.NumericAttribute("fps", 30)
vattr3 = etad.BooleanAttribute("daytime", True)

# Frame attributes
fattr1 = etad.CategoricalAttribute("scene", "intersection", confidence=0.9)
fattr2 = etad.NumericAttribute("quality", 0.5)
fattr3 = etad.BooleanAttribute("on_road", True)

# Create some objects
tl = etag.RelativePoint(0, 0)
br = etag.RelativePoint(1, 1)
bb = etag.BoundingBox(tl, br)
obj1 = etao.DetectedObject("car", bb, confidence=0.9, index=1)
obj1.add_attribute(etad.CategoricalAttribute("make", "Honda"))
obj2 = etao.DetectedObject("person", bb, index=2)
obj2.add_attribute(etad.NumericAttribute("age", 42, confidence=0.99))

#
# Populate VideoSetLabels
#

video_labels1 = etav.VideoLabels(filename="video1.mp4")
video_labels2 = etav.VideoLabels(filename="video2.mov")

vattrs = etad.AttributeContainer()
vattrs.add(vattr2)
vattrs.add(vattr3)
video_labels1.add_video_attribute(vattr1)
video_labels2.add_video_attributes(vattrs)

# Add a frame
frame_labels1 = etav.VideoFrameLabels(1)
frame_labels1.add_frame_attribute(fattr1)
frame_labels1.add_object(obj1)
video_labels1.add_frame(frame_labels1)

frame_labels2 = etav.VideoFrameLabels(1)
frame_labels2.add_frame_attribute(fattr2)
video_labels2.add_frame(frame_labels2)

# Add another frame a different way
video_labels1.add_frame_attribute(fattr3, 2)
video_labels2.add_object(obj2, 2)

video_set_labels = etav.BigVideoSetLabels()
video_set_labels.add(video_labels1)
video_set_labels.add(video_labels2)

# Test serialization
etav.BigVideoSetLabels.from_str(str(video_set_labels))
Serializable.from_str(video_set_labels.to_str(reflective=True))

# Test schema
print(video_set_labels)
video_set_labels.freeze_schema()
print(video_set_labels)
video_set_labels.remove_schema()
print(video_set_labels)
video_set_labels.freeze_schema()

# Test schema filtering
print(video_set_labels.to_set())
video_set_labels.filter_by_schema(etav.VideoLabelsSchema())
print(video_set_labels.to_set())

################################################################################
# Test BigImageSetLabels
################################################################################

import eta.core.data as etad
import eta.core.image as etai
import eta.core.geometry as etag
import eta.core.objects as etao
from eta.core.serial import Serializable

# Attributes
iattr1 = etad.CategoricalAttribute("scene", "intersection", confidence=0.9)
iattr2 = etad.NumericAttribute("quality", 0.5)
iattr3 = etad.BooleanAttribute("on_road", True)

# Objects
tl = etag.RelativePoint(0, 0)
br = etag.RelativePoint(1, 1)
bb = etag.BoundingBox(tl, br)
obj1 = etao.DetectedObject("car", bb, confidence=0.9, index=1)
obj1.add_attribute(etad.CategoricalAttribute("make", "Honda"))
obj2 = etao.DetectedObject("person", bb, index=2)
obj2.add_attribute(etad.NumericAttribute("age", 42, confidence=0.99))

# Test BigImageSetLabels
image_set_labels = etai.BigImageSetLabels()

image_labels1 = etai.ImageLabels()
image_labels1a = etai.ImageLabels()
image_labels1b = etai.ImageLabels()

image_labels1.add_image_attribute(iattr1)
image_labels1a.add_image_attribute(iattr2)
image_labels1b.add_object(obj1)
image_labels1.merge_labels(image_labels1a)
image_labels1.merge_labels(image_labels1b)

image_labels2 = etai.ImageLabels()
image_labels2.add_image_attribute(iattr3)
image_labels2.add_object(obj2)

image_set_labels2 = etai.BigImageSetLabels()
image_set_labels2.add(image_labels2)

image_set_labels.add(image_labels1)
image_set_labels.add_set(image_set_labels2)

# Verify serialization
etai.BigImageSetLabels.from_str(str(image_set_labels))
Serializable.from_str(image_set_labels.to_str(reflective=True))

# Test schema
print(image_set_labels)
image_set_labels.freeze_schema()
print(image_set_labels)

# Test schema filtering
print(image_set_labels.to_set())
image_set_labels.filter_by_schema(etai.ImageLabelsSchema())
print(image_set_labels.to_set())
```