### PR TITLE
Add ability to prepend dataset name to data and labels files

### DIFF
--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1842,8 +1842,8 @@ class LabeledDatasetBuilder(object):
                 record.build(data_path, labels_path, pretty_print=pretty_print)
 
                 dataset.add_file_and_rename(data_path, labels_path,
-                                            record.new_data_path,
-                                            record.new_labels_path,
+                                            os.path.basename(record.new_data_path),
+                                            os.path.basename(record.new_labels_path),
                                             move_files=True)
 
         dataset.write_manifest(os.path.basename(path))

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2994,13 +2994,14 @@ class Merger(DatasetTransformer):
         if self.prepend:
             for record in self._builder_dataset_to_merge.records:
 
+                print("dpath:", record.data_path)
                 base = os.path.basename(os.path.basename(os.path.dirname(record.data_path)))
 
                 record.new_data_path = base + '_' + os.path.basename(record.data_path)
                 record.new_labels_path = base + '_' + os.path.basename(record.labels_path)
 
-                print(record.new_data_path)
-                print(record.new_labels_path)
+                print("new_dpath:", record.new_data_path)
+                print("new_lpath:", record.new_labels_path)
 
         src.add_container(self._builder_dataset_to_merge)
 

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2995,7 +2995,7 @@ class Merger(DatasetTransformer):
             for record in self._builder_dataset_to_merge.records:
 
                 print("dpath:", record.data_path)
-                base = os.path.basename(os.path.basename(os.path.dirname(record.data_path)))
+                base = os.path.basename(os.path.basename(os.path.basename(os.path.dirname(record.data_path))))
 
                 record.new_data_path = base + '_' + os.path.basename(record.data_path)
                 record.new_labels_path = base + '_' + os.path.basename(record.labels_path)

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2927,6 +2927,7 @@ class Merger(DatasetTransformer):
                 /new_directory/dataset001_001-123
         '''
         self._builder_dataset_to_merge = dataset_builder.builder_dataset
+        self.prepend = prepend
 
     def transform(self, src):
         '''Merges `self._builder_dataset_to_merge` into `src`.

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1841,10 +1841,6 @@ class LabeledDatasetBuilder(object):
 
                 record.build(data_path, labels_path, pretty_print=pretty_print)
 
