### PR TITLE
Update install.bash

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -267,17 +267,6 @@ CRITICAL protoc research/object_detection/protos/*.proto \
 MSG "You must have '$(pwd)/research' in 'pythonpath_dirs' in your ETA config"
 MSG "You must have '$(pwd)/research/slim' in 'pythonpath_dirs' in your ETA config"
 
-# Remove all tensorflow/models subdirectories that we don't use
-MSG "Removing unused tensorflow/models subdirectories"
-rm -rf samples
-rm -rf tutorials
-mv research/slim .
-mv research/object_detection .
-rm -rf research
-mkdir -p research
-mv slim research
-mv object_detection research
-
 cd ../..
 
 


### PR DESCRIPTION
We do not need to download all of this code in TF-Models just to remove it later.  The code has now been removed preemptively in the voxel51/models submodule repository (Reduced Models repo from 1GB to 650MB).