### PR TITLE
Consistent filenames after dataset transforms

### DIFF
--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -3011,15 +3011,3 @@ class FilterByPath(DatasetTransformer):
 class DatasetTransformerError(Exception):
     '''Exception raised when there is an error in a DatasetTransformer'''
     pass
-
-
-class TylersTestTransform(DatasetTransformer):
-
-    def transform(self, src):
-        old_records = src.records
-        src.clear()
-        for idx, record in enumerate(old_records):
-            src.add(record)
-            src.add(record)
-            src.add(record)
-            break

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1770,16 +1770,25 @@ class LabeledDatasetBuilder(object):
         with etau.TempDir(tmp_dir_base) as tmp_dir:
             for record in self._dataset:
                 data_filename = os.path.basename(record.data_path)
-                labels_filename = os.path.basename(record.labels_path)
-
                 data_path = os.path.join(tmp_dir, data_filename)
+                labels_filename = os.path.basename(record.labels_path)
                 labels_path = os.path.join(tmp_dir, labels_filename)
 
-                # @todo(Tyler)
-                # while dataset.has_data_with_name(data_path):
+                # add an incrementing index to the filename until a unique name
+                # is found
+                data_basename, data_ext = os.path.splitext(data_filename)
+                labels_basename, labels_ext = os.path.splitext(labels_filename)
+                idx = -1
+                while dataset.has_data_with_name(data_path):
+                    idx += 1
+                    unique_appender = "-{}".format(idx)
+                    data_path = os.path.join(
+                        tmp_dir, data_basename + unique_appender + data_ext)
+                    labels_path = os.path.join(
+                        tmp_dir, labels_basename + unique_appender + labels_ext)
 
                 record.build(data_path, labels_path, pretty_print=pretty_print)
-                dataset.add_file(data_path, labels_path, move_files=True)
+                dataset.add_file(labels_basename, labels_path, move_files=True)
 
         dataset.write_manifest(os.path.basename(path))
         return dataset
@@ -3011,6 +3020,6 @@ class TylersTestTransform(DatasetTransformer):
         src.clear()
         for idx, record in enumerate(old_records):
             src.add(record)
-            # src.add(record)
-            # src.add(record)
+            src.add(record)
+            src.add(record)
             break

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1773,7 +1773,7 @@ class LabeledDatasetBuilder(object):
                 labels_filename = os.path.basename(record.labels_path)
 
                 data_path = os.path.join(tmp_dir, data_filename)
-                labels_path = os.path.join(labels_filename, tmp_dir)
+                labels_path = os.path.join(tmp_dir, labels_filename)
 
                 # @todo(Tyler)
                 # while dataset.has_data_with_name(data_path):

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -662,7 +662,7 @@ class LabeledDataset(object):
         return dataset_list
 
     def has_data_with_name(self, data_path):
-        '''Checks whether if a data file already exists in the dataset with the
+        '''Checks whether a data file already exists in the dataset with the
         provided filename.
 
         Args:

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1788,7 +1788,7 @@ class LabeledDatasetBuilder(object):
                         tmp_dir, labels_basename + unique_appender + labels_ext)
 
                 record.build(data_path, labels_path, pretty_print=pretty_print)
-                dataset.add_file(labels_basename, labels_path, move_files=True)
+                dataset.add_file(data_path, labels_path, move_files=True)
 
         dataset.write_manifest(os.path.basename(path))
         return dataset

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -661,6 +661,20 @@ class LabeledDataset(object):
 
         return dataset_list
 
+    def has_data_with_name(self, data_path):
+        '''Checks whether if a data file already exists in the dataset with the
+        provided filename.
+
+        Args:
+            data_path: path to or filename of a data file
+
+        Returns:
+            (bool): True if the filename of `data_path` is the same as a
+                data file already present in the dataset
+        '''
+        data_file = os.path.basename(data_path)
+        return data_file in self._data_to_labels_map
+
     def add_file(self, data_path, labels_path, move_files=False,
                  error_on_duplicates=False):
         '''Adds a single data file and its labels file to this dataset.
@@ -685,8 +699,9 @@ class LabeledDataset(object):
                 data file already present in the dataset and
                 `error_on_duplicates` is True
         '''
-        if error_on_duplicates:
-            self._validate_new_data_file(data_path)
+        if error_on_duplicates and self.has_data_with_name(data_path):
+            raise ValueError("Data file '%s' already present in dataset"
+                             % os.path.basename(data_path))
 
         data_subdir = os.path.join(self.data_dir, self._DATA_SUBDIR)
         labels_subdir = os.path.join(self.data_dir, self._LABELS_SUBDIR)
@@ -737,8 +752,9 @@ class LabeledDataset(object):
         Returns:
             self
         '''
-        if error_on_duplicates:
-            self._validate_new_data_file(data_filename)
+        if error_on_duplicates and self.has_data_with_name(data_filename):
+            raise ValueError("Data file '%s' already present in dataset"
+                             % os.path.basename(data_filename))
 
         data_path = os.path.join(
             self.data_dir, self._DATA_SUBDIR, data_filename)
@@ -1142,22 +1158,6 @@ class LabeledDataset(object):
                     "Data file '%s' maps to multiple labels files" %
                     data_file)
             self._data_to_labels_map[data_file] = labels_file
-
-    def _validate_new_data_file(self, data_path):
-        '''Checks whether a data file would be a duplicate of an existing
-        data file in the dataset.
-
-        Args:
-            data_path: path to or filename of the new data file
-
-        Raises:
-            ValueError: if the filename of `data_path` is the same as a
-                data file already present in the dataset
-        '''
-        data_file = os.path.basename(data_path)
-        if data_file in self._data_to_labels_map:
-            raise ValueError(
-                "Data file '%s' already present in dataset" % data_file)
 
     def _read_data(self, path):
         '''Reads data from a data file at the given path.

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -3009,3 +3009,13 @@ class FilterByPath(DatasetTransformer):
 class DatasetTransformerError(Exception):
     '''Exception raised when there is an error in a DatasetTransformer'''
     pass
+
+
+class TylersTestTransform(DatasetTransformer):
+
+    def transform(self, src):
+        old_records = src.records
+        src.clear()
+        for idx, record in enumerate(old_records):
+            if idx % 2 == 0:
+                src.add(record)


### PR DESCRIPTION
Dataset builder now preserves the data and labels filenames.

If filenames conflict an incrementing integer is appended until a unique name is found. Example output from my test with 3 records with filename `cat.10649.jpg`:
```
cat.10649-0.jpg
cat.10649-1.jpg
cat.10649.jpg
```
This was branched off of `wrangle-helpers` but so I'm merging it into there. There are two PRs so that it's easier to review each individually