### PR TITLE
File method options for dataset copies, merges, adding files, and builders. And more!

### DIFF
--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -33,7 +33,6 @@ import logging
 import os
 import random
 import re
-import shutil
 
 import numpy as np
 

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -856,6 +856,7 @@ class LabeledDataset(object):
             new_data_file = os.path.basename(data_path)
             new_data_path = os.path.join(new_data_subdir, new_data_file)
             data_method(data_path, new_data_path)
+
             new_labels_file = os.path.basename(labels_path)
             new_labels_path = os.path.join(new_labels_subdir, new_labels_file)
             labels_method(labels_path, new_labels_path)

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -712,7 +712,7 @@ class LabeledDataset(object):
                 will be deleted.
             file_method: how to add the files to the dataset. One of "copy",
                 "link", move", or "symlink". A tuple, e.g. `("move", "copy")`,
-                may be used as well to move data files and copy label files,
+                may be used as well to move data files and copy labels files,
                 for example. The default is "copy"
 
         Returns:
@@ -834,7 +834,7 @@ class LabeledDataset(object):
                 directory must either not exist or be empty.
             file_method: how to add the files to the dataset. One of "copy",
                 "link", move", or "symlink". A tuple, e.g. `("move", "copy")`,
-                may be used as well to move data files and copy label files,
+                may be used as well to move data files and copy labels files,
                 for example. The default is "copy"
 
         Returns:
@@ -887,7 +887,7 @@ class LabeledDataset(object):
                 dataset. If not specified, the existing description is used.
             file_method: how to add the files to the dataset. One of "copy",
                 "link", move", or "symlink". A tuple, e.g. `("move", "copy")`,
-                may be used as well to move data files and copy label files,
+                may be used as well to move data files and copy labels files,
                 for example. The default is "copy"
 
         Returns:
@@ -963,7 +963,7 @@ class LabeledDataset(object):
         return self
 
     def prune(self):
-        '''Deletes data and label files that are not in the index.
+        '''Deletes data and labels files that are not in the index.
 
         Note that actual files will be deleted if they are not present in
         `self.dataset_index`, for which the current state can be different

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1750,7 +1750,7 @@ class LabeledDatasetBuilder(object):
         return self._dataset.record_cls
 
     def build(self, path, description=None, pretty_print=False,
-              tmp_dir_base=None, create_empty=False, data_method="copy"):
+              create_empty=False, data_method="copy"):
         '''Build the new LabeledDataset after all records and transformations
         have been added.
 
@@ -1759,7 +1759,6 @@ class LabeledDatasetBuilder(object):
             description: optional dataset description
             pretty_print: whether to pretty print JSON labels. By default, this
                 is False
-            tmp_dir_base: optional directory in which to make temp dirs
             create_empty: whether to write empty datasets to disk. By default,
                 this is False
             data_method: how to add the data files to the dataset, when

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -662,7 +662,7 @@ class LabeledDataset(object):
         return dataset_list
 
     def add_file(self, data_path, labels_path, move_files=False,
-                 error_on_duplicates=False):
+                 error_on_duplicates=False, hard_link_data=False):
         '''Adds a single data file and its labels file to this dataset.
 
         Args:
@@ -685,6 +685,9 @@ class LabeledDataset(object):
                 data file already present in the dataset and
                 `error_on_duplicates` is True
         '''
+        if move_files and hard_link_data:
+            raise ValueError(
+                "only one of move_files and hard_link_data can be True")
         if error_on_duplicates:
             self._validate_new_data_file(data_path)
 
@@ -693,6 +696,8 @@ class LabeledDataset(object):
         if os.path.dirname(data_path) != data_subdir:
             if move_files:
                 etau.move_file(data_path, data_subdir)
+            elif hard_link_data:
+                etau.link_file(data_path, data_subdir)
             else:
                 etau.copy_file(data_path, data_subdir)
         if os.path.dirname(labels_path) != labels_subdir:

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -705,15 +705,15 @@ class LabeledDataset(object):
         Args:
             data_path: path to data file to be added
             labels_path: path to corresponding labels file to be added
+            file_method: how to add the files to the dataset. One of "copy",
+                "link", move", or "symlink". A tuple, e.g. `("move", "copy")`,
+                may be used as well to move data files and copy labels files,
+                for example. The default is "copy"
             error_on_duplicates: whether to raise an error if the file
                 at `data_path` has the same filename as an existing
                 data file in the dataset. If this is set to `False`, the
                 previous mapping of the data filename to a labels file
                 will be deleted.
-            file_method: how to add the files to the dataset. One of "copy",
-                "link", move", or "symlink". A tuple, e.g. `("move", "copy")`,
-                may be used as well to move data files and copy labels files,
-                for example. The default is "copy"
 
         Returns:
             self
@@ -868,7 +868,7 @@ class LabeledDataset(object):
         return cls(dataset_path)
 
     def merge(self, labeled_dataset_or_path, merged_dataset_path,
-              in_place=False, description=None, file_method="copy"):
+              in_place=False, description=None, file_method=COPY):
         '''Union of two labeled datasets.
 
         Args:
