### PR TITLE
Adding module to sample frames from a video

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -24,7 +24,7 @@
     "patterns": {},
     "max_model_versions_to_keep": -1,
     "allow_model_downloads": true,
-    "default_sequence_idx" : "%05d",
+    "default_sequence_idx" : "%06d",
     "default_video_ext": ".mp4",
-    "default_image_ext": ".png"
+    "default_image_ext": ".jpg"
 }

--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -496,6 +496,32 @@ class Config(etas.Serializable):
         return _parse_key(d, key, None, default)[0]
 
     @staticmethod
+    def parse_categorical(d, key, choices, default=no_default):
+        '''Parses a categorical JSON field, which must take a value from among
+        the given choices.
+
+        Args:
+            d: a JSON dictionary
+            key: the key to parse
+            choices: an iterable of possible values
+            default: a default value to return if key is not present
+
+        Returns:
+            the raw (untouched) value of the given field, which is equal to a
+            value from `choices`
+
+        Raises:
+            ConfigError: if the key was present in the dictionary but its value
+                was not an allowed choice, or if no default value was provided
+                and the key was not found in the dictionary
+        '''
+        val, found = _parse_key(d, key, None, default)
+        if found and val not in choices:
+            raise ConfigError(
+                "Unsupported value %s; choices are %s" % (val, choices))
+        return val
+
+    @staticmethod
     def parse_mutually_exclusive_fields(fields):
         '''Parses a mutually exclusive dictionary of pre-parsed fields, which
         must contain exactly one field with a truthy value.

--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -538,7 +538,7 @@ class Config(etas.Serializable):
         d = [(k, v) for k, v in iteritems(fields) if v]
         num_fields = len(d)
         if num_fields != 1:
-            ConfigError(
+            raise ConfigError(
                 "Expected exactly one field in the following to be specified, "
                 "but found %d:\n%s" % (num_fields, etas.pretty_str(d)))
         return d[0]

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -759,7 +759,10 @@ def read(path, include_alpha=False, flag=None):
         a uint8 numpy array containing the image
     '''
     flag = _get_opencv_imread_flag(flag, include_alpha)
