### PR TITLE
Update virtualenv_guide.md

### DIFF
--- a/docs/virtualenv_guide.md
+++ b/docs/virtualenv_guide.md
@@ -24,13 +24,15 @@ brew install python
 brew install python3
 ```
 * <b>Note:</b>
-Since we currently only support up to Python 3.6.X, you may need to brew install this older Python version. If you have had Python 3.6 installed previously, run the following:
+Since we currently only support Python 3.6.X, you may need to install this older Python version. Homebrew allows us to roll back to a previous version of Python. If, for example, you have had Python 3.6.5 installed previously, you may run the following:
 ```shell
+# Mac
 brew switch python 3.6.5_1
 ```
 
 * If you need a fresh install of Python 3.6.5, run the following:
 ```shell
+# Mac
 brew unlink python
 brew install pkg-config gdbm openssl readline sqlite xz
 brew install --ignore-dependencies https://raw.githubusercontent.com/Homebrew/homebrew-core/f2a764ef944b1080be64bd88dca9a1d80130c558/Formula/python.rb

--- a/docs/virtualenv_guide.md
+++ b/docs/virtualenv_guide.md
@@ -11,28 +11,12 @@ packages and Python applications on your machine.
 
 Follow these instructions to create Python 2 and Python 3 virtual environments.
 
-* If desired, install fresh python distributions from
+* If desired, install fresh python distributions (2.7 and 3.6) from
 https://www.python.org/downloads
 
+* Sometimes installing an older version of Python can be unclear. If you need a fresh install of Python 3.6, you can also run the following:
 ```shell
-# Linux
-sudo apt-get install python2.7
-sudo apt-get install python3.6
-
-# Mac
-brew install python
-brew install python3
-```
-* <b>Note:</b>
-Since we currently only support Python 3.6.X, you may need to install this older Python version. On MacOS, Homebrew allows us to roll back to a previous version of Python. If, for example, you have had Python 3.6.5 installed previously, you may run the following:
-```shell
-# Mac
-brew switch python 3.6.5_1
-```
-
-* If you need a fresh install of Python 3.6.5, run the following:
-```shell
-# Linux
+# Ubuntu
 sudo apt-get update
 sudo apt-get -y --no-install-recommends install software-properties-common
 sudo add-apt-repository -y ppa:deadsnakes/ppa
@@ -47,6 +31,13 @@ sudo pip install virtualenv
 brew unlink python
 brew install pkg-config gdbm openssl readline sqlite xz
 brew install --ignore-dependencies https://raw.githubusercontent.com/Homebrew/homebrew-core/f2a764ef944b1080be64bd88dca9a1d80130c558/Formula/python.rb
+```
+
+* <b>Note:</b>
+If you have previously had Python 3.6.5 installed through Homebrew on MacOS, running the following will switch your Python 3.7.x with Python 3.6.5. In some cases, this may be an easier solution.
+```shell
+# Mac
+brew switch python 3.6.5_1
 ```
 
 * Install the `virtualenv` package:

--- a/docs/virtualenv_guide.md
+++ b/docs/virtualenv_guide.md
@@ -24,7 +24,7 @@ brew install python
 brew install python3
 ```
 * <b>Note:</b>
-Since we currently only support Python 3.6.X, you may need to install this older Python version. Homebrew allows us to roll back to a previous version of Python. If, for example, you have had Python 3.6.5 installed previously, you may run the following:
+Since we currently only support Python 3.6.X, you may need to install this older Python version. On MacOS, Homebrew allows us to roll back to a previous version of Python. If, for example, you have had Python 3.6.5 installed previously, you may run the following:
 ```shell
 # Mac
 brew switch python 3.6.5_1
@@ -32,6 +32,17 @@ brew switch python 3.6.5_1
 
 * If you need a fresh install of Python 3.6.5, run the following:
 ```shell
+# Linux
+sudo apt-get update
+sudo apt-get -y --no-install-recommends install software-properties-common
+sudo add-apt-repository -y ppa:deadsnakes/ppa
+sudo apt-get update
+sudo apt-get -y --no-install-recommends install python3.6 python3.6-dev
+sudo ln -s /usr/bin/python3.6 /usr/local/bin/python
+curl https://bootstrap.pypa.io/get-pip.py | sudo python
+sudo pip install --upgrade pip setuptools
+sudo pip install virtualenv
+
 # Mac
 brew unlink python
 brew install pkg-config gdbm openssl readline sqlite xz

--- a/docs/virtualenv_guide.md
+++ b/docs/virtualenv_guide.md
@@ -23,6 +23,18 @@ sudo apt-get install python3.6
 brew install python
 brew install python3
 ```
+* <b>Note:</b>
+Since we currently only support up to Python 3.6.X, you may need to brew install this older Python version. If you have had Python 3.6 installed previously, run the following:
+```shell
+brew switch python 3.6.5_1
+```
+
+* If you need a fresh install of Python 3.6.5, run the following:
+```shell
+brew unlink python
+brew install pkg-config gdbm openssl readline sqlite xz
+brew install --ignore-dependencies https://raw.githubusercontent.com/Homebrew/homebrew-core/f2a764ef944b1080be64bd88dca9a1d80130c558/Formula/python.rb
+```
 
 * Install the `virtualenv` package:
 


### PR DESCRIPTION
We require Python 3.6.X, as Python 3.7+ causes issues. Because of this, I have updated the virtualenv_guide.md document with instructions on how to install Python 3.6.X on a fresh machine, or revert back to a previous version of Python if you have had it installed before.