-                base = os.path.basename(os.path.dirname(os.path.dirname(record.data_path)))
-                record.new_data_path = base + '_' + os.path.basename(record.data_path)
-                record.new_labels_path = base + '_' + os.path.basename(record.labels_path)
-
                 dataset.add_file_and_rename(data_path, labels_path,
                                             record.new_data_path,
                                             record.new_labels_path,

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2968,8 +2968,8 @@ class Merger(DatasetTransformer):
                 to be merged with the existing one
             prepend_dataset_name: This flag enables an option to prepend both
                 the data and labels filepaths with the folder name containing
-                the original files. E.g. /path/to/dataset001/001-123.mp4 =>
-                /new_directory/dataset001_001-123
+                the original files. E.g. /path/to/dataset001/data/001-123.mp4 =>
+                /new_directory/data/dataset001_001-123
         '''
         self._builder_dataset_to_merge = dataset_builder.builder_dataset
         self.prepend_dataset_name = prepend_dataset_name

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2993,11 +2993,11 @@ class Merger(DatasetTransformer):
         # Prepend the folder name containing the record
         if self.prepend:
             for record in self._builder_dataset_to_merge.records:
-                record.new_data_path = os.path.basename(os.path.dirname(
-                    record.data_path)) + '_' + os.path.basename(record.data_path)
 
-                record.new_labels_path = os.path.basename(os.path.dirname(
-                    record.labels_path)) + '_' + os.path.basename(record.labels_path)
+                base = os.path.basename(os.path.basename(os.path.dirname(record.data_path)))
+
+                record.new_data_path = base + '_' + os.path.basename(record.data_path)
+                record.new_labels_path = base + '_' + os.path.basename(record.labels_path)
 
                 print(record.new_data_path)
                 print(record.new_labels_path)

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -3000,10 +3000,18 @@ class Merger(DatasetTransformer):
         src.add_container(self._builder_dataset_to_merge)
 
 class PrependDatasetNameToRecords(DatasetTransformer):
-    ''' TODO '''
+    ''' Given a labeled dataset, this transformation prepends the dataset name
+    followed by an underscore to all data and label files in the dataset.
+    E.g. mydataset/data/vid.mp4 is now mydataset/data/mydataset_vid.mp4
+    '''
 
     def transform(self, src):
-        ''' TODO '''
+        '''Prepends the dataset name and an underscore to all records in the
+        dataset
+
+        Args:
+            src: a BuilderDataset
+        '''
         for i in range(len(src.records)):
             base = os.path.basename(os.path.dirname(os.path.dirname(
                 src.records[i].data_path)))

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2995,7 +2995,7 @@ class Merger(DatasetTransformer):
             for record in self._builder_dataset_to_merge.records:
 
                 print("dpath:", record.data_path)
-                base = os.path.basename(os.path.basename(os.path.basename(os.path.dirname(record.data_path))))
+                base = os.path.basename(os.path.dirname(os.path.dirname(record.data_path)))
 
                 record.new_data_path = base + '_' + os.path.basename(record.data_path)
                 record.new_labels_path = base + '_' + os.path.basename(record.labels_path)

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1840,6 +1840,11 @@ class LabeledDatasetBuilder(object):
                         tmp_dir, labels_basename + unique_appender + labels_ext)
 
                 record.build(data_path, labels_path, pretty_print=pretty_print)
+
+                base = os.path.basename(os.path.dirname(os.path.dirname(record.data_path)))
+                record.new_data_path = base + '_' + os.path.basename(record.data_path)
+                record.new_labels_path = base + '_' + os.path.basename(record.labels_path)
+
                 dataset.add_file_and_rename(data_path, labels_path,
                                             record.new_data_path,
                                             record.new_labels_path,

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1850,11 +1850,11 @@ class BuilderDataRecord(BaseDataRecord):
 
     @new_data_path.setter
     def new_data_path(self, value):
-        self._data_path = value
+        self._new_data_path = value
 
     @new_labels_path.setter
     def new_labels_path(self, value):
-        self._labels_path = value
+        self._new_labels_path = value
 
     def build(self, data_path, labels_path, pretty_print=False):
         '''Write the transformed labels and data files to dir_path. The
@@ -2935,8 +2935,6 @@ class Merger(DatasetTransformer):
 
                 print(record.data_path)
                 print(record.labels_path)
-                # record.data_path = ""
-                # record.labels_path = ""
 
         src.add_container(self._builder_dataset_to_merge)
 

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2973,9 +2973,7 @@ class PrependDatasetNameToRecords(DatasetTransformer):
         '''
         for i in range(len(src.records)):
             base = _get_dataset_name(src.records[i].data_path)
-            print("base:", base)
             src.records[i].prepend_to_name(prefix=base)
-            print("rec:", src.records[i].new_data_path)
 
 
 class FilterByFilename(DatasetTransformer):

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2973,7 +2973,9 @@ class PrependDatasetNameToRecords(DatasetTransformer):
         '''
         for i in range(len(src.records)):
             base = _get_dataset_name(src.records[i].data_path)
+            print("base:", base)
             src.records[i].prepend_to_name(prefix=base)
+            print("rec:", src.records[i].new_data_path)
 
 
 class FilterByFilename(DatasetTransformer):

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2975,7 +2975,7 @@ class PrependDatasetNameToRecords(DatasetTransformer):
         '''
         for i in range(len(src.records)):
             base = _get_dataset_name(src.records[i].data_path)
-            src.records[i].record.prepend_to_name(prefix=base)
+            src.records[i].prepend_to_name(prefix=base)
 
 
 class FilterByFilename(DatasetTransformer):

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1840,7 +1840,6 @@ class LabeledDatasetBuilder(object):
                         tmp_dir, labels_basename + unique_appender + labels_ext)
 
                 record.build(data_path, labels_path, pretty_print=pretty_print)
-
                 dataset.add_file_and_rename(data_path, labels_path,
                                             os.path.basename(record.new_data_path),
                                             os.path.basename(record.new_labels_path),
@@ -2994,17 +2993,26 @@ class Merger(DatasetTransformer):
         # Prepend the folder name containing the record
         if self.prepend:
             for record in self._builder_dataset_to_merge.records:
-
-                print("dpath:", record.data_path)
                 base = os.path.basename(os.path.dirname(os.path.dirname(record.data_path)))
-
                 record.new_data_path = base + '_' + os.path.basename(record.data_path)
                 record.new_labels_path = base + '_' + os.path.basename(record.labels_path)
 
-                print("new_dpath:", record.new_data_path)
-                print("new_lpath:", record.new_labels_path)
-
         src.add_container(self._builder_dataset_to_merge)
+
+class PrependDatasetNameToRecords(DatasetTransformer):
+    ''' TODO '''
+
+    def transform(self, src):
+        ''' TODO '''
+        for i in range(len(src.records)):
+            base = os.path.basename(os.path.dirname(os.path.dirname(
+                src.records[i].data_path)))
+
+            src.records[i].new_data_path = base + '_' + \
+                os.path.basename(src.records[i].data_path)
+
+            src.records[i].new_labels_path = base + '_' + \
+                os.path.basename(src.records[i].labels_path)
 
 
 class FilterByFilename(DatasetTransformer):

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -42,7 +42,6 @@ from eta.core.serial import Serializable
 import eta.core.utils as etau
 import eta.core.video as etav
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -1642,7 +1641,7 @@ class LabeledDatasetIndex(Serializable):
         return [
             LabeledDatasetIndex(self.type, split_index, description)
             for split_index, description in zip(
-                    split_indices, descriptions)]
+                split_indices, descriptions)]
 
     @classmethod
     def from_dict(cls, d):
@@ -1794,12 +1793,11 @@ class LabeledDatasetBuilder(object):
                         tmp_dir, labels_basename + unique_appender + labels_ext)
 
                 record.build(data_path, labels_path, pretty_print=pretty_print)
-                dataset.add_file_and_rename(data_path, labels_path,
-                                            os.path.basename(
-                                                record.new_data_path),
-                                            os.path.basename(
-                                                record.new_labels_path),
-                                            move_files=True)
+                dataset.add_file(data_path, labels_path, os.path.basename(
+                    record.new_data_path),
+                                 os.path.basename(
+                                     record.new_labels_path),
+                                 move_files=True)
 
         dataset.write_manifest(os.path.basename(path))
         return dataset
@@ -2023,7 +2021,7 @@ class BuilderVideoRecord(BuilderDataRecord):
             self, clip_end_frame, duration, total_frame_count):
         metadata = etav.VideoMetadata.build_for(self.data_path)
         self.total_frame_count = (
-            total_frame_count or metadata.total_frame_count)
+                total_frame_count or metadata.total_frame_count)
         self.duration = duration or metadata.duration
         self.clip_end_frame = clip_end_frame or metadata.total_frame_count
 
@@ -2221,7 +2219,7 @@ class Balancer(DatasetTransformer):
             return
 
         if (not specified["attribute_name"] and not specified["object_label"]
-            and specified["labels_schema"]):
+                and specified["labels_schema"]):
             return
 
         # Anything else is unacceptable. Raise a ValueError with the
@@ -2382,7 +2380,7 @@ class Balancer(DatasetTransformer):
 
             for frame_no in labels:
                 if (frame_no < record.clip_start_frame or
-                    frame_no >= record.clip_end_frame):
+                        frame_no >= record.clip_end_frame):
                     continue
 
                 frame = labels[frame_no]

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -765,7 +765,10 @@ class LabeledDataset(object):
         labels_subdir = os.path.join(self.data_dir, self._LABELS_SUBDIR)
         if os.path.dirname(data_path) != data_subdir:
             if move_files:
-                etau.move_file(data_path, os.path.join(data_subdir, new_data_path))
+                print(data_path)
+                out_path = os.path.join(data_subdir, new_data_path)
+                print(out_path)
+                etau.move_file(data_path, out_path)
             else:
                 etau.copy_file(data_path, os.path.join(data_subdir, new_data_path))
         if os.path.dirname(labels_path) != labels_subdir:

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -444,6 +444,12 @@ def _iter_filtered_video_frames(video_dataset, frame_filter, stride):
 
 
 def _get_dataset_name(path):
+    ''' Given a filepath to a specific data or label file in a labeled dataset,
+    this will return the dataset name determined by the containing folder.
+    
+    E.g. => /datasets/special-dataset-1/labels/vid-1.json 
+    returns 'special-dataset-1'
+    '''
     base = os.path.basename(os.path.dirname(os.path.dirname(path)))
     return base
 
@@ -685,8 +691,8 @@ class LabeledDataset(object):
         Args:
             data_path: path to data file to be added
             labels_path: path to corresponding labels file to be added
-            new_data_path: filename for the data file to be renamed to
-            new_labels_path: filename for the labels file to be renamed to
+            new_data_path: optional filename for the data file to be renamed to
+            new_labels_path: optional filename for the labels file to be renamed to
             move_files: whether to move the files from their original
                 location into the dataset directory. If False, files
                 are copied into the dataset directory.

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2960,19 +2960,19 @@ class EmptyLabels(DatasetTransformer):
 class Merger(DatasetTransformer):
     '''Merges another dataset into the existing dataset.'''
 
-    def __init__(self, dataset_builder, prepend=True):
+    def __init__(self, dataset_builder, prepend_dataset_name=True):
         '''Creates a Merger instance.
 
         Args:
             dataset_builder: a LabeledDatasetBuilder instance for the dataset
                 to be merged with the existing one
-            prepend: This flag enables an option to prepend both the data and
-                labels filepaths with the folder name containing the original
-                files. E.g. /path/to/dataset001/001-123.mp4 =>
+            prepend_dataset_name: This flag enables an option to prepend both
+                the data and labels filepaths with the folder name containing
+                the original files. E.g. /path/to/dataset001/001-123.mp4 =>
                 /new_directory/dataset001_001-123
         '''
         self._builder_dataset_to_merge = dataset_builder.builder_dataset
-        self.prepend = prepend
+        self.prepend_dataset_name = prepend_dataset_name
 
     def transform(self, src):
         '''Merges the given BuilderDataset into this instance.
@@ -2990,8 +2990,7 @@ class Merger(DatasetTransformer):
                 )
             )
 
