### PR TITLE
Removing unused tensorflow/models directories during install

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ eta build -r classify-images-tfslim-template.json --patterns {{model}}=mobilenet
 cd ..
 ```
 
-View the images in the `demo_image_classifier/out/images-mobilenet-v2`
+View the images in the `demo_image_classifier/out/images-mobilenet-v2-imagenet`
 directory to inspect the output of the pipeline.
 
 

--- a/install.bash
+++ b/install.bash
@@ -262,7 +262,18 @@ CRITICAL protoc research/object_detection/protos/*.proto \
     --python_out=research
 MSG "You must have '$(pwd)/research' in 'pythonpath_dirs' in your ETA config"
 MSG "You must have '$(pwd)/research/slim' in 'pythonpath_dirs' in your ETA config"
-cd ../..
+
+#
+# Remove all tensorflow/models subdirectories that we don't use
+#
+MSG "Removing unused tensorflow/models subdirectories"
+rm -rf samples
+rm -rf tutorials
+cd research
+find . ! \( -name . -o -name "slim" -o -name "object_detection" \) -type d \
+    -exec rm -rf {} +
+
+cd ../../..
 
 
 EXIT "INSTALLATION COMPLETE"

--- a/install.bash
+++ b/install.bash
@@ -263,17 +263,18 @@ CRITICAL protoc research/object_detection/protos/*.proto \
 MSG "You must have '$(pwd)/research' in 'pythonpath_dirs' in your ETA config"
 MSG "You must have '$(pwd)/research/slim' in 'pythonpath_dirs' in your ETA config"
 
-#
 # Remove all tensorflow/models subdirectories that we don't use
-#
 MSG "Removing unused tensorflow/models subdirectories"
 rm -rf samples
 rm -rf tutorials
-cd research
-find . ! \( -name . -o -name "slim" -o -name "object_detection" \) -type d \
-    -exec rm -rf {} +
+mv research/slim .
+mv research/object_detection .
+rm -rf research
+mkdir -p research
+mv slim research
+mv object_detection research
 
-cd ../../..
+cd ../..
 
 
 EXIT "INSTALLATION COMPLETE"


### PR DESCRIPTION
ETA has https://github.com/tensorflow/models as a submodule, but we only use `research/slim` and `research/object_detection`. The installation process now deletes all other subdirectories, which saves 100's MBs of space.