### PR TITLE
Support for inference with non-published models

### DIFF
--- a/eta/detectors/tfmodels_detectors.py
+++ b/eta/detectors/tfmodels_detectors.py
@@ -31,7 +31,6 @@ from eta.core.geometry import BoundingBox, RelativePoint
 from eta.core.learning import ObjectDetector, HasDefaultDeploymentConfig
 import eta.core.models as etam
 from eta.core.objects import DetectedObject, DetectedObjectContainer
-import eta.core.serial as etas
 from eta.core.tfutils import UsesTFSession
 import eta.core.utils as etau
 

--- a/eta/models/manifest.json
+++ b/eta/models/manifest.json
@@ -251,20 +251,20 @@
             "date_created": "2018-12-23 14:34:09"
         },
         {
-            "base_name": "ssd-resnet50-v1-fpn-coco",
-            "base_filename": "ssd-resnet50-v1-fpn-coco.pb",
+            "base_name": "ssd-resnet50-fpn-coco",
+            "base_filename": "ssd-resnet50-fpn-coco.pb",
             "version": null,
             "description": "A FPN Single Shot Detector with ResNet50 backbone trained on COCO",
             "manager": {
                 "type": "eta.core.models.ETAModelManager",
                 "config": {
-                    "google_drive_id": "1ZvVQTuDIexyfntq8ajBVp5aSndHW6wQk"
+                    "google_drive_id": "1pC9WX7Ol2cy4ERAcLQ-a2Dd04d91vJxj"
                 }
             },
             "default_deployment_config_dict": {
                 "type": "eta.detectors.TFModelsDetector",
                 "config": {
-                    "model_name": "ssd-resnet50-v1-fpn-coco",
+                    "model_name": "ssd-resnet50-fpn-coco",
                     "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_label_map.pbtxt"
                 }
             },
@@ -298,7 +298,7 @@
             "manager": {
                 "type": "eta.core.models.ETAModelManager",
                 "config": {
-                    "google_drive_id": "1pC9WX7Ol2cy4ERAcLQ-a2Dd04d91vJxj"
+                    "google_drive_id": "1ZvVQTuDIexyfntq8ajBVp5aSndHW6wQk"
                 }
             },
             "default_deployment_config_dict": {

--- a/examples/demo_cats/detect-classify-cats.json
+++ b/examples/demo_cats/detect-classify-cats.json
@@ -11,7 +11,7 @@
         "apply_object_detector.detector": {
             "type": "eta.detectors.TFModelsDetector",
             "config": {
-                "model_name": "ssd-resnet50-v1-fpn-coco"
+                "model_name": "ssd-resnet50-fpn-coco"
             }
         },
         "apply_object_detector.objects": [


### PR DESCRIPTION
This PR adds the ability to load inference models that are not "published". It's not rocket science, you just provide a `model_path` directly, rather than a `model_name` (which looks up the model path in the models manifest behind the scenes). Easy. 

This PR also fixes two bugs relating to pre-trained models:
- the model formally named `ssd-resnet50-v1-fpn-coco` should have been named `ssd-resnet50-fpn-coco`
- the models manifest entries for `ssd-resnet50-fpn-coco` and `ssd-mobilenet-v1-fpn-coco` were mixed up. If you were trying to use `resnet50`, you were actually getting the `mobilenet` model, and vice versa. This is now fixed

Existing approach: loading a published model
```py
import eta.core.learning as etal
from eta.detectors import TFModelsDetector, TFModelsDetectorConfig

# One way to load a model
model = etal.load_default_deployment_model("ssd-inception-v2-coco")

# Another way
config = TFModelsDetectorConfig({"model_name": "ssd-inception-v2-coco"})
model = TFModelsDetector(config)
```

Now possible approach:
```py
from eta.detectors import TFModelsDetector, TFModelsDetectorConfig

config = TFModelsDetectorConfig({
    "model_path": "/path/to/frozen_inference_graph.pb",
    "labels_path": "/path/to/labels.pbtxt",
})
model = TFModelsDetector(config)
```