-        # Prepend the folder name containing the record
-        if self.prepend:
+        if self.prepend_dataset_name:
             for record in self._builder_dataset_to_merge.records:
                 base = os.path.basename(os.path.dirname(os.path.dirname(record.data_path)))
                 record.new_data_path = base + '_' + os.path.basename(record.data_path)

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -1866,7 +1866,7 @@ class BuilderDataRecord(BaseDataRecord):
 
     @property
     def new_labels_path(self):
-        return self._new_data_path if self._new_data_path is not None else self._data_path
+        return self._new_labels_path if self._new_labels_path is not None else self._labels_path
 
     @new_data_path.setter
     def new_data_path(self, value):

--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -765,9 +765,9 @@ class LabeledDataset(object):
         labels_subdir = os.path.join(self.data_dir, self._LABELS_SUBDIR)
         if os.path.dirname(data_path) != data_subdir:
             if move_files:
-                print(data_path)
+                print("data_path:", data_path)
                 out_path = os.path.join(data_subdir, new_data_path)
-                print(out_path)
+                print("out_path:", out_path)
                 etau.move_file(data_path, out_path)
             else:
                 etau.copy_file(data_path, os.path.join(data_subdir, new_data_path))
@@ -2999,8 +2999,8 @@ class Merger(DatasetTransformer):
                 record.new_labels_path = os.path.basename(os.path.dirname(
                     record.labels_path)) + '_' + os.path.basename(record.labels_path)
 
