### PR TITLE
GPU Install Problems

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -117,7 +117,7 @@ fi
 # GPU flag
 MSG "Checking system for GPU"
 if [ "${OS}" == "Linux" ]; then
-    lspci | grep -q "NVIDIA"
+    grep -q "NVIDIA" <(lspci)
     if [ $? -eq 0 ]; then
         GCARD=ON
     else


### PR DESCRIPTION
The command `lspci | grep -q "NVIDIA"` was producing an exit status of `141`. Using process substitution as an alternative command as per this discussion:
https://stackoverflow.com/questions/19120263/why-exit-code-141-with-grep-q