-    return _exchange_rb(cv2.imread(path, flag))
+    img_bgr = cv2.imread(path, flag)
+    if img_bgr is None:
+        raise OSError("Image not found '%s'" % path)
+    return _exchange_rb(img_bgr)
 
 
 def write(img, path):

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -95,7 +95,7 @@ def run(
 
 
 def _make_pipeline_status(pipeline_config):
-    pipeline_status = etas.PipelineStatus(pipeline_config.name)
+    pipeline_status = etas.PipelineStatus(name=pipeline_config.name)
 
     if pipeline_config.status_path:
         pcb = _make_publish_status_callback(pipeline_config.status_path)

--- a/eta/core/status.py
+++ b/eta/core/status.py
@@ -55,23 +55,28 @@ class PipelineStatus(Serializable):
             that make up the pipeline
     '''
 
-    def __init__(self, name, serialize_jobs=True):
+    def __init__(
+            self, name=None, state=PipelineState.READY, start_time=None,
+            complete_time=None, fail_time=None, messages=None, jobs=None):
         '''Construct a new PipelineStatus instance.
 
         Args:
             name: the name of the pipeline
-            serialize_jobs: whether to include jobs when serializing this
-                instance
+            state: an optional PipelineState of the pipeline. The default is
+                PipelineState.READY
+            start_time: the time the pipeline started, if applicable
+            complete_time: the time the pipeline completed, if applicable
+            fail_time: the time the pipeline failed, if applicable
+            messages: an optional list of StatusMessage instances
+            jobs: an optional list of JobStatus instances
         '''
-        self.name = name
+        self.name = name or ""
         self.state = PipelineState.READY
         self.start_time = None
         self.complete_time = None
         self.fail_time = None
         self.messages = []
         self.jobs = []
-
-        self._serialize_jobs = serialize_jobs
         self._publish_callback = None
         self._active_job = None
 
@@ -130,28 +135,25 @@ class PipelineStatus(Serializable):
         self.state = PipelineState.FAILED
 
     def attributes(self):
-        attrs = [
+        '''Returns a list of class attributes to be serialized.'''
+        return [
             "name", "state", "start_time", "complete_time", "fail_time",
-            "messages"]
-        if self._serialize_jobs:
-            attrs.append("jobs")
-        return attrs
+            "messages", "jobs"]
 
     @classmethod
     def from_dict(cls, d):
         '''Constructs a PipelineStatus instance from a JSON dictionary.'''
-        pipeline_status = cls(d["name"])
-        pipeline_status.state = d["state"]
-        pipeline_status.start_time = d["start_time"]
-        pipeline_status.complete_time = d["complete_time"]
-        pipeline_status.fail_time = d["fail_time"]
-        pipeline_status.messages = [
-            StatusMessage.from_dict(_d) for _d in d["messages"]
-        ]
-        pipeline_status.jobs = [
-            JobStatus.from_dict(_d) for _d in d.get("jobs", [])
-        ]
-        return pipeline_status
+        name = d["name"]
+        state = d["state"]
+        start_time = d["start_time"]
+        complete_time = d["complete_time"]
+        fail_time = d["fail_time"]
+        messages = [StatusMessage.from_dict(sd) for sd in d["messages"]]
+        jobs = [JobStatus.from_dict(_d) for _d in d.get("jobs", [])]
+        return cls(
+            name, state=state, start_time=start_time,
+            complete_time=complete_time, fail_time=fail_time,
+            messages=messages, jobs=jobs)
 
 
 class JobState(object):

--- a/eta/core/status.py
+++ b/eta/core/status.py
@@ -14,7 +14,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import *
-from future.utils import iteritems
 # pragma pylint: enable=redefined-builtin
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
@@ -71,12 +70,13 @@ class PipelineStatus(Serializable):
             jobs: an optional list of JobStatus instances
         '''
         self.name = name or ""
-        self.state = PipelineState.READY
-        self.start_time = None
-        self.complete_time = None
-        self.fail_time = None
-        self.messages = []
-        self.jobs = []
+        self.state = state
+        self.start_time = start_time
+        self.complete_time = complete_time
+        self.fail_time = fail_time
+        self.messages = messages or []
+        self.jobs = jobs or []
+
         self._publish_callback = None
         self._active_job = None
 

--- a/eta/core/status.py
+++ b/eta/core/status.py
@@ -149,7 +149,7 @@ class PipelineStatus(Serializable):
         complete_time = d["complete_time"]
         fail_time = d["fail_time"]
         messages = [StatusMessage.from_dict(sd) for sd in d["messages"]]
-        jobs = [JobStatus.from_dict(_d) for _d in d.get("jobs", [])]
+        jobs = [JobStatus.from_dict(jd) for jd in d.get("jobs", [])]
         return cls(
             name, state=state, start_time=start_time,
             complete_time=complete_time, fail_time=fail_time,
@@ -235,8 +235,7 @@ class JobStatus(Serializable):
         job_status.complete_time = d["complete_time"]
         job_status.fail_time = d["fail_time"]
         job_status.messages = [
-            StatusMessage.from_dict(_d) for _d in d["messages"]
-        ]
+            StatusMessage.from_dict(sd) for sd in d["messages"]]
         return job_status
 
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -555,6 +555,10 @@ class VideoLabels(Serializable):
     def __getitem__(self, frame_number):
         return self.get_frame(frame_number)
 
+    def __setitem__(self, frame_number, frame_labels):
+        frame_labels.frame_number = frame_number
+        self.add_frame(frame_labels, overwrite=True)
+
     def __delitem__(self, frame_number):
         self.delete_frame(frame_number)
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -592,6 +592,10 @@ class VideoLabels(Serializable):
         '''Deletes the VideoFrameLabels for the given frame number.'''
         del self.frames[frame_number]
 
+    def get_frame_numbers(self):
+        '''Returns a sorted list of all frames with VideoFrameLabels.'''
+        return sorted(self.frames.keys())
+
     def merge_video_labels(self, video_labels):
         '''Merges the given VideoLabels into this labels.'''
         self.attrs.add_container(video_labels.attrs)

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -596,6 +596,11 @@ class VideoLabels(Serializable):
         '''Returns a sorted list of all frames with VideoFrameLabels.'''
         return sorted(self.frames.keys())
 
+    def get_frame_range(self):
+        '''Returns the (min, max) frame numbers with VideoFrameLabels.'''
+        fns = self.get_frame_numbers()
+        return (fns[0], fns[-1]) if fns else (None, None)
+
     def merge_video_labels(self, video_labels):
         '''Merges the given VideoLabels into this labels.'''
         self.attrs.add_container(video_labels.attrs)

--- a/eta/modules/sample_videos.json
+++ b/eta/modules/sample_videos.json
@@ -1,0 +1,62 @@
+{
+    "info": {
+        "name": "sample_videos",
+        "type": "eta.core.types.Module",
+        "version": "0.1.0",
+        "description": "A module for sampling frames from videos",
+        "exe": "sample_videos.py"
+    },
+    "inputs": [
+        {
+            "name": "input_path",
+            "type": "eta.core.types.Video",
+            "description": "The input video",
+            "required": true
+        }
+    ],
+    "outputs": [
+        {
+            "name": "output_frames_dir",
+            "type": "eta.core.types.ImageSequenceDirectory",
+            "description": "A directory of sampled frames",
+            "required": true
+        }
+    ],
+    "parameters": [
+        {
+            "name": "max_size",
+            "type": "eta.core.types.Array",
+            "description": "A maximum (width, height) allowed for the sampled frames. Frames are resized as necessary to meet this limit. Dimensions can be -1, in which case no constraint is applied to them",
+            "required": false,
+            "default": null
+        },
+        {
+            "name": "always_sample_last",
+            "type": "eta.core.types.Boolean",
+            "description": "Whether to always sample the last frame of the video",
+            "required": false,
+            "default": false
+        },
+        {
+            "name": "accel",
+            "type": "eta.core.types.Number",
+            "description": "A desired acceleration factor to apply when sampling fframes. For example, an acceleration of 2x would correspond to sampling every other frame",
+            "required": false,
+            "default": null
+        },
+        {
+            "name": "fps",
+            "type": "eta.core.types.Number",
+            "description": "The desired sampling rate, which must be less than the frame rate of the input video",
+            "required": false,
+            "default": null
+        },
+        {
+            "name": "size",
+            "type": "eta.core.types.Array",
+            "description": "A desired output (width, height) of the sampled frames. Dimensions can be -1, in which case the input aspect ratio is preserved",
+            "required": false,
+            "default": null
+        }
+    ]
+}

--- a/eta/modules/sample_videos.json
+++ b/eta/modules/sample_videos.json
@@ -40,7 +40,7 @@
         {
             "name": "accel",
             "type": "eta.core.types.Number",
-            "description": "A desired acceleration factor to apply when sampling fframes. For example, an acceleration of 2x would correspond to sampling every other frame",
+            "description": "A desired acceleration factor to apply when sampling frames. For example, an acceleration of 2x would correspond to sampling every other frame",
             "required": false,
             "default": null
         },

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -151,7 +151,8 @@ def _process_video(input_path, output_frames_dir, parameters):
 
     # Sample frames
     output_patt = os.path.join(
-        output_frames_dir, eta.config.default_sequence_idx)
+        output_frames_dir,
+        eta.config.default_sequence_idx + eta.config.default_image_ext)
     with etav.FFmpegVideoReader(input_path) as vr:
         for img in vr:
             if vr.frame_number not in sample_frames:

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -30,6 +30,8 @@ import logging
 import os
 import sys
 
