### PR TITLE
Improving docs

### DIFF
--- a/docs/export_tf_graphs_guide.md
+++ b/docs/export_tf_graphs_guide.md
@@ -1,0 +1,74 @@
+# Exporting TensorFlow Graphs Guide
+
+This document describes how to export frozen TensorFlow graphs for inference.
+
+
+## Exporting pre-trained models from the TF-Slim Model Zoo
+
+This section describes how to export a pre-trained model from the
+[TensorFlow-Slim Model Zoo](https://github.com/tensorflow/models/tree/master/research/slim).
+
+First, choose a model of interest from the zoo:
+
+```shell
+#
+# Choose any model from
+# https://github.com/tensorflow/models/tree/master/research/slim
+#
+MODEL=resnet_v2_50_2017_04_14
+MODEL_NAME=resnet_v2_50
+OUTPUT_NODE=resnet_v2_50/predictions/Reshape_1
+```
+
+download it:
+
+```
+mkdir -p tmp
+wget -P tmp http://download.tensorflow.org/models/${MODEL}.tar.gz
+tar -xf tmp/${MODEL}.tar.gz -C tmp
+```
+
+and extract the training checkpoint:
+
+```shell
+mv tmp/*.ckpt ${MODEL_NAME}.ckpt
+rm -r tmp
+```
+
+Next, export the inference graph using the `export_inference_graph.py` tool
+provided in the TF-Slim library:
+
+```shell
+TF_SLIM_DIR = $(eta constants TF_SLIM_DIR)
+
+python "${TF_SLIM_DIR}/export_inference_graph.py" \
+    --alsologtostderr \
+    --model_name=${MODEL_NAME} \
+    --output_file=${MODEL_NAME}_graph.pb
+```
+
+Finally, freeze the graph using the `freeze_graph` tool from the TF repository:
+
+```shell
+bazel-bin/tensorflow/python/tools/freeze_graph \
+  --input_graph=${MODEL_NAME}_graph.pb \
+  --input_checkpoint=${MODEL_NAME}.ckpt \
+  --input_binary=true \
+  --output_graph=${MODEL_NAME}.pb \
+  --output_node_names=${OUTPUT_NODE}
+```
+
+The last step assumes that you have built the `freeze_graph` tool
+from the [TensorFlow Repository](https://github.com/tensorflow/tensorflow):
+
+```shell
+bazel build tensorflow/python/tools:freeze_graph
+```
+
+
+## Copyright
+
+Copyright 2017-2019, Voxel51, Inc.<br>
+voxel51.com
+
+Brian Moore, brian@voxel51.com

--- a/docs/export_tf_graphs_guide.md
+++ b/docs/export_tf_graphs_guide.md
@@ -16,8 +16,6 @@ First, choose a model of interest from the zoo:
 # https://github.com/tensorflow/models/tree/master/research/slim
 #
 MODEL=resnet_v2_50_2017_04_14
-MODEL_NAME=resnet_v2_50
-OUTPUT_NODE=resnet_v2_50/predictions/Reshape_1
 ```
 
 download it:
@@ -31,38 +29,23 @@ tar -xf tmp/${MODEL}.tar.gz -C tmp
 and extract the training checkpoint:
 
 ```shell
-mv tmp/*.ckpt ${MODEL_NAME}.ckpt
+mv tmp/*.ckpt ${MODEL}.ckpt
 rm -r tmp
 ```
 
-Next, export the inference graph using the `export_inference_graph.py` tool
-provided in the TF-Slim library:
+Finally, export the frozen inference graph using the
+`eta.classifiers.tfslim_classifiers.export_frozen_inference_graph()` method:
 
-```shell
-TF_SLIM_DIR = $(eta constants TF_SLIM_DIR)
+```py
+import eta.classifiers.tfslim_classifiers as etat
 
-python "${TF_SLIM_DIR}/export_inference_graph.py" \
-    --alsologtostderr \
-    --model_name=${MODEL_NAME} \
-    --output_file=${MODEL_NAME}_graph.pb
-```
+checkpoint_path = "resnet_v2_50_2017_04_14.ckpt"
+network_name = "resnet_v2_50"
+labels_map_path = "tfslim_imagenet_labels.txt"
+output_path = "resnet_v2_50_2017_04_14.pb"
 
-Finally, freeze the graph using the `freeze_graph` tool from the TF repository:
-
-```shell
-bazel-bin/tensorflow/python/tools/freeze_graph \
-  --input_graph=${MODEL_NAME}_graph.pb \
-  --input_checkpoint=${MODEL_NAME}.ckpt \
-  --input_binary=true \
-  --output_graph=${MODEL_NAME}.pb \
-  --output_node_names=${OUTPUT_NODE}
-```
-
-The last step assumes that you have built the `freeze_graph` tool
-from the [TensorFlow Repository](https://github.com/tensorflow/tensorflow):
-
-```shell
-bazel build tensorflow/python/tools:freeze_graph
+etat.export_frozen_inference_graph(
+    checkpoint_path, network_name, labels_map_path, output_path)
 ```
 
 

--- a/docs/export_tf_graphs_guide.md
+++ b/docs/export_tf_graphs_guide.md
@@ -41,11 +41,10 @@ import eta.classifiers.tfslim_classifiers as etat
 
 checkpoint_path = "resnet_v2_50_2017_04_14.ckpt"
 network_name = "resnet_v2_50"
-labels_map_path = "tfslim_imagenet_labels.txt"
 output_path = "resnet_v2_50_2017_04_14.pb"
 
 etat.export_frozen_inference_graph(
-    checkpoint_path, network_name, labels_map_path, output_path)
+    checkpoint_path, network_name, output_path, num_classes=1001)
 ```
 
 

--- a/eta/classifiers/tfslim_classifiers.py
+++ b/eta/classifiers/tfslim_classifiers.py
@@ -81,8 +81,8 @@ class TFSlimClassifierConfig(Config, etal.HasDefaultDeploymentConfig):
     Attributes:
         model_name: the name of the published model to load. If this value is
             provided, `model_path` does not need to be
-        model_path: the path to a TF SavedModel in `.pb` format to load. If
-            this value is provided, `model_name` does not need to be
+        model_path: the path to a frozen inference graph in `.pb` format to
+            load. If this value is provided, `model_name` does not need to be
         attr_name: the name of the attribute that the classifier predicts
         network_name: the name of the network architecture from
             `tf.slim.nets.nets_factory`

--- a/eta/classifiers/tfslim_classifiers.py
+++ b/eta/classifiers/tfslim_classifiers.py
@@ -275,7 +275,7 @@ class TFSlimClassifier(etal.ImageClassifier, etat.UsesTFSession):
 
 def export_frozen_inference_graph(
         checkpoint_path, network_name, output_path, num_classes=None,
-        labels_map_path=None, output_node=None):
+        labels_map_path=None, output_name=None):
     '''Exports the given TF-Slim model checkpoint as a frozen inference graph
     suitable for running inference.
 
@@ -291,7 +291,7 @@ def export_frozen_inference_graph(
         labels_map_path: the path to the labels map for the classifier; used to
             determine the number of output classes. Must be provided if
             `num_classes` is not provided
-        output_node: the name of the output node from which to extract
+        output_name: the name of the output node from which to extract
             predictions. By default, this value is loaded from
             `_DEFAULT_OUTPUT_NAMES`
     '''
@@ -303,16 +303,16 @@ def export_frozen_inference_graph(
         else:
             num_classes = len(etal.load_labels_map(labels_map_path))
 
-    output_node = _DEFAULT_OUTPUT_NAMES.get(network_name, None)
-    if output_node is None:
+    output_name = _DEFAULT_OUTPUT_NAMES.get(network_name, None)
+    if output_name is None:
         raise ValueError(
-            "No 'output_node' manually provided and no default output found " +
+            "No 'output_name' manually provided and no default output found " +
             "for network '%s'" % network_name)
 
     with tf.Graph().as_default() as graph:
         graph_def = _get_graph_def(graph, network_name, num_classes)
         freeze_graph.freeze_graph_with_def_protos(
-            graph_def, None, checkpoint_path, output_node, None, None,
+            graph_def, None, checkpoint_path, output_name, None, None,
             output_path, True, "")
 
 


### PR DESCRIPTION
This PR adds two types of documentation:
(a) adds a description of `default_deployment_config_dict` to `docs/models_dev_guide.md`
(b) adds instructions for exporting frozen TF graphs for models from the TF-Slim framework