@@ -981,12 +981,12 @@ class LabeledDataset(object):
         data_subdir = os.path.join(self.data_dir, self._DATA_SUBDIR)
         for filename in etau.list_files(data_subdir):
             if filename not in data_filenames:
-                os.unlink(os.path.join(data_subdir, filename))
+                os.remove(os.path.join(data_subdir, filename))
 
         labels_subdir = os.path.join(self.data_dir, self._LABELS_SUBDIR)
         for filename in etau.list_files(labels_subdir):
             if filename not in labels_filenames:
-                os.unlink(os.path.join(labels_subdir, filename))
+                os.remove(os.path.join(labels_subdir, filename))
 
         return self
 
@@ -1886,7 +1886,7 @@ class BuilderDataRecord(BaseDataRecord):
         return self._labels_path
 
     def build(self, data_path, labels_path, pretty_print=False,
-              data_method="copy"):
+              data_method=COPY):
         '''Write the transformed labels and data files to dir_path. The
         subclasses BuilderVideoRecord and BuilderDataRecord are responsible for
         writing the data file.

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -981,12 +981,12 @@ class LabeledDataset(object):
         data_subdir = os.path.join(self.data_dir, self._DATA_SUBDIR)
         for filename in etau.list_files(data_subdir):
             if filename not in data_filenames:
-                os.remove(os.path.join(data_subdir, filename))
+                etau.delete_file(os.path.join(data_subdir, filename))
 
         labels_subdir = os.path.join(self.data_dir, self._LABELS_SUBDIR)
         for filename in etau.list_files(labels_subdir):
             if filename not in labels_filenames:
-                os.remove(os.path.join(labels_subdir, filename))
+                etau.delete_file(os.path.join(labels_subdir, filename))
 
         return self
 

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1750,7 +1750,7 @@ class LabeledDatasetBuilder(object):
         return self._dataset.record_cls
 
     def build(self, path, description=None, pretty_print=False,
-              create_empty=False, data_method="copy"):
+              create_empty=False, data_method=COPY):
         '''Build the new LabeledDataset after all records and transformations
         have been added.
 

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -706,7 +706,7 @@ class LabeledDataset(object):
             data_path: path to data file to be added
             labels_path: path to corresponding labels file to be added
             file_method: how to add the files to the dataset. One of "copy",
-                "link", move", or "symlink". A tuple, e.g. `("move", "copy")`,
+                "link", "move", or "symlink". A tuple, e.g. `("move", "copy")`,
                 may be used as well to move data files and copy labels files,
                 for example. The default is "copy"
             error_on_duplicates: whether to raise an error if the file
@@ -833,7 +833,7 @@ class LabeledDataset(object):
                 copy of the dataset that will be written. The containing
                 directory must either not exist or be empty.
             file_method: how to add the files to the dataset. One of "copy",
-                "link", move", or "symlink". A tuple, e.g. `("move", "copy")`,
+                "link", "move", or "symlink". A tuple, e.g. `("move", "copy")`,
                 may be used as well to move data files and copy labels files,
                 for example. The default is "copy"
 
@@ -886,7 +886,7 @@ class LabeledDataset(object):
             description: optional description for the manifest of the merged
                 dataset. If not specified, the existing description is used.
             file_method: how to add the files to the dataset. One of "copy",
