### PR TITLE
S3 storage client

### DIFF
--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -935,7 +935,7 @@ class GoogleCloudStorageClient(
         Returns:
             a list of full cloud paths to the files in the folder
         '''
-        bucket_name, folder_name = self._parse_cloud_storage_path(cloud_folder)
+        bucket_name, folder_name = self._parse_gcs_path(cloud_folder)
         bucket = self._client.get_bucket(bucket_name)
 
         if folder_name and not folder_name.endswith("/"):
@@ -972,12 +972,12 @@ class GoogleCloudStorageClient(
         return blob.generate_signed_url(expiration=expiration, method=method)
 
     def _get_blob(self, cloud_path):
-        bucket_name, object_name = self._parse_cloud_storage_path(cloud_path)
+        bucket_name, object_name = self._parse_gcs_path(cloud_path)
         bucket = self._client.get_bucket(bucket_name)
         return bucket.blob(object_name, chunk_size=self.chunk_size)
 
     @staticmethod
-    def _parse_cloud_storage_path(cloud_path):
+    def _parse_gcs_path(cloud_path):
         '''Parses a Google Cloud Storage path.
 
         Args:

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -171,7 +171,7 @@ class StorageClient(object):
 
 
 class CanSyncDirectories(object):
-    '''Mixin class for `StorageClient`s that can sync directories to/remote
+    '''Mixin class for `StorageClient`s that can sync directories to/from
     remote storage.
 
     Depending on the nature of the concrete StorageClient, `remote_dir` may be

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -270,6 +270,20 @@ class LocalStorageClient(StorageClient):
         '''
         etau.delete_file(storage_path)
 
+    def list_files_in_folder(self, storage_dir, recursive=True):
+        '''Returns a list of the files in the given storage directory.
+
+        Args:
+            storage_dir: the storage directory
+            recursive: whether to recursively traverse sub-directories. By
+                default, this is True
+
+        Returns:
+            a list of full paths to the files in the storage directory
+        '''
+        return etau.list_files(
+            storage_dir, abs_paths=True, recursive=recursive)
+
 
 class NeedsAWSCredentials(object):
     '''Mixin for classes that need AWS credentials to take authenticated

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -5,17 +5,17 @@ See `docs/storage_dev_guide.md` for more information and best practices for
 using this module to work with remote storage resources.
 
 This module currently provides clients for the following storage resources:
-- Google Cloud buckets via the `google.cloud.storage` API
-- Google Drive via the `googleapiclient` Drive API
+- S3 buckets via the `boto3` package
+- Google Cloud buckets via the `google.cloud.storage` package
+- Google Drive via the `googleapiclient` package
+- Remote servers via the `pysftp` package
 - Web storage via HTTP requests
-- Remote servers via SFTP
 - Local disk storage
 
-Copyright 2018-2019, Voxel51, Inc.
+Copyright 2017-2019, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
-Ravali Pinnaka, ravali@voxel51.com
 '''
 # pragma pylint: disable=redefined-builtin
 # pragma pylint: disable=unused-wildcard-import

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -93,27 +93,80 @@ def google_cloud_api_retry(func):
 
 
 class StorageClient(object):
-    '''Interface for storage clients.'''
+    '''Interface for storage clients that read/write files from remote storage
+    locations.
 
-    def upload(self, *args, **kwargs):
+    Depending on the nature of the concrete StorageClient, `remote_path` may be
+    a cloud object, a file ID, or some other construct that represents the path
+    to which the file will be written.
+    '''
+
+    def upload(self, local_path, remote_path):
+        '''Uploads the file to the given remote path.
+
+        Args:
+            local_path: the path to the file to upload
+            remote_path: the remote path to write the file
+        '''
         raise NotImplementedError("subclass must implement upload()")
 
-    def upload_bytes(self, *args, **kwargs):
+    def upload_bytes(self, bytes_str, remote_path):
+        '''Uploads the given bytes to the given remote path.
+
+        Args:
+            bytes_str: the bytes string to upload
+            remote_path: the remote path to write the file
+        '''
         raise NotImplementedError("subclass must implement upload_bytes()")
 
-    def upload_stream(self, *args, **kwargs):
+    def upload_stream(self, file_obj, remote_path):
+        '''Uploads the contents of the given file-like object to the given
+        remote path.
+
+        Args:
+            file_obj: the file-like object to upload, which must be open for
+                reading
+            remote_path: the remote path to write the file
+        '''
         raise NotImplementedError("subclass must implement upload_stream()")
 
-    def download(self, *args, **kwargs):
+    def download(self, remote_path, local_path):
+        '''Downloads the remote file to the given local path.
+
+        Args:
+            remote_path: the remote file to download
+            local_path: the path to which to write the downloaded file
+        '''
         raise NotImplementedError("subclass must implement download()")
 
-    def download_bytes(self, *args, **kwargs):
+    def download_bytes(self, remote_path):
+        '''Downloads bytes from the given remote path.
+
+        Args:
+            remote_path: the remote file to download
+
+        Returns:
+            the downloaded bytes string
+        '''
         raise NotImplementedError("subclass must implement download_bytes()")
 
-    def download_stream(self, *args, **kwargs):
+    def download_stream(self, remote_path, file_obj):
+        '''Downloads the file from the given remote path to the given
+        file-like object.
+
+        Args:
+            remote_path: the remote file to download
+            file_obj: the file-like object to which to write the download,
+                which must be open for writing
+        '''
         raise NotImplementedError("subclass must implement download_stream()")
 
-    def delete(self, *args, **kwargs):
+    def delete(self, remote_path):
+        '''Deletes the file at the remote path.
+
+        Args:
+            remote_path: the remote path to delete
+        '''
         raise NotImplementedError("subclass must implement delete()")
 
 

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -41,6 +41,7 @@ try:
 except ImportError:
     import urlparse  # Python 2
 
+import boto3
 import google.api_core.exceptions as gae
 import google.cloud.storage as gcs
 import google.oauth2.service_account as gos
@@ -215,6 +216,51 @@ class LocalStorageClient(StorageClient):
             storage_path: the path to the storage location
         '''
         etau.delete_file(storage_path)
+
+
+class NeedsAWSCredentials(object):
+    '''Mixin for classes that need AWS credentials to take authenticated
+    actions.
+
+    By convention, StorageClient classes that derive from this class should
+    allow users to specify their credentials in the following ways, rather than
+    using the `from_ini()` method:
+
+        (1) setting the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
+            `AWS_DEFAULT_REGION` environment variables directly
+
+        (2) setting the `AWS_SHARED_CREDENTIALS_FILE` environment variable to
+            point to a valid credentials `.ini` file
+
+        (3) setting the `AWS_CONFIG_FILE` environment variable to point to a
+            valid credentials `.ini` file
+
+    In the above, the `.ini` file should have syntax similar to the following:
+
+    ```
+    [default]
+    aws_access_key_id = XXX
+    aws_secret_access_key = YYY
+    region = ZZZ
+    ```
+
+    See the following link for more information:
+    https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration
+    '''
+
+    @classmethod
+    def from_ini(cls, credentials_path):
+        '''Creates a cls instance from the given credentials file.
+
+        Args:
+            credentials_path: the path to a credentials `.ini` file
+
+        Returns:
+            an instance of cls with the given credentials
+        '''
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = credentials_path
+        os.environ["AWS_CONFIG_FILE"] = credentials_path
+        return cls()
 
 
 class NeedsGoogleCredentials(object):

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -908,8 +908,7 @@ class GoogleCloudStorageClient(
 
         Returns:
             a dictionary containing metadata about the file, including its
-                `name`, `bucket`, `creation_date`, `size`, `mime_type`, and
-                `encoding`
+                `name`, `bucket`, `creation_date`, `size`, and `mime_type`
         '''
         blob = self._get_blob(cloud_path)
         blob.patch()  # must call `patch()` to populate the blob's properties
@@ -919,7 +918,6 @@ class GoogleCloudStorageClient(
             "creation_date": blob.updated,
             "size": blob.size,
             "mime_type": blob.content_type,
-            "encoding": blob.content_encoding
         }
 
     @google_cloud_api_retry

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -552,7 +552,6 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
                 the same value is used. Otherwise, the default value
                 ("application/octet-stream") is used
         '''
-        # @todo use a self._client method directly to do this!
         with io.BytesIO(_to_bytes(bytes_str)) as f:
             self._do_upload(cloud_path, file_obj=f, content_type=content_type)
 
@@ -584,7 +583,6 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
         Returns:
             the downloaded bytes string
         '''
-        # @todo use a self._client method directly to do this!
         with io.BytesIO() as f:
             self.download_stream(cloud_path, f)
             return f.getvalue()

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -705,6 +705,7 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
         bucket, object_name = self._parse_s3_path(cloud_path)
 
         if local_path:
+            etau.ensure_basedir(local_path)
             self._client.download_file(bucket, object_name, local_path)
 
         if file_obj is not None:

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -948,10 +948,12 @@ class GoogleCloudStorageClient(
         for blob in blobs:
             if not blob.name.endswith("/"):
                 paths.append(os.path.join(prefix, blob.name))
+
         return paths
 
     @google_cloud_api_retry
-    def generate_signed_url(self, cloud_path, method="GET", hours=24):
+    def generate_signed_url(
+            self, cloud_path, method="GET", hours=24, content_type=None):
         '''Generates a signed URL for accessing the given storage object.
 
         Anyone with the URL can access the object with the permission until it
@@ -963,13 +965,16 @@ class GoogleCloudStorageClient(
             cloud_path: the path to the Google Cloud object
             method: the HTTP verb (GET, PUT, DELETE) to authorize
             hours: the number of hours that the URL is valid
+            content_type: (PUT actions only) the optional type of the content
+                being uploaded
 
         Returns:
             a URL for accessing the object via HTTP request
         '''
         blob = self._get_blob(cloud_path)
         expiration = datetime.timedelta(hours=hours)
-        return blob.generate_signed_url(expiration=expiration, method=method)
+        return blob.generate_signed_url(
+            expiration=expiration, method=method, content_type=content_type)
 
     def _get_blob(self, cloud_path):
         bucket_name, object_name = self._parse_gcs_path(cloud_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 blockdiag==1.5.3
+boto3==1.10.9
 contextlib2==0.5.5
 Cython==0.28.5
 dill==0.2.7.1


### PR DESCRIPTION
This PR does the following:
- adds an `eta.core.storage.S3StorageClient` class for reading/writing objects from S3 buckets
- refactors the directory-related functions from `GoogleCloudStorageClient` into a `CanSyncDirectories` mixin class, which allows `S3StorageClient` to auto-magically inherit the same fanciness
- updates `docs/storage_dev_guide.md` to include documentation for `S3StorageClient`

Test code that I ran to verify that this new functionality works:

```py
import os

import eta.core.storage as etas

local_video_path1 = "/Users/Brian/Desktop/video.mp4"
local_video_path2 = "/Users/Brian/Desktop/video2.mp4"
local_video_path3 = "/Users/Brian/Desktop/video3.mp4"
local_dir1 = "/Users/Brian/Desktop/tmp1"
local_dir2 = "/Users/Brian/Desktop/tmp2"
cloud_bucket = "s3://voxel51-test"
cloud_video_path = "s3://voxel51-test/video/test.mp4"
cloud_text_path = "s3://voxel51-test/text/test.txt"


client = etas.S3StorageClient.from_ini("/Users/Brian/Desktop/tokens/s3-storage-admin.ini")
http_client = etas.HTTPStorageClient()

# Upload via client
client.upload(local_video_path1, cloud_video_path)

# Get file metadata
print(client.get_file_metadata(cloud_video_path))

# Delete file
client.delete(cloud_video_path)

# Upload via signed URL
put_url = client.generate_signed_url(cloud_video_path, method="PUT")
http_client.upload(local_video_path1, put_url)

# Download via client
client.download(cloud_video_path, local_video_path2)

# Download via signed URL
get_url = client.generate_signed_url(cloud_video_path, method="GET")
http_client.download(get_url, local_video_path3)

# Upload/download bytes
client.upload_bytes("Hello, world!", cloud_text_path, content_type="text/plain")
print(client.get_file_metadata(cloud_text_path))
print(client.download_bytes(cloud_text_path))

# List files in folder
files = client.list_files_in_folder(cloud_bucket)
print(files)

# Download sync
client.download_dir_sync(cloud_bucket, local_dir1)

# Upload sync
# `local_dir2` doesn't exist, so this deletes the contents of `cloud_bucket`
client.upload_dir_sync(local_dir2, cloud_bucket)
```
