### PR TITLE
Handling of Falsey keys for `Set`

### DIFF
--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -588,7 +588,9 @@ class Set(Serializable):
         Args:
             element: an instance of `_ELE_CLS`
         '''
-        key = self.get_key(element) or str(uuid4())
+        key = self.get_key(element)
+        if key is None:
+            key = str(uuid4())
         self[key] = element
 
     def add_set(self, set_):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1160,7 +1160,7 @@ class BigSet(BigMixin, Set):
         self[key] = element
 
     def add_by_path(self, path, key=None):
-        '''Adds an element to the BigSet via its path on disk.
+        '''Adds an element to the set via its path on disk.
 
         Args:
             path: the path to the element JSON file on disk

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1154,7 +1154,9 @@ class BigSet(BigMixin, Set):
         Args:
             element: an instance of `_ELE_CLS`
         '''
-        key = self.get_key(element) or str(uuid4())
+        key = self.get_key(element)
+        if key is None:
+            key = str(uuid4())
         self[key] = element
 
     def add_by_path(self, path, key=None):


### PR DESCRIPTION
In Set.add(), only default to a uuid if the key extracted is None, as opposed to any Falsey value