-                "link", move", or "symlink". A tuple, e.g. `("move", "copy")`,
+                "link", "move", or "symlink". A tuple, e.g. `("move", "copy")`,
                 may be used as well to move data files and copy labels files,
                 for example. The default is "copy"
 
@@ -1763,7 +1763,7 @@ class LabeledDatasetBuilder(object):
                 this is False
             data_method: how to add the data files to the dataset, when
                 applicable. If clipping is required, this option is ignored,
-                for example. One of "copy", "link", move", or "symlink". Labels
+                for example. One of "copy", "link", "move", or "symlink". Labels
                 files are written from their class instances and do not apply.
 
         Returns:

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -743,11 +743,11 @@ class LabeledDataset(object):
                              % os.path.basename(data_path))
 
         data_subdir = os.path.join(self.data_dir, self._DATA_SUBDIR)
-        if new_data_filename is not None:
+        if new_data_filename is None:
             new_data_filename = os.path.basename(data_path)
 
         labels_subdir = os.path.join(self.data_dir, self._LABELS_SUBDIR)
-        if new_labels_filename is not None:
+        if new_labels_filename is None:
             new_labels_filename = os.path.basename(data_path)
 
         data_method, labels_method = self._parse_file_methods(file_method)

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -708,7 +708,7 @@ class LabeledDataset(object):
 
         return _FILE_METHODS_MAP[data_method], _FILE_METHODS_MAP[labels_method]
 