+import numpy as np
+
 import eta
 from eta.core.config import Config, ConfigError
 import eta.core.image as etai
@@ -128,8 +130,8 @@ def _process_video(input_path, output_frames_dir, parameters):
         raise ConfigError("One of `accel` or `fps` must be specified")
 
     # Determine frames to sample
-    maxi = int(iframe_count / accel)  # rounds down
-    sample_frames = set(1 + int(round(accel * i)) for i in range(maxi))
+    sample_pts = np.arange(1, iframe_count, accel)
+    sample_frames = set(int(round(x)) for x in sample_pts)
     if parameters.always_sample_last:
         sample_frames.add(iframe_count)
 

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+'''
+A module for sampling frames from videos.
+
+The sampled frames are written to a directory with filenames that encode their
+frame number in the original video.
+
+Info:
+    type: eta.core.types.Module
+    version: 0.1.0
+
+Copyright 2017-2019, Voxel51, Inc.
+voxel51.com
+
+Brian Moore, brian@voxel51.com
+'''
+# pragma pylint: disable=redefined-builtin
+# pragma pylint: disable=unused-wildcard-import
+# pragma pylint: disable=wildcard-import
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import *
+# pragma pylint: enable=redefined-builtin
+# pragma pylint: enable=unused-wildcard-import
+# pragma pylint: enable=wildcard-import
+
+import logging
+import sys
+
+from eta.core.config import Config, ConfigError
+import eta.core.image as etai
+import eta.core.module as etam
+import eta.core.numutils as etan
+import eta.core.utils as etau
+import eta.core.video as etav
+
+
+logger = logging.getLogger(__name__)
+
+
+class SampleVideosConfig(etam.BaseModuleConfig):
+    '''Formatter configuration settings.
+
+    Attributes:
+        data (DataConfig)
+        parameters (ParametersConfig)
+    '''
+
+    def __init__(self, d):
+        super(SampleVideosConfig, self).__init__(d)
+        self.data = self.parse_object_array(d, "data", DataConfig)
+        self.parameters = self.parse_object(d, "parameters", ParametersConfig)
+
+
+class DataConfig(Config):
+    '''Data configuration settings.
+
+    Inputs:
+        input_path (eta.core.types.Video): The input video
+
+    Outputs:
+        output_frames_dir (eta.core.types.ImageSequenceDirectory): A directory
+            of sampled frames
+    '''
+
+    def __init__(self, d):
+        self.input_path = self.parse_string(d, "input_path")
+        self.output_frames_dir = self.parse_string(d, "output_frames_dir")
+
+
+class ParametersConfig(Config):
+    '''Parameter configuration settings.
+
+    Parameters:
+        accel (eta.core.types.Number): [None] A desired acceleration factor to
+            apply when sampling fframes. For example, an acceleration of 2x
+            would correspond to sampling every other frame
+        fps (eta.core.types.Number): [None] The desired sampling rate, which
+            must be less than the frame rate of the input video
+        size (eta.core.types.Array): [None] A desired output (width, height)
+            of the sampled frames. Dimensions can be -1, in which case the
+            input aspect ratio is preserved
+        max_size (eta.core.types.Array): [None] A maximum (width, height)
+            allowed for the sampled frames. Frames are resized as necessary to
+            meet this limit. Dimensions can be -1, in which case no constraint
+            is applied to them
+        always_sample_last (eta.core.types.Boolean): [False] Whether to always
+            sample the last frame of the video
+    '''
+
+    def __init__(self, d):
+        self.accel = self.parse_number(d, "accel", default=1.0)
+        self.fps = self.parse_number(d, "fps", default=None)
+        self.size = self.parse_array(d, "size", default=None)
+        self.max_size = self.parse_array(d, "max_size", default=None)
+        self.always_sample_last = self.parse_bool(
+            d, "always_sample_last", default=False)
+
+
+def _sample_videos(config):
+    parameters = config.parameters
+    for data in config.data:
+        _process_video(data.input_path, data.output_frames_dir, parameters)
+
+
+def _process_video(input_path, output_frames_dir, parameters):
+    stream_info = etav.VideoStreamInfo.build_for(input_path)
+    ifps = stream_info.frame_rate
+    isize = stream_info.frame_size
+    iframe_count = stream_info.total_frame_count
+
+    # Compute acceleration
+    if parameters.accel is not None:
+        if parameters.accel < 1:
+            raise ValueError(
+                "Acceleration factor must be greater than 1; found "
+                "%d" % parameters.accel)
+        accel = parameters.accel
+    elif parameters.fps is not None:
+        if parameters.fps > ifps:
+            raise ValueError(
+                "Sampling frame rate (%d) cannot be greater than input frame "
+                "rate (%d)", parameters.fps, ifps)
+        accel = ifps / parameters.fps
+    else:
+        raise ConfigError("One of `accel` or `fps` must be specified")
+
+    # Determine frames to sample
+    maxi = int(iframe_count / accel)  # rounds down
+    sample_frames = set(1 + int(round(accel * i)) for i in range(maxi))
+    if parameters.always_sample_last:
+        sample_frames.add(iframe_count)
+
+    # Compute output frame size
+    if parameters.size:
+        psize = etai.parse_frame_size(parameters.size)
+        osize = etai.infer_missing_dims(psize, isize)
+    else:
+        osize = isize
+    if parameters.max_size:
+        msize = etai.parse_frame_size(parameters.max_size)
+        osize = etai.clamp_frame_size(osize, msize)
+
+    # Avoid resizing if possible
+    same_size = osize == isize
+    if not same_size:
+        owidth, oheight = osize
+        logger.info("Resizing frames to %d x %d", owidth, oheight)
+
+    # Sample frames
+    output_patt = os.path.join(
+        output_frames_dir, eta.config.default_sequence_idx)
+    with etav.FFmpegVideoReader(input_path) as vr:
+        for img in vr:
+            if vr.frame_number not in sample_frames:
+                continue
+            if not same_size:
+                img = etai.resize(img, width=owidth, height=oheight)
+
+            logger.debug("Sampling frame %d", vr.frame_number)
+            etai.write(img, output_patt % vr.frame_number)
+
+
+def run(config_path, pipeline_config_path=None):
+    '''Run the sample_videos module.
+
+    Args:
+        config_path: path to a SampleVideosConfig file
+        pipeline_config_path: optional path to a PipelineConfig file
+    '''
+    config = SampleVideosConfig.from_json(config_path)
+    etam.setup(config, pipeline_config_path=pipeline_config_path)
+    _sample_videos(config)
+
+
+if __name__ == "__main__":
+    run(*sys.argv[1:])

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -27,13 +27,13 @@ from builtins import *
 # pragma pylint: enable=wildcard-import
 
 import logging
