### PR TITLE
Using frombuffer when reading video frames, for efficiency

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2368,7 +2368,7 @@ class FFmpegVideoReader(VideoReader):
 
         width, height = self.frame_size
         try:
-            vec = np.fromstring(self._raw_frame, dtype="uint8")
+            vec = np.frombuffer(self._raw_frame, dtype="uint8")
             return vec.reshape((height, width, 3))
         except ValueError as e:
             # Possible alternative: return all zeros matrix instead


### PR DESCRIPTION
`fromstring` works, but it copies the data. `frombuffer` avoids copying the data:
https://stackoverflow.com/questions/22236749/numpy-what-is-the-difference-between-frombuffer-and-fromstring
