### PR TITLE
Dataset wrangling helpers

### DIFF
--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1738,7 +1738,7 @@ class LabeledDatasetBuilder(object):
         return self._dataset.record_cls
 
     def build(self, path, description=None, pretty_print=False,
-              tmp_dir_base=None):
+              tmp_dir_base=None, create_empty=False):
         '''Build the new LabeledDataset after all records and transformations
         have been added.
 
@@ -1747,6 +1747,7 @@ class LabeledDatasetBuilder(object):
             description (str): optional dataset description
             pretty_print (bool): pretty print flag for json labels
             tmp_dir_base (str): optional directory in which to make temp dirs
+            create_empty (bool): if False, empty dataset is not written to disk
 
         Returns:
             LabeledDataset
@@ -1755,6 +1756,10 @@ class LabeledDatasetBuilder(object):
 
         for transformer in self._transformers:
             transformer.transform(self._dataset)
+
+        if not create_empty and not len(self.builder_dataset):
+            logger.info("Built dataset is empty. Skipping write out.")
+            return None
 
         logger.info(
             "Building dataset with %d elements" % len(self.builder_dataset)

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -184,6 +184,24 @@ class ImageLabels(Serializable):
         self.attrs.filter_by_schema(schema.attrs)
         self.objects.filter_by_schema(schema)
 
+    @property
+    def has_attributes(self):
+        '''Returns True/False whether the container has at least one attribute.
+        '''
+        return bool(self.attrs)
+
+    @property
+    def has_objects(self):
+        '''Returns True/False whether the container has at least one
+        DetectedObject.
+        '''
+        return bool(self.objects)
+
+    @property
+    def is_empty(self):
+        '''Returns True if the container has no labels of any kind.'''
+        return not self.has_attributes and not self.has_objects
+
     def attributes(self):
         '''Returns the list of class attributes that will be serialized.'''
         _attrs = []

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -599,6 +599,13 @@ class VideoLabels(Serializable):
         return bool(self.frames)
 
     @property
+    def has_video_attributes(self):
+        '''Returns True/False whether the container has at least one video
+        attribute.
+        '''
+        return bool(self.attrs)
+
+    @property
     def has_frame_attributes(self):
         '''Returns True/False whether the container has at least one frame
         attribute.
@@ -619,6 +626,13 @@ class VideoLabels(Serializable):
                 return True
 
         return False
+
+    @property
+    def is_empty(self):
+        '''Returns True if the container has no labels of any kind.'''
+        return (not self.has_video_attributes
+                and not self.has_frame_attributes
+                and not self.has_objects)
 
     @property
     def has_schema(self):


### PR DESCRIPTION
Three minor changes:
1) `is_empty` property for `ImageLabels` and `VideoLabels`
2) `SchemaFilter` can now prune samples that have empty labels post-filtering (and does this by default
3) `LabeledDatasetBuilder` can optionally not write-out empty datasets (and does this by default)