+import os
 import sys
 
+import eta
 from eta.core.config import Config, ConfigError
 import eta.core.image as etai
 import eta.core.module as etam
-import eta.core.numutils as etan
-import eta.core.utils as etau
 import eta.core.video as etav
 
 
@@ -121,8 +121,8 @@ def _process_video(input_path, output_frames_dir, parameters):
     elif parameters.fps is not None:
         if parameters.fps > ifps:
             raise ValueError(
-                "Sampling frame rate (%d) cannot be greater than input frame "
-                "rate (%d)", parameters.fps, ifps)
+                "Sampling frame rate (%g) cannot be greater than input frame "
+                "rate (%g)" % (parameters.fps, ifps))
         accel = ifps / parameters.fps
     else:
         raise ConfigError("One of `accel` or `fps` must be specified")

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -77,7 +77,7 @@ class ParametersConfig(Config):
 
     Parameters:
         accel (eta.core.types.Number): [None] A desired acceleration factor to
-            apply when sampling fframes. For example, an acceleration of 2x
+            apply when sampling frames. For example, an acceleration of 2x
             would correspond to sampling every other frame
         fps (eta.core.types.Number): [None] The desired sampling rate, which
             must be less than the frame rate of the input video


### PR DESCRIPTION
Adding a `sample_videos` module that allows for sampling frames from a video with intuitive parameters such as "acceleration" (e.g., 2x accel means sample every other frame). Unlike the `format_videos` module, the frames are written to disk with their original frame numbers from the source video.

Also adds:
- an `eta.core.config.Config.parse_categorical` method to parse config fields that can only take one of a predefined set of values
- fully implements the `Serializable` interface for `eta.core.status.PipelineStatus`