-    def add_file(self, data_path, labels_path=None, new_data_filename=None,
+    def add_file(self, data_path, labels_path, new_data_filename=None,
                  new_labels_filename=None, file_method=COPY,
                  error_on_duplicates=False):
         '''Adds a single data file and its labels file to this dataset.
@@ -748,7 +748,7 @@ class LabeledDataset(object):
 
         labels_subdir = os.path.join(self.data_dir, self._LABELS_SUBDIR)
         if new_labels_filename is None:
-            new_labels_filename = os.path.basename(data_path)
+            new_labels_filename = os.path.basename(labels_path)
 
         data_method, labels_method = self._parse_file_methods(file_method)
 

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -445,11 +445,13 @@ def _iter_filtered_video_frames(video_dataset, frame_filter, stride):
 
 # Core LabeledDataset infrastructure
 
+
+# File method enums and helpers
 COPY = "copy"
 LINK = "link"
 MOVE = "move"
 SYMLINK = "symlink"
-FILE_METHODS = set(COPY, LINK, MOVE, SYMLINK)
+FILE_METHODS = {COPY, LINK, MOVE, SYMLINK}
 _FILE_METHODS_MAP = {
     COPY: etau.copy_file,
     LINK: etau.link_file,
@@ -684,7 +686,7 @@ class LabeledDataset(object):
         data_file = os.path.basename(data_path)
         return data_file in self._data_to_labels_map
 
-    def _parse_file_methods(self, file_method, by_dir=False):
+    def _parse_file_methods(self, file_method):
         if isinstance(file_method, tuple) and len(file_method) == 2:
             data_method, labels_method = file_method
         else:

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -750,7 +750,8 @@ def copy_dir(indir, outdir):
         outdir: the output directory
     '''
     if os.path.isdir(outdir):
-        e
+        communicate_or_die(["rm", "-rf",  outdir])
+    ensure_dir(outdir)
 
     for filepath in list_files(indir, include_hidden_files=True, sort=False):
         copy_file(

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -583,7 +583,7 @@ def move_file(inpath, outpath, check_ext=False):
         if check_ext:
             assert_same_extensions(inpath, outpath)
         ensure_basedir(outpath)
-    shutil.move(inpath, outpath)
+    communicate_or_die(["mv", inpath, outpath])
 
 
 def move_dir(indir, outdir):
@@ -599,7 +599,7 @@ def move_dir(indir, outdir):
     if os.path.isdir(outdir):
         delete_dir(outdir)
     ensure_basedir(outdir)
-    shutil.move(indir, outdir)
+    communicate_or_die(["mv", inpath, outpath])
 
 
 def partition_files(indir, outdir=None, num_parts=None, dir_size=None):
@@ -750,7 +750,7 @@ def copy_dir(indir, outdir):
         outdir: the output directory
     '''
     if os.path.isdir(outdir):
-        shutil.rmtree(outdir)
+        e
 
     for filepath in list_files(indir, include_hidden_files=True, sort=False):
         copy_file(
@@ -788,12 +788,9 @@ def delete_dir(dir_):
 
     Args:
         dir_: the directory path
-
-    Raises:
-        OSError: if the directory did not exist
     '''
     dir_ = os.path.normpath(dir_)
-    shutil.rmtree(dir_)
+    communicate_or_die(["rm", "-rf",  dir_])
     try:
         os.removedirs(os.path.dirname(dir_))
     except OSError:

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -599,7 +599,7 @@ def move_dir(indir, outdir):
     if os.path.isdir(outdir):
         delete_dir(outdir)
     ensure_basedir(outdir)
-    communicate_or_die(["mv", inpath, outpath])
+    communicate_or_die(["mv", indir, outdir])
 
 
 def partition_files(indir, outdir=None, num_parts=None, dir_size=None):

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -496,7 +496,7 @@ def copy_file(inpath, outpath, check_ext=False):
 
 
 def link_file(filepath, linkpath, check_ext=False):
-    '''Creates a hard link at the given location that using the given file.
+    '''Creates a hard link at the given location using the given file.
 
     The base output directory is created if necessary, and any existing file
     will be overwritten.
@@ -644,9 +644,8 @@ def copy_sequence(inpatt, outpatt, check_ext=False):
         copy_file(inpatt % idx, outpatt % idx)
 
 
-def symlink_sequence(inpatt, outpatt, check_ext=False):
-    '''Creates hard links at the given locations using the given
-    sequence.
+def link_sequence(inpatt, outpatt, check_ext=False):
+    '''Creates hard links at the given locations using the given sequence.
 
     The base output directory is created if necessary, and any existing files
     will be overwritten.
@@ -1773,5 +1772,3 @@ class ExecutableRuntimeError(Exception):
     def __init__(self, cmd, err):
         message = "Command '%s' failed with error:\n%s" % (cmd, err)
         super(ExecutableRuntimeError, self).__init__(message)
-
-

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -1262,8 +1262,8 @@ def list_files(dir_path, abs_paths=False, recursive=False,
             default, this is False
         recursive: whether to recursively traverse subdirectories. By default,
             this is False
-        sort: whether to sort the list of files
         include_hidden_files: whether to include dot files
+        sort: whether to sort the list of files
 
     Returns:
         a sorted list of the non-hidden files in the directory

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -495,6 +495,29 @@ def copy_file(inpath, outpath, check_ext=False):
     communicate_or_die(["cp", inpath, outpath])
 
 
+def link_file(filepath, linkpath, check_ext=False):
+    '''Creates a hard link at the given location that using the given file.
+
+    The base output directory is created if necessary, and any existing file
+    will be overwritten.
+
+    Args:
+        filepath: a file or directory
+        linkpath: the desired symlink path
+        check_ext: whether to check if the extensions (or lack thereof, for
+            directories) of the input and output paths match
+
+    Raises:
+        OSError: if check_ext is True and the input and output paths have
+            different extensions
+    '''
+    if check_ext:
+        assert_same_extensions(filepath, linkpath)
+    ensure_basedir(linkpath)
+    if os.path.exists(linkpath):
+        os.remove(linkpath)
+    os.link(os.path.realpath(filepath), linkpath)
+
 
 def symlink_file(filepath, linkpath, check_ext=False):
     '''Creates a symlink at the given location that points to the given file.
@@ -619,6 +642,29 @@ def copy_sequence(inpatt, outpatt, check_ext=False):
         assert_same_extensions(inpatt, outpatt)
     for idx in parse_pattern(inpatt):
         copy_file(inpatt % idx, outpatt % idx)
+
+
+def symlink_sequence(inpatt, outpatt, check_ext=False):
+    '''Creates hard links at the given locations using the given
+    sequence.
+
+    The base output directory is created if necessary, and any existing files
+    will be overwritten.
+
+    Args:
+        inpatt: the input sequence
+        outpatt: the output sequence
+        check_ext: whether to check if the extensions of the input and output
+            sequences match
+
+    Raises:
+        OSError: if check_ext is True and the input and output sequences have
+            different extensions
+    '''
+    if check_ext:
+        assert_same_extensions(inpatt, outpatt)
+    for idx in parse_pattern(inpatt):
+        link_file(inpatt % idx, outpatt % idx)
 
 
 def symlink_sequence(inpatt, outpatt, check_ext=False):

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -943,7 +943,7 @@ def split_path(path):
         if parts[0] == path:  # sentinel for absolute paths
             all_parts.insert(0, parts[0])
             break
-        elif parts[1] == path: # sentinel for relative paths
+        elif parts[1] == path:  # sentinel for relative paths
             all_parts.insert(0, parts[1])
             break
         else:
@@ -1262,6 +1262,8 @@ def list_files(dir_path, abs_paths=False, recursive=False,
             default, this is False
         recursive: whether to recursively traverse subdirectories. By default,
             this is False
+        sort: whether to sort the list of files
+        include_hidden_files: whether to include dot files
 
     Returns:
         a sorted list of the non-hidden files in the directory
@@ -1276,7 +1278,7 @@ def list_files(dir_path, abs_paths=False, recursive=False,
         files = [
             f for f in os.listdir(dir_path)
             if os.path.isfile(os.path.join(dir_path, f))
-                and (not f.startswith(".") or include_hidden_files)]
+            and (not f.startswith(".") or include_hidden_files)]
 
     if sort:
         files = sorted(files)
@@ -1312,7 +1314,7 @@ def list_subdirs(dir_path, abs_paths=False, recursive=False):
         dirs = [
             d for d in os.listdir(dir_path)
             if os.path.isdir(os.path.join(dir_path, d))
-                and not d.startswith(".")]
+            and not d.startswith(".")]
 
     dirs = sorted(dirs)
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -530,7 +530,7 @@ def link_file(filepath, linkpath, check_ext=False):
         assert_same_extensions(filepath, linkpath)
     ensure_basedir(linkpath)
     if os.path.exists(linkpath):
-        os.remove(linkpath)
+        delete_file(linkpath)
     os.link(os.path.realpath(filepath), linkpath)
 
 
@@ -554,7 +554,7 @@ def symlink_file(filepath, linkpath, check_ext=False):
         assert_same_extensions(filepath, linkpath)
     ensure_basedir(linkpath)
     if os.path.exists(linkpath):
-        os.remove(linkpath)
+        delete_file(linkpath)
     os.symlink(os.path.realpath(filepath), linkpath)
 
 
@@ -771,11 +771,8 @@ def delete_file(path):
 
     Args:
         path: the filepath
-
-    Raises:
-        OSError: if the file did not exist
     '''
-    os.remove(path)
+    communicate_or_die(["rm", "-f",  path])
     try:
         os.removedirs(os.path.dirname(path))
     except OSError:
@@ -855,7 +852,7 @@ def ensure_path(path):
     '''
     if os.path.isfile(path):
         logger.debug("Deleting '%s'", path)
-        os.remove(path)
+        delete_file(path)
 
     ensure_basedir(path)
 


### PR DESCRIPTION
Quite a few changes and additions are introduced in this PR that all focus on improving `LabeledDataset` workflows.

1. Use `utils.communicate_or_die` to call `cp` directly for `utils.copy_file()`. I am seeing a ~20% speed increase using this approach over `shutil.copy()`.
2. Introduce hard links with `utils.link_file()` and `utils.link_sequence()` which can then be used as an option for adding files in `LabeledDatasets`. The performance improvements here are obvious.
3. Introduce a standard `file_method` argument where relevant and deprecate `move_files`.
   * Options are `copy`, `move`, `link`, `symlink` or a tuple, e.g. `("link", "copy")`. In this example, data files are linked and labels files are copied.
4. Introduces `data_method` for `BuilderDataset.build()`. This method is used when applicable, which is most cases. When clipping, though, the option is not applicable, as an example.
5. Drop `TempDIr` usage when building a dataset in `BuilderDataset.build()` and write directly to the new dataset's directory. Thanks @iantimmis!