### PR TITLE
TempDir: creating base directory if necessary

### DIFF
--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1751,7 +1751,7 @@ class LabeledDatasetBuilder(object):
 
         dataset = self.dataset_cls.create_empty_dataset(path, description)
 
-        with etau.TempDir(dir=tmp_dir_base) as dir_path:
+        with etau.TempDir(tmp_dir_base) as dir_path:
             for idx, record in enumerate(self._dataset):
                 result = record.build(dir_path, str(idx),
                                       pretty_print=pretty_print)

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -1646,32 +1646,34 @@ class MD5FileHasher(FileHasher):
             return str(hashlib.md5(f.read()).hexdigest())
 
 
-def make_temp_dir(dir=None):
+def make_temp_dir(basedir=None):
     '''Makes a temporary directory.
 
     Args:
-        dir: an optional directory in which to put the temp dir
+        basedir: an optional directory in which to create the new directory
 
     Returns:
         the path to the temporary directory
     '''
-    return tempfile.mkdtemp(dir=dir)
+    if basedir:
+        ensure_dir(basedir)
+    return tempfile.mkdtemp(dir=basedir)
 
 
 class TempDir(object):
     '''Context manager that creates and destroys a temporary directory.'''
 
-    def __init__(self, dir=None):
+    def __init__(self, basedir=None):
         '''Creates a TempDir instance.
 
         Args:
-            dir: an optional directory in which to put the temp dir
+            basedir: an optional base directory in which to create the temp dir
         '''
-        self._dir = dir
+        self._basedir = basedir
         self._name = None
 
     def __enter__(self):
-        self._name = make_temp_dir(dir=self._dir)
+        self._name = make_temp_dir(basedir=self._basedir)
         return self._name
 
     def __exit__(self, *args):

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -1655,8 +1655,10 @@ def make_temp_dir(basedir=None):
     Returns:
         the path to the temporary directory
     '''
-    if basedir:
-        ensure_dir(basedir)
+    if not basedir:
+        basedir = tempfile.gettempdir()
+
+    ensure_dir(basedir)
     return tempfile.mkdtemp(dir=basedir)
 
 


### PR DESCRIPTION
This PR basically just adds `eta.core.utils.ensuredir()` to `eta.core.utils.make_temp_dir()` to ensure that the base directory exists before creating it.

This will make it so that repeated calls to `TempDir` won't cause any errors due to the base directory originally existing but now not 

Note that it _is_ intentional for `__exit__()` to use `eta.core.utils.delete_dir()`, which will prune the directory tree as possible to avoid empty directories sticking around