-                print(record.data_path)
-                print(record.labels_path)
+                print(record.new_data_path)
+                print(record.new_labels_path)
 
         src.add_container(self._builder_dataset_to_merge)
 


### PR DESCRIPTION
This PR contains a few changes to make note of.

1. The `Merger` DatasetTransformer now accepts a parameter `prepend_dataset_name` which defaults to TRUE. When true, this will automatically rename the data and labels files to prepend the dataset name followed by an underscore. This renaming is ONLY applied to the data being merged into the dataset. For example, in the following code, only the records in data2 are renamed.

```py
import eta.core.datasets as etad
  
data1 = etad.LabeledImageDataset("/path/to/dataset1/manifest.json")
data2 = etad.LabeledImageDataset("/path/to/dataset2/manifest.json")

builder = data1.builder()
builder.add_transform(etad.Merger(d2.builder()))

builder.build("/path/to/merged/manifest.json")
```

2. We also introduce a new DatasetTransformer called `PrependDatasetNameToRecords` which can perform the same operation. We can use either of the two following options to ensure ALL data has been renamed upon building the new dataset.

Option 1:
```py
import eta.core.datasets as etad
  
data1 = etad.LabeledImageDataset("/path/to/dataset1/manifest.json")
data2 = etad.LabeledImageDataset("/path/to/dataset2/manifest.json")

builder = data1.builder()
builder.add_transform(etad.PrependDatasetNameToRecords())
builder.add_transform(etad.Merger(d2.builder()))

builder.build("/path/to/merged/manifest.json")
```

Option 2:
```py
import eta.core.datasets as etad
  
data1 = etad.LabeledImageDataset("/path/to/dataset1/manifest.json")
data2 = etad.LabeledImageDataset("/path/to/dataset2/manifest.json")

builder = data1.builder()
builder.add_transform(etad.Merger(d2.builder(), prepend_dataset_name=False))
builder.add_transform(etad.PrependDatasetNameToRecords())

builder.build("/path/to/merged/manifest.json")
```