### PR TITLE
Specify directory in which to put TempDir

### DIFF
--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1579,7 +1579,7 @@ class LabeledDatasetBuilder(object):
         '''Record class getter.'''
         return self._dataset.record_cls
 
-    def build(self, path, description=None, pretty_print=False):
+    def build(self, path, description=None, pretty_print=False, dir=None):
         '''Build the new LabeledDataset after all records and transformations
         have been added.
 
@@ -1587,6 +1587,7 @@ class LabeledDatasetBuilder(object):
             path (str): path to write the new dataset (manifest.json)
             description (str): optional dataset description
             pretty_print (bool): pretty print flag for json labels
+            dir (str): optional directory in which to make temp dirs
 
         Returns:
             LabeledDataset
@@ -1602,7 +1603,7 @@ class LabeledDatasetBuilder(object):
 
         dataset = self.dataset_cls.create_empty_dataset(path, description)
 
-        with etau.TempDir() as dir_path:
+        with etau.TempDir(dir=dir) as dir_path:
             for idx, record in enumerate(self._dataset):
                 result = record.build(dir_path, str(idx),
                                       pretty_print=pretty_print)

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1579,7 +1579,8 @@ class LabeledDatasetBuilder(object):
         '''Record class getter.'''
         return self._dataset.record_cls
 
-    def build(self, path, description=None, pretty_print=False, dir=None):
+    def build(self, path, description=None, pretty_print=False,
+              tmp_dir_base=None):
         '''Build the new LabeledDataset after all records and transformations
         have been added.
 
@@ -1587,7 +1588,7 @@ class LabeledDatasetBuilder(object):
             path (str): path to write the new dataset (manifest.json)
             description (str): optional dataset description
             pretty_print (bool): pretty print flag for json labels
-            dir (str): optional directory in which to make temp dirs
+            tmp_dir_base (str): optional directory in which to make temp dirs
 
         Returns:
             LabeledDataset
@@ -1603,7 +1604,7 @@ class LabeledDatasetBuilder(object):
 
         dataset = self.dataset_cls.create_empty_dataset(path, description)
 
-        with etau.TempDir(dir=dir) as dir_path:
+        with etau.TempDir(dir=tmp_dir_base) as dir_path:
             for idx, record in enumerate(self._dataset):
                 result = record.build(dir_path, str(idx),
                                       pretty_print=pretty_print)

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -1542,23 +1542,32 @@ class MD5FileHasher(FileHasher):
             return str(hashlib.md5(f.read()).hexdigest())
 
 
-def make_temp_dir():
+def make_temp_dir(dir=None):
     '''Makes a temporary directory.
+
+    Args:
+        dir: an optional directory in which to put the temp dir
 
     Returns:
         the path to the temporary directory
     '''
-    return tempfile.mkdtemp()
+    return tempfile.mkdtemp(dir=dir)
 
 
 class TempDir(object):
     '''Context manager that creates and destroys a temporary directory.'''
 
-    def __init__(self):
+    def __init__(self, dir=None):
+        '''Creates a TempDir instance.
+
+        Args:
+            dir: an optional directory in which to put the temp dir
+        '''
+        self._dir = dir
         self._name = None
 
     def __enter__(self):
-        self._name = make_temp_dir()
+        self._name = make_temp_dir(dir=self._dir)
         return self._name
 
     def __exit__(self, *args):


### PR DESCRIPTION
Added option to specify a directory in which to put the temp dir in TempDir class. This is useful if you want to make sure your temp dir is on a given disk, for example.