### PR TITLE
Adding support for using StorageClients from the ETA CLI

### DIFF
--- a/eta/__init__.py
+++ b/eta/__init__.py
@@ -135,9 +135,14 @@ def set_config_settings(**kwargs):
 
 def startup_message():
     '''Logs ETA startup message.'''
-    logger.info("Starting...\n" + etac.ASCII_ART)
+    logger.info("Starting...\n" + _load_ascii_art())
     logger.info(version)
     logger.info("Revision %s", etau.get_eta_rev())
+
+
+def _load_ascii_art():
+    with open(etac.ASCII_ART_PATH, "rt") as f:
+        return f.read()
 
 
 def is_python2():

--- a/eta/constants.py
+++ b/eta/constants.py
@@ -55,8 +55,3 @@ AUTHOR = _VER["author"]
 CONTACT = _VER["contact"]
 URL = _VER["url"]
 LICENSE = _VER["license"]
-
-
-# ASCII art
-with open(ASCII_ART_PATH, "rt") as f:
-    ASCII_ART = f.read()

--- a/eta/constants.py
+++ b/eta/constants.py
@@ -26,6 +26,7 @@ import os
 
 # Directories
 ETA_DIR = os.path.abspath(os.path.dirname(__file__))
+ETA_CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".eta")
 BASE_DIR = os.path.dirname(ETA_DIR)
 EXAMPLES_DIR = os.path.join(BASE_DIR, "examples")
 RESOURCES_DIR = os.path.join(ETA_DIR, "resources")

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -510,7 +510,7 @@ class AuthCommand(Command):
         subparsers = parser.add_subparsers(title="available commands")
         _register_command(subparsers, "show", ShowAuthCommand)
         _register_command(subparsers, "activate", ActivateAuthCommand)
-        _register_command(subparsers, "clean", CleanAuthCommand)
+        _register_command(subparsers, "deactivate", DeactivateAuthCommand)
 
 
 class ShowAuthCommand(Command):
@@ -641,8 +641,8 @@ class ActivateAuthCommand(Command):
             etas.NeedsSSHCredentials.activate_credentials(args.ssh)
 
 
-class CleanAuthCommand(Command):
-    '''Delete authentication credentials.'''
+class DeactivateAuthCommand(Command):
+    '''Deactivate authentication credentials.'''
 
     @staticmethod
     def setup(parser):

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -713,10 +713,10 @@ class S3InfoCommand(Command):
 
     Examples:
         # Get file info
-        eta s3 info <path> [...]
+        eta s3 info <cloud-path> [...]
 
         # Get folder info
-        eta s3 info --folder <path> [...]
+        eta s3 info --folder <cloud-path> [...]
     '''
 
     @staticmethod
@@ -1095,10 +1095,10 @@ class GCSInfoCommand(Command):
 
     Examples:
         # Get file info
-        eta gcs info <path> [...]
+        eta gcs info <cloud-path> [...]
 
         # Get folder info
-        eta gcs info --folder <path> [...]
+        eta gcs info --folder <cloud-path> [...]
     '''
 
     @staticmethod

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -492,18 +492,40 @@ class ConstantsCommand(Command):
     '''Print constants from `eta.constants`.
 
     Examples:
-        # Print a constant defined in `eta.constants`
+        # Print the specified constant
         eta constants <CONSTANT>
+
+        # Print all constants
+        eta constants --all
     '''
 
     @staticmethod
     def setup(parser):
         parser.add_argument(
-            "constant", metavar="CONSTANT", help="the constant to print")
+            "constant", nargs="?", metavar="CONSTANT",
+            help="the constant to print")
+        parser.add_argument(
+            "-a", "--all", action="store_true",
+            help="print all available constants")
 
     @staticmethod
     def run(args):
-        logger.info(getattr(etac, args.constant))
+        if args.all:
+            d = {
+                k: v for k, v in iteritems(vars(etac))
+                if not k.startswith("_") and k == k.upper()
+            }
+            _print_constants_table(d)
+
+        if args.constant:
+            logger.info(getattr(etac, args.constant))
+
+
+def _print_constants_table(d):
+    contents = sorted(d.items(), key=lambda kv: kv[0])
+    table_str = tabulate(
+        contents, headers=["constant", "value"], tablefmt=TABLE_FORMAT)
+    logger.info(table_str)
 
 
 class AuthCommand(Command):

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -1473,10 +1473,10 @@ class GoogleDriveInfoCommand(Command):
 
     Examples:
         # Get file info
-        eta gdrive info <id> [...]
+        eta gdrive info <file-id> [...]
 
         # Get folder info
-        eta gdrive info --folder <id> [...]
+        eta gdrive info --folder <folder-id> [...]
     '''
 
     @staticmethod
@@ -1826,7 +1826,7 @@ class GoogleDriveDeleteCommand(Command):
 
     Examples:
         # Delete file
-        eta gdrive delete <id>
+        eta gdrive delete <file-id>
     '''
 
     @staticmethod
@@ -1847,10 +1847,10 @@ class GoogleDriveDeleteDirCommand(Command):
 
     Examples:
         # Delete directory
-        eta gdrive delete-dir <id>
+        eta gdrive delete-dir <folder-id>
 
         # Delete the contents (only) of a directory
-        eta gdrive delete-dir <id> --contents-only
+        eta gdrive delete-dir <folder-id> --contents-only
     '''
 
     @staticmethod

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -1258,6 +1258,28 @@ class GCSDeleteCommand(Command):
         client.delete(args.cloud_path)
 
 
+class GCSDeleteDirCommand(Command):
+    '''Delete directory from GCS.
+
+    Examples:
+        # Delete directory
+        eta gcs delete-dir <cloud-dir>
+    '''
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument(
+            "cloud_dir", metavar="CLOUD_DIR", help="the GCS directory to "
+            "delete")
+
+    @staticmethod
+    def run(args):
+        client = etas.GoogleCloudStorageClient()
+
+        logger.info("Deleting '%s'", args.cloud_dir)
+        client.delete_folder(args.cloud_dir)
+
+
 class GoogleDriveStorageCommand(Command):
     '''Tools for working with Google Drive.'''
 

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -2144,7 +2144,10 @@ def _parse_size(size):
 
 
 def _parse_datetime(dt):
-    return dt.astimezone(get_localzone()).strftime("%Y-%m-%d %H:%M:%S %Z")
+    try:
+        return dt.astimezone(get_localzone()).strftime("%Y-%m-%d %H:%M:%S %Z")
+    except:
+        return "-"
 
 
 def _render_names_in_dirs_str(d):

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -727,18 +727,98 @@ class S3ListCommand(Command):
 
     Examples:
         # List folder contents
-        eta s3 list <folder>
+        eta s3 list s3://<bucket>/<prefix>
 
         # List folder contents recursively
-        eta s3 list <folder> --recursive
+        eta s3 list s3://<bucket>/<prefix> --recursive
 
         # List folder contents according to the given query
-        eta s3 list <folder>
+        eta s3 list s3://<bucket>/<prefix>
+            [--recursive]
             [--limit <limit>]
-            [--search [<field>:]<str>]
+            [--search [<field><operator>]<str>[,...]]
             [--sort-by <field>]
             [--ascending]
             [--count]
+
+        # List the last 10 modified files that contain "test" in any field
+        eta s3 list s3://<bucket>/<prefix> \\
+            --search test --limit 10 --sort-by last_modified
+
+        # List files whose size is 10-20MB, from smallest to largest
+        eta s3 list s3://<bucket>/<prefix> \\
+            --search 'size>10MB,size<20MB' --sort-by size --ascending
+
+        # List files that were uploaded before November 26th, 2019, recurisvely
+        # traversing subfolders, and display the count
+        eta s3 list s3://<bucket>/<prefix> \\
+            --recursive --search 'last modified<2019-11-26' --count
+
+    Search syntax:
+        The generic search syntax is:
+
+            --search [<field><operator>]<str>[,...]
+
+        where:
+            <field>    an optional field name on which to search
+            <operator> an optional operator to use when evaluating matches
+            <str>      the search string
+
+        If <field><operator> is omitted, the search will match any records for
+        which any column contains the given search string.
+
+        Multiple searches can be specified as a comma-separated list. Records
+        must match all searches in order to appear in the search results.
+
+        The supported fields are:
+
+        field         type     description
+        ------------- -------- ------------------------------------------
+        bucket        string   the name of the bucket
+        name          string   the name of the object in the bucket
+        size          bytes    the size of the object
+        type          string   the MIME type of the object
+        last modified datetime the date that the object was last modified
+
+        Fields are case insensitive, and underscores can be used in-place of
+        spaces.
+
+        The meaning of the operators are as follows:
+
+        operator  type       description
+        --------- ---------- --------------------------------------------------
+        =         contains   the field contains the search string
+        ==        comparison the search string is equal to the field
+        <         comparison the search string is less than the field
+        <=        comparison the search string is less or equal to the field
+        >         comparison the search string is greater than the field
+        >=        comparison the search string is greater or equal to the field
+
+        For contains ("=") queries, the search/record values are parsed as
+        follows:
+
+        type     description
+        -------- --------------------------------------------------------------
+        string   the search and record are treated as strings
+        bytes    the search is treated as a string, and the record is converted
+                 to a human-readable bytes string
+        datetime the search is treated as a string, and the record is rendered
+                 as a string in "%Y-%m-%d %H:%M:%S %Z" format in local timezone
+
+        For comparison ("==", "<", "<=", ">", ">=") queries, the search/record
+        values are parsed as follows:
+
+        type     description
+        -------- ------------------------------------------------------------
+        string   the search and record are treated as strings
+        bytes    the search must be a human-readable bytes string, which is
+                 converted to numeric bytes for comparison with the record
+        datetime the search must be an ISO time string, which is converted to
+                 a datetime for comparison with the record. If no timezone is
+                 included in the search, local time is assumed
+
+        To perform literal matches on special characters ("=", "<", ">", ",")
+        in search string, escape them with "\\".
     '''
 
     @staticmethod
@@ -1029,18 +1109,98 @@ class GCSListCommand(Command):
 
     Examples:
         # List folder contents
-        eta gcs list <folder>
+        eta gcs list gs://<bucket>/<prefix>
 
         # List folder contents recursively
-        eta gcs list <folder> --recursive
+        eta gcs list gs://<bucket>/<prefix> --recursive
 
         # List folder contents according to the given query
-        eta gcs list <folder>
+        eta gcs list gs://<bucket>/<prefix>
+            [--recursive]
             [--limit <limit>]
-            [--search [<field>:]<str>]
+            [--search [<field><operator>]<str>[,...]]
             [--sort-by <field>]
             [--ascending]
             [--count]
+
+        # List the last 10 modified files that contain "test" in any field
+        eta gcs list gs://<bucket>/<prefix> \\
+            --search test --limit 10 --sort-by last_modified
+
+        # List files whose size is 10-20MB, from smallest to largest
+        eta gcs list gs://<bucket>/<prefix> \\
+            --search 'size>10MB,size<20MB' --sort-by size --ascending
+
+        # List files that were uploaded before November 26th, 2019, recurisvely
+        # traversing subfolders, and display the count
+        eta gcs list gs://<bucket>/<prefix> \\
+            --recursive --search 'last modified<2019-11-26' --count
+
+    Search syntax:
+        The generic search syntax is:
+
+            --search [<field><operator>]<str>[,...]
+
+        where:
+            <field>    an optional field name on which to search
+            <operator> an optional operator to use when evaluating matches
+            <str>      the search string
+
+        If <field><operator> is omitted, the search will match any records for
+        which any column contains the given search string.
+
+        Multiple searches can be specified as a comma-separated list. Records
+        must match all searches in order to appear in the search results.
+
+        The supported fields are:
+
+        field         type     description
+        ------------- -------- ------------------------------------------
+        bucket        string   the name of the bucket
+        name          string   the name of the object in the bucket
+        size          bytes    the size of the object
+        type          string   the MIME type of the object
+        last modified datetime the date that the object was last modified
+
+        Fields are case insensitive, and underscores can be used in-place of
+        spaces.
+
+        The meaning of the operators are as follows:
+
+        operator  type       description
+        --------- ---------- --------------------------------------------------
+        =         contains   the field contains the search string
+        ==        comparison the search string is equal to the field
+        <         comparison the search string is less than the field
+        <=        comparison the search string is less or equal to the field
+        >         comparison the search string is greater than the field
+        >=        comparison the search string is greater or equal to the field
+
+        For contains ("=") queries, the search/record values are parsed as
+        follows:
+
+        type     description
+        -------- --------------------------------------------------------------
+        string   the search and record are treated as strings
+        bytes    the search is treated as a string, and the record is converted
+                 to a human-readable bytes string
+        datetime the search is treated as a string, and the record is rendered
+                 as a string in "%Y-%m-%d %H:%M:%S %Z" format in local timezone
+
+        For comparison ("==", "<", "<=", ">", ">=") queries, the search/record
+        values are parsed as follows:
+
+        type     description
+        -------- ------------------------------------------------------------
+        string   the search and record are treated as strings
+        bytes    the search must be a human-readable bytes string, which is
+                 converted to numeric bytes for comparison with the record
+        datetime the search must be an ISO time string, which is converted to
+                 a datetime for comparison with the record. If no timezone is
+                 included in the search, local time is assumed
+
+        To perform literal matches on special characters ("=", "<", ">", ",")
+        in search string, escape them with "\\".
     '''
 
     @staticmethod
@@ -1346,18 +1506,98 @@ class GoogleDriveListCommand(Command):
 
     Examples:
         # List folder contents
-        eta gdrive list <id>
+        eta gdrive list <folder-id>
 
         # List folder contents recursively
-        eta gdrive list <id> --recursive
+        eta gdrive list <folder-id> --recursive
 
         # List folder contents according to the given query
-        eta gdrive list <id>
+        eta gdrive list <folder-id>
+            [--recursive]
             [--limit <limit>]
-            [--search [<field>:]<str>]
+            [--search [<field><operator>]<str>[,...]]
             [--sort-by <field>]
             [--ascending]
             [--count]
+
+        # List the last 10 modified files that contain "test" in any field
+        eta gdrive list <folder-id> \\
+            --search test --limit 10 --sort-by last_modified
+
+        # List files whose size is 10-20MB, from smallest to largest
+        eta gdrive list <folder-id> \\
+            --search 'size>10MB,size<20MB' --sort-by size --ascending
+
+        # List files that were uploaded before November 26th, 2019, recurisvely
+        # traversing subfolders, and display the count
+        eta gdrive list <folder-id> \\
+            --recursive --search 'last modified<2019-11-26' --count
+
+    Search syntax:
+        The generic search syntax is:
+
+            --search [<field><operator>]<str>[,...]
+
+        where:
+            <field>    an optional field name on which to search
+            <operator> an optional operator to use when evaluating matches
+            <str>      the search string
+
+        If <field><operator> is omitted, the search will match any records for
+        which any column contains the given search string.
+
+        Multiple searches can be specified as a comma-separated list. Records
+        must match all searches in order to appear in the search results.
+
+        The supported fields are:
+
+        field         type     description
+        ------------- -------- ------------------------------------------
+        id            string   the ID of the file
+        name          string   the name of the file
+        size          bytes    the size of the file
+        type          string   the MIME type of the object
+        last modified datetime the date that the file was last modified
+
+        Fields are case insensitive, and underscores can be used in-place of
+        spaces.
+
+        The meaning of the operators are as follows:
+
+        operator  type       description
+        --------- ---------- --------------------------------------------------
+        =         contains   the field contains the search string
+        ==        comparison the search string is equal to the field
+        <         comparison the search string is less than the field
+        <=        comparison the search string is less or equal to the field
+        >         comparison the search string is greater than the field
+        >=        comparison the search string is greater or equal to the field
+
+        For contains ("=") queries, the search/record values are parsed as
+        follows:
+
+        type     description
+        -------- --------------------------------------------------------------
+        string   the search and record are treated as strings
+        bytes    the search is treated as a string, and the record is converted
+                 to a human-readable bytes string
+        datetime the search is treated as a string, and the record is rendered
+                 as a string in "%Y-%m-%d %H:%M:%S %Z" format in local timezone
+
+        For comparison ("==", "<", "<=", ">", ">=") queries, the search/record
+        values are parsed as follows:
+
+        type     description
+        -------- ------------------------------------------------------------
+        string   the search and record are treated as strings
+        bytes    the search must be a human-readable bytes string, which is
+                 converted to numeric bytes for comparison with the record
+        datetime the search must be an ISO time string, which is converted to
+                 a datetime for comparison with the record. If no timezone is
+                 included in the search, local time is assumed
+
+        To perform literal matches on special characters ("=", "<", ">", ",")
+        in search string, escape them with "\\".
     '''
 
     @staticmethod

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -621,6 +621,9 @@ class ActivateAuthCommand(Command):
 
         # Activate AWS credentials
         eta auth activate --aws '/path/to/credentials.ini'
+
+        # Activate SSH credentials
+        eta auth activate --ssh '/path/to/id_rsa'
     '''
 
     @staticmethod
@@ -646,7 +649,21 @@ class ActivateAuthCommand(Command):
 
 
 class DeactivateAuthCommand(Command):
-    '''Deactivate authentication credentials.'''
+    '''Deactivate authentication credentials.
+
+    Examples:
+        # Deactivate Google credentials
+        eta auth deactivate --google '/path/to/service-account.json'
+
+        # Deactivate AWS credentials
+        eta auth deactivate --aws '/path/to/credentials.ini'
+
+        # Deactivate SSH credentials
+        eta auth deactivate --ssh '/path/to/id_rsa'
+
+        # Deactivate all credentials
+        eta auth deactivate --all
+    '''
 
     @staticmethod
     def setup(parser):
@@ -659,16 +676,18 @@ class DeactivateAuthCommand(Command):
         parser.add_argument(
             "--ssh", action="store_true",
             help="delete the active SSH credentials")
+        parser.add_argument(
+            "--all", action="store_true", help="delete all active credentials")
 
     @staticmethod
     def run(args):
-        if args.google:
+        if args.google or args.all:
             etas.NeedsGoogleCredentials.deactivate_credentials()
 
-        if args.aws:
+        if args.aws or args.all:
             etas.NeedsAWSCredentials.deactivate_credentials()
 
-        if args.ssh:
+        if args.ssh or args.all:
             etas.NeedsSSHCredentials.deactivate_credentials()
 
 

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -403,11 +403,11 @@ class Serializable(object):
 def _recurse(v, reflective):
     if isinstance(v, Serializable):
         return v.serialize(reflective=reflective)
-    elif isinstance(v, set):
+    if isinstance(v, set):
         v = list(v)  # convert sets to lists
     if isinstance(v, list):
         return [_recurse(vi, reflective) for vi in v]
-    elif isinstance(v, dict):
+    if isinstance(v, dict):
         return OrderedDict(
             (ki, _recurse(vi, reflective)) for ki, vi in iteritems(v))
     return v

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -516,7 +516,7 @@ class NeedsAWSCredentials(object):
     '''Mixin for classes that need AWS credentials to take authenticated
     actions.
 
-    Storage clients that dervie from this class should allow users to provide
+    Storage clients that derive from this class should allow users to provide
     credentials in the following ways (in order of precedence):
 
         (1) manually constructing an instance of the class via the
@@ -1037,7 +1037,7 @@ class NeedsGoogleCredentials(object):
     '''Mixin for classes that need a `google.auth.credentials.Credentials`
     instance to take authenticated actions.
 
-    Storage clients that dervie from this class should allow users to provide
+    Storage clients that derive from this class should allow users to provide
     credentials in the following ways (in order of precedence):
 
         (1) manually constructing an instance of the class via the
@@ -2442,7 +2442,7 @@ class NeedsSSHCredentials(object):
 
     The SSH key used must have _no password_.
 
-    Storage clients that dervie from this class should allow users to provide
+    Storage clients that derive from this class should allow users to provide
     their private key in the following ways (in order of precedence):
 
         (1) manually providing a private key path when contructing an instance

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1656,8 +1656,8 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
         Drive folder, retaining the (now empty) parent folder.
 
         Args:
-            folder_id: the ID of the Google Drive folder from which the files
-                are to be deleted
+            folder_id: the ID of the folder from which the files are to be
+                deleted
             skip_failures: whether to gracefully skip delete errors. By
                 default, this is False
         '''

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -648,9 +648,20 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
     strategy used by this class.
     '''
 
-    def __init__(self):
-        '''Creates an S3StorageClient instance.'''
-        self._client = boto3.client("s3")
+    def __init__(self, credentials=None):
+        '''Creates an S3StorageClient instance.
+
+        Args:
+            credentials: an optional AWS credentials dictionary. If provided,
+                the values are directly passed to `boto3` via
+                `boto3.client("s3", **credentials)`. If not provided, active
+                credentials are automatically loaded as described in
+                `NeedsAWSCredentials`
+        '''
+        if credentials is None:
+            credentials = {}
+
+        self._client = boto3.client("s3", **credentials)
 
     def upload(self, local_path, cloud_path, content_type=None):
         '''Uploads the file to S3.

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1365,8 +1365,8 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
     strategy used by this class.
 
     Attributes:
-        chunk_size: the chunk size (in bytes) that will be used for streaming
-            uploads and downloads
+        chunk_size: the chunk size (in bytes) that will be used for uploads and
+            downloads
     '''
 
     #
@@ -1457,7 +1457,7 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
 
         Args:
             file_id: the ID of the file to download
-            local_path: the path to the storage location
+            local_path: the path to which to download the file
         '''
         etau.ensure_basedir(local_path)
         with open(local_path, "wb") as f:

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -661,7 +661,12 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
                 `NeedsAWSCredentials`
         '''
         if credentials is None:
-            credentials = {}
+            credentials, _ = self.load_credentials()
+
+            # The .ini files use `region` but `boto3.client` uses `region_name`
+            region = credentials.pop("region", None)
+            if region:
+                credentials["region_name"] = region
 
         self._client = boto3.client("s3", **credentials)
 

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1168,20 +1168,17 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
         '''Creates a GoogleDriveStorageClient instance.
 
         Args:
-            credentials: a `google.auth.credentials.Credentials` instance. If
-                not provided, the `GOOGLE_APPLICATION_CREDENTIALS` environment
-                variable must be set to point to a valid service account JSON
-                file
+            credentials: an optional `google.auth.credentials.Credentials`
+                instance. If not provided, active credentials are automatically
+                loaded as described in `NeedsGoogleCredentials`
             chunk_size: an optional chunk size (in bytes) to use for uploads
                 and downloads. By default, `DEFAULT_CHUNK_SIZE` is used
         '''
-        if credentials:
-            self._service = gad.build(
-                "drive", "v3", credentials=credentials, cache_discovery=False)
-        else:
-            # Uses credentials from GOOGLE_APPLICATION_CREDENTIALS
-            self._service = gad.build("drive", "v3", cache_discovery=False)
+        if credentials is None:
+            credentials = self.load_credentials()
 
+        self._service = gad.build(
+            "drive", "v3", credentials=credentials, cache_discovery=False)
         self.chunk_size = chunk_size or self.DEFAULT_CHUNK_SIZE
 
     def upload(self, local_path, folder_id, filename=None, content_type=None):

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -2020,6 +2020,7 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
 
 
 class GoogleDriveStorageClientError(Exception):
+    '''Error raised when a problem occurred in a GoogleDriveStorageClient.'''
     pass
 
 

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -927,19 +927,17 @@ class GoogleCloudStorageClient(
         '''Creates a GoogleCloudStorageClient instance.
 
         Args:
-            credentials: a `google.auth.credentials.Credentials instance`. If
-                not provided, the `GOOGLE_APPLICATION_CREDENTIALS` environment
-                variable must be set to point to a valid service account JSON
-                file
+            credentials: an optional `google.auth.credentials.Credentials`
+                instance. If not provided, active credentials are automatically
+                loaded as described in `NeedsGoogleCredentials`
             chunk_size: an optional chunk size (in bytes) to use for uploads
                 and downloads. By default, `DEFAULT_CHUNK_SIZE` is used
         '''
-        if credentials:
-            self._client = gcs.Client(
-                credentials=credentials, project=credentials.project_id)
-        else:
-            # Uses credentials from GOOGLE_APPLICATION_CREDENTIALS
-            self._client = gcs.Client()
+        if credentials is None:
+            credentials = self.load_credentials()
+
+        self._client = gcs.Client(
+            credentials=credentials, project=credentials.project_id)
         self.chunk_size = chunk_size or self.DEFAULT_CHUNK_SIZE
 
     @google_cloud_api_retry

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -995,7 +995,7 @@ class NeedsGoogleCredentials(object):
             logger.info("No Google credentials to deactivate")
 
     @classmethod
-    def has_activate_credentials(cls):
+    def has_active_credentials(cls):
         '''Determines whether there are any active credentials stored at
         `~/.eta/google-credentials.json`.
 
@@ -1069,7 +1069,7 @@ class NeedsGoogleCredentials(object):
             logger.debug(
                 "Loading Google credentials from environment variable "
                 "'GOOGLE_APPLICATION_CREDENTIALS=%s'", credentials_path)
-        elif cls.has_activate_credentials():
+        elif cls.has_active_credentials():
             credentials_path = cls.CREDENTIALS_PATH
             logger.debug(
                 "Loading activated Google credentials from '%s'",

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -42,6 +42,8 @@ try:
 except ImportError:
     import urlparse  # Python 2
 
+import dateutil.parser
+
 import boto3
 import google.api_core.exceptions as gae
 import google.cloud.storage as gcs
@@ -369,8 +371,8 @@ class LocalStorageClient(StorageClient, CanSyncDirectories):
     def __init__(self, chunk_size=None):
         '''Creates a LocalStorageClient instance.
 
-        chunk_size: an optional chunk size (in bytes) to use for uploads
-            and downloads. By default, `DEFAULT_CHUNK_SIZE` is used
+        chunk_size: an optional chunk size (in bytes) to use for streaming
+            uploads and downloads. By default, `DEFAULT_CHUNK_SIZE` is used
         '''
         self.chunk_size = chunk_size or self.DEFAULT_CHUNK_SIZE
 
@@ -530,7 +532,7 @@ class NeedsAWSCredentials(object):
             logger.info("No AWS credentials to deactivate")
 
     @classmethod
-    def has_activate_credentials(cls):
+    def has_active_credentials(cls):
         '''Determines whether there are any active credentials stored at
         `~/.eta/aws-credentials.json`.
 
@@ -587,7 +589,7 @@ class NeedsAWSCredentials(object):
             logger.debug(
                 "Loading AWS credentials from environment variable "
                 "AWS_CONFIG_FILE='%s'", credentials_path)
-        elif cls.has_activate_credentials():
+        elif cls.has_active_credentials():
             credentials_path = cls.CREDENTIALS_PATH
             logger.debug(
                 "Loading activated AWS credentials from '%s'",
@@ -633,7 +635,7 @@ class AWSCredentialsError(Exception):
             message: the error message
         '''
         super(AWSCredentialsError, self).__init__(
-            "%s. Read the documentation for "
+            "%s. Read the class docstring of "
             "`eta.core.storage.NeedsAWSCredentials` for more information "
             "about authenticating with AWS services." % message)
 

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -548,13 +548,12 @@ class NeedsAWSCredentials(object):
     https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration
     '''
 
-    CREDENTIALS_PATH = os.path.join(
-        etac.ETA_CONFIG_DIR, "aws-credentials.json")
+    CREDENTIALS_PATH = os.path.join(etac.ETA_CONFIG_DIR, "aws-credentials.ini")
 
     @classmethod
     def activate_credentials(cls, credentials_path):
         '''Activate the credentials by copying them to
-        `~/.eta/aws-credentials.json`.
+        `~/.eta/aws-credentials.ini`.
 
         Args:
             credentials_path: the path to a credentials `.ini` file
@@ -568,7 +567,7 @@ class NeedsAWSCredentials(object):
     def deactivate_credentials(cls):
         '''Deactivates (deletes) the currently active credentials, if any.
 
-        Active credentials (if any) are at `~/.eta/aws-credentials.json`.
+        Active credentials (if any) are at `~/.eta/aws-credentials.ini`.
         '''
         try:
             os.remove(cls.CREDENTIALS_PATH)
@@ -581,7 +580,7 @@ class NeedsAWSCredentials(object):
     @classmethod
     def has_active_credentials(cls):
         '''Determines whether there are any active credentials stored at
-        `~/.eta/aws-credentials.json`.
+        `~/.eta/aws-credentials.ini`.
 
         Returns:
             True/False

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1519,29 +1519,42 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
                     "Failed to delete '%s' from '%s' (%s)", f["name"],
                     folder_id, t.elapsed_time_str)
 
-    def get_file_metadata(self, file_id, extra_fields=None, all_fields=False):
+    def get_file_metadata(self, file_id, all_fields=False):
         '''Gets metadata about the file with the given ID.
 
         Args:
             file_id: the ID of a file (or folder)
-            extra_fields: an optional list of extra fields to return
             all_fields: an optional flag to set if you want to return all
                 available metadata fields. By default, this is False
 
         Returns:
             a dictionary containing the available metadata about the file,
-                including (at least) the `name`, `size`, `createdTime`, and
-                `mimeType` fields
+                including (at least) its `id`, `name`, `size`, `mime_type`, and
+                `last_modified`
         '''
+        fields = ["id", "name", "size", "mimeType", "modifiedTime"]
+        metadata = self._get_file_metadata(
+            file_id, fields=fields, all_fields=all_fields)
+        return self._parse_file_metadata(metadata)
+
+    def _get_file_metadata(self, file_id, fields=None, all_fields=False):
         if all_fields:
             fields = "*"
         else:
-            fields = "name,size,createdTime,mimeType"
-            if extra_fields is not None:
-                fields += "," + ",".join(extra_fields)
+            fields = ",".join(fields)
 
         return self._service.files().get(
             fileId=file_id, fields=fields, supportsTeamDrives=True).execute()
+
+    @staticmethod
+    def _parse_file_metadata(metadata):
+        return {
+            "id": metadata["id"],
+            "name": metadata["name"],
+            "size": int(metadata.get("size", -1)),
+            "mime_type": metadata["mimeType"],
+            "last_modified": dateutil.parser.parse(metadata["modifiedTime"]),
+        }
 
     def get_team_drive_id(self, name):
         '''Get the ID of the Team Drive with the given name.
@@ -1573,8 +1586,7 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
             the ID of the Team Drive, or None if the file does not live in a
                 Team Drive
         '''
-        metadata = self.get_file_metadata(
-            file_id, extra_fields=["teamDriveId"])
+        metadata = self._get_file_metadata(file_id, ["teamDriveId"])
         return metadata.get("teamDriveId", None)
 
     def is_folder(self, file_id):
@@ -1586,8 +1598,8 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
         Returns:
             True/False whether the file is a folder
         '''
-        f = self.get_file_metadata(file_id)
-        return self._is_folder(f)
+        metadata = self._get_file_metadata(file_id, ["mimeType"])
+        return self._is_folder(metadata)
 
     def create_folder_if_necessary(self, folder_name, parent_folder_id):
         '''Creates the given folder within the given parent folder, if
@@ -1632,8 +1644,8 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
                 default, this is False
 
         Returns:
-            A list of dicts containing the `id`, `name`, and `mimeType` of the
-                subfolders in the folder
+            a list of dicts containing the `id`, `name`, `size`, `mime_type`
+                and `last_modified` of the subfolders in the folder
         '''
         # List folder contents
         _, folders = self._list_folder_contents(folder_id)
@@ -1646,7 +1658,7 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
                     f["name"] = os.path.join(folder["name"], f["name"])
                     folders.append(f)
 
-        return folders
+        return [self._parse_file_metadata(f) for f in folders]
 
     def list_files_in_folder(
             self, folder_id, include_folders=False, recursive=False):
@@ -1660,8 +1672,8 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
                 default, this is False
 
         Returns:
-            A list of dicts containing the `id`, `name`, and `mimeType` of the
-                files/subfolders in the folder
+            a list of dicts containing the `id`, `name`, `size`, `mime_type`,
+                and `last_modified` of the files/subfolders in the folder
         '''
         # List folder contents
         files, folders = self._list_folder_contents(folder_id)
@@ -1683,7 +1695,7 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
         elif include_folders:
             files.extend(folders)
 
-        return files
+        return [self._parse_file_metadata(f) for f in files]
 
     def count_files_in_folder(self, folder_id, recursive=False):
         '''Returns count of number of files in the Google Drive folder.
@@ -1982,11 +1994,12 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
         files = []
         page_token = None
         query = "'%s' in parents and trashed=false" % folder_id
+        fields = "id,name,size,mimeType,modifiedTime"
         while True:
             # Get the next page of files
             response = self._service.files().list(
                 q=query,
-                fields="files(id, name, mimeType),nextPageToken",
+                fields="files(%s),nextPageToken" % fields,
                 pageSize=256,
                 pageToken=page_token,
                 **params

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -688,7 +688,7 @@ class AWSCredentialsError(Exception):
 
 
 class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
-    '''Client for reading/writing data from S3 buckets.
+    '''Client for reading/writing data from Amazon S3 buckets.
 
     All cloud path strings used by this class should have the form
     "s3://<bucket>/<path/to/object>".
@@ -1179,11 +1179,11 @@ class GoogleCloudStorageClient(
 
     @google_cloud_api_retry
     def upload(self, local_path, cloud_path, content_type=None):
-        '''Uploads the file to Google Cloud Storage.
+        '''Uploads the file to GCS.
 
         Args:
             local_path: the path to the file to upload
-            cloud_path: the path to the Google Cloud object to create
+            cloud_path: the path to the GCS object to create
             content_type: the optional type of the content being uploaded. If
                 no value is provided, it is guessed from the filename
         '''
@@ -1193,11 +1193,11 @@ class GoogleCloudStorageClient(
 
     @google_cloud_api_retry
     def upload_bytes(self, bytes_str, cloud_path, content_type=None):
-        '''Uploads the given bytes to Google Cloud Storage.
+        '''Uploads the given bytes to GCS.
 
         Args:
             bytes_str: the bytes string to upload
-            cloud_path: the path to the Google Cloud object to create
+            cloud_path: the path to the GCS object to create
             content_type: the optional type of the content being uploaded. If
                 no value is provided but the object already exists in GCS, then
                 the same value is used. Otherwise, the default value
@@ -1208,13 +1208,12 @@ class GoogleCloudStorageClient(
 
     @google_cloud_api_retry
     def upload_stream(self, file_obj, cloud_path, content_type=None):
-        '''Uploads the contents of the given file-like object to Google Cloud
-        Storage.
+        '''Uploads the contents of the given file-like object to GCS.
 
         Args:
             file_obj: the file-like object to upload, which must be open for
                 reading
-            cloud_path: the path to the Google Cloud object to create
+            cloud_path: the path to the GCS object to create
             content_type: the optional type of the content being uploaded. If
                 no value is provided but the object already exists in GCS, then
                 the same value is used. Otherwise, the default value
@@ -1225,10 +1224,10 @@ class GoogleCloudStorageClient(
 
     @google_cloud_api_retry
     def download(self, cloud_path, local_path):
-        '''Downloads the file from Google Cloud Storage to the given location.
+        '''Downloads the file from GCS to the given location.
 
         Args:
-            cloud_path: the path to the Google Cloud object to download
+            cloud_path: the path to the GCS object to download
             local_path: the local disk path to store the downloaded file
         '''
         blob = self._get_blob(cloud_path)
@@ -1237,11 +1236,10 @@ class GoogleCloudStorageClient(
 
     @google_cloud_api_retry
     def download_bytes(self, cloud_path):
-        '''Downloads the file from Google Cloud Storage and returns the bytes
-        string.
+        '''Downloads the file from GCS and returns the bytes string.
 
         Args:
-            cloud_path: the path to the Google Cloud object to download
+            cloud_path: the path to the GCS object to download
 
         Returns:
             the downloaded bytes string
@@ -1251,11 +1249,10 @@ class GoogleCloudStorageClient(
 
     @google_cloud_api_retry
     def download_stream(self, cloud_path, file_obj):
-        '''Downloads the file from Google Cloud Storage to the given file-like
-        object.
+        '''Downloads the file from GCS to the given file-like object.
 
         Args:
-            cloud_path: the path to the Google Cloud object to download
+            cloud_path: the path to the GCS object to download
             file_obj: the file-like object to which to write the download,
                 which must be open for writing
         '''
@@ -1264,20 +1261,20 @@ class GoogleCloudStorageClient(
 
     @google_cloud_api_retry
     def delete(self, cloud_path):
-        '''Deletes the given file from Google Cloud Storage.
+        '''Deletes the given file from GCS.
 
         Args:
-            cloud_path: the path to the Google Cloud object to delete
+            cloud_path: the path to the GCS object to delete
         '''
         blob = self._get_blob(cloud_path)
         blob.delete()
 
     @google_cloud_api_retry
     def get_file_metadata(self, cloud_path):
-        '''Returns metadata about the given file in Google Cloud Storage.
+        '''Returns metadata about the given file in GCS.
 
         Args:
-            cloud_path: the path to the Google Cloud object
+            cloud_path: the path to the GCS object
 
         Returns:
             a dictionary containing metadata about the file, including its
@@ -1291,8 +1288,7 @@ class GoogleCloudStorageClient(
     @google_cloud_api_retry
     def list_files_in_folder(
             self, cloud_folder, recursive=True, return_metadata=False):
-        '''Returns a list of the files in the given "folder" in Google Cloud
-        Storage.
+        '''Returns a list of the files in the given "folder" in GCS.
 
         Args:
             cloud_folder: a string like `gs://<bucket-name>/<folder-path>`
@@ -1337,7 +1333,7 @@ class GoogleCloudStorageClient(
     @google_cloud_api_retry
     def generate_signed_url(
             self, cloud_path, method="GET", hours=24, content_type=None):
-        '''Generates a signed URL for accessing the given storage object.
+        '''Generates a signed URL for accessing the given GCS object.
 
         Anyone with the URL can access the object with the permission until it
         expires.
@@ -1345,7 +1341,7 @@ class GoogleCloudStorageClient(
         Note that you should use `PUT`, not `POST`, to upload objects!
 
         Args:
-            cloud_path: the path to the Google Cloud object
+            cloud_path: the path to the GCS object
             method: the HTTP verb (GET, PUT, DELETE) to authorize
             hours: the number of hours that the URL is valid
             content_type: (PUT actions only) the optional type of the content
@@ -1364,7 +1360,8 @@ class GoogleCloudStorageClient(
         bucket = self._client.get_bucket(bucket_name)
         return bucket.blob(object_name, chunk_size=self.chunk_size)
 
-    def _get_file_metadata(self, blob):
+    @staticmethod
+    def _get_file_metadata(blob):
         return {
             "bucket": blob.bucket.name,
             "object_name": blob.name,
@@ -1376,18 +1373,6 @@ class GoogleCloudStorageClient(
 
     @staticmethod
     def _parse_gcs_path(cloud_path):
-        '''Parses a Google Cloud Storage path.
-
-        Args:
-            cloud_path: a string of form "gs://<bucket_name>/<object_name>"
-
-        Returns:
-            bucket_name: the name of the Google Cloud Storage bucket
-            object_name: the name of the object
-
-        Raises:
-            GoogleCloudStorageClientError: if the cloud path string was invalid
-        '''
         if not cloud_path.startswith("gs://"):
             raise GoogleCloudStorageClientError(
                 "Cloud storage path '%s' must start with gs://" % cloud_path)
@@ -1567,7 +1552,7 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
                     folder_id, t.elapsed_time_str)
 
     def get_file_metadata(self, file_id, all_fields=False):
-        '''Gets metadata about the file with the given ID.
+        '''Gets metadata about the file (or folder) with the given ID.
 
         Args:
             file_id: the ID of a file (or folder)
@@ -1577,31 +1562,12 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
         Returns:
             a dictionary containing the available metadata about the file,
                 including (at least) its `id`, `name`, `size`, `mime_type`, and
-                `last_modified`
+                `last_modified`. For folders, `size == -1`
         '''
         fields = ["id", "name", "size", "mimeType", "modifiedTime"]
         metadata = self._get_file_metadata(
             file_id, fields=fields, all_fields=all_fields)
         return self._parse_file_metadata(metadata)
-
-    def _get_file_metadata(self, file_id, fields=None, all_fields=False):
-        if all_fields:
-            fields = "*"
-        else:
-            fields = ",".join(fields)
-
-        return self._service.files().get(
-            fileId=file_id, fields=fields, supportsTeamDrives=True).execute()
-
-    @staticmethod
-    def _parse_file_metadata(metadata):
-        return {
-            "id": metadata["id"],
-            "name": metadata["name"],
-            "size": int(metadata.get("size", -1)),
-            "mime_type": metadata["mimeType"],
-            "last_modified": dateutil.parser.parse(metadata["modifiedTime"]),
-        }
 
     def get_team_drive_id(self, name):
         '''Get the ID of the Team Drive with the given name.
@@ -2064,6 +2030,33 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
                 break
 
         return files, folders
+
+    def _get_file_metadata(self, file_id, fields=None, all_fields=False):
+        if all_fields:
+            fields = "*"
+        else:
+            fields = ",".join(fields)
+
+        return self._service.files().get(
+            fileId=file_id, fields=fields, supportsTeamDrives=True).execute()
+
+    @staticmethod
+    def _parse_file_metadata(metadata):
+        return {
+            "id": metadata["id"],
+            "name": metadata["name"],
+            "size": int(metadata.get("size", -1)),
+            "mime_type": metadata["mimeType"],
+            "last_modified": dateutil.parser.parse(metadata["modifiedTime"]),
+        }
+
+    @staticmethod
+    def _parse_folder_metadata(metadata):
+        return {
+            "id": metadata["id"],
+            "name": metadata["name"],
+            "last_modified": dateutil.parser.parse(metadata["modifiedTime"]),
+        }
 
 
 class GoogleDriveStorageClientError(Exception):

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -30,7 +30,6 @@ import eta
 import eta.core.features as etaf
 import eta.core.image as etai
 import eta.core.learning as etal
-import eta.core.tfutils as etat
 import eta.core.utils as etau
 import eta.core.video as etav
 
@@ -1427,6 +1426,8 @@ class TFRecord(File, ConcreteData):
 
     @staticmethod
     def is_valid_path(path):
+        # Do this locally to avoid importing TF unless absolutely necessary
+        import eta.core.tfutils as etat
         return File.is_valid_path(path) and etat.is_valid_tf_record_path(path)
 
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -258,10 +258,9 @@ def query_yes_no(question, default=None):
         choice = six.moves.input().lower()
         if default and not choice:
             return valid[default]
-        elif choice in valid:
+        if choice in valid:
             return valid[choice]
-        else:
-            print("Please respond with 'y[es]' or 'n[o]'")
+        print("Please respond with 'y[es]' or 'n[o]'")
 
 
 def call(args):

--- a/eta/core/web.py
+++ b/eta/core/web.py
@@ -121,13 +121,13 @@ class WebSession(object):
         etau.ensure_basedir(path)
 
         num_bytes = 0
-        start_time = time.time()
+        start_time = time()
         with open(path, "wb") as f:
             for chunk in r.iter_content(chunk_size=self.chunk_size):
                 num_bytes += len(chunk)
                 f.write(chunk)
 
-        time_elapsed = time.time() - start_time
+        time_elapsed = time() - start_time
         _log_download_stats(num_bytes, time_elapsed)
 
     def _get_streaming_response(self, url, params=None):
@@ -172,6 +172,6 @@ class GoogleDriveSession(WebSession):
 
 def _log_download_stats(num_bytes, time_elapsed):
     bytes_str = etau.to_human_bytes_str(num_bytes)
+    time_str = etau.to_human_time_str(time_elapsed)
     avg_speed = etau.to_human_bits_str(8 * num_bytes / time_elapsed) + "/s"
-    logger.info(
-        "%s downloaded in %.1fs (%s)" % (bytes_str, time_elapsed, avg_speed))
+    logger.info("%s downloaded in %s (%s)", bytes_str, time_str, avg_speed)

--- a/eta/core/web.py
+++ b/eta/core/web.py
@@ -1,7 +1,7 @@
 '''
-Core tools for accessing files on the web.
+Core tools for downloading files from the web.
 
-Copyright 2017-2018, Voxel51, Inc.
+Copyright 2017-2019, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
@@ -21,7 +21,7 @@ from future.utils import iteritems
 
 import logging
 import requests
-import time
+from time import time
 
 import eta.constants as etac
 import eta.core.utils as etau

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pylint==1.9.4;python_version<"3"
 pylint==2.3.1;python_version>="3"
 pysftp==0.2.9
 pytz==2019.3
-python-dateutil==2.6.1
+python-dateutil==2.7.0
 requests==2.21.0
 requests-toolbelt==0.8.0
 retrying==1.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ simplejson==3.8.1
 six==1.11.0
 Sphinx==1.7.5
 sphinxcontrib-napoleon==0.6.1
+tabulate==0.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pycodestyle==2.3.1
 pylint==1.9.4;python_version<"3"
 pylint==2.3.1;python_version>="3"
 pysftp==0.2.9
+pytz==2019.3
 python-dateutil==2.6.1
 requests==2.21.0
 requests-toolbelt==0.8.0
@@ -30,3 +31,4 @@ six==1.11.0
 Sphinx==1.7.5
 sphinxcontrib-napoleon==0.6.1
 tabulate==0.8.5
+tzlocal==2.0.0


### PR DESCRIPTION
This PR adds full support for interacting with remote storage via the `eta` command-line tool.

A key additional feature to support this is the notion of "active" credentials. For example, for `GoogleCloudStorageClient`, the "active" credentials are located using the following strategy (taken from `eta.core.storage.NeedsGoogleCredentials`):

```
    Storage clients that derive from this class should allow users to provide
    credentials in the following ways (in order of precedence):

        (1) manually constructing an instance of the class via the
            `cls.from_json()` method by providing a path to a valid service
            account JSON file

        (2) setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable
            to point to a service account JSON file

        (3) loading credentials from `~/.eta/google-credentials.json` that have
            been activated via `cls.activate_credentials()`
```

Point number (3) above is new --- the ability to permanently activate credentials by installing them in a `~/.eta` folder. This is analogous to how tokens can be permanently activated in https://github.com/voxel51/api-py.

Permanent credential activation has been supported for AWS, Google, and SSH credentials via the associated `activate_credentials()` methods. Activation and deactivation of credentials is also supported via the `eta auth activate` and `eta auth deactivate` CLI tools.

Example of activated credentials for various storage clients:
```
$ eta auth show
Google credentials
--------------------  ------------------------------------------------------------------
project id            <project-id>
client email          <account-name>@<project-id>.iam.gserviceaccount.com
private key id        <private-key>
path                  /path/to/google-credentials.json

AWS credentials
---------------------  ----------------------------------------
aws access key id      <access-key>
aws secret access key  <secret-key>
region                 <region-name>
path                   /path/to/aws-credentials.ini

SSH credentials
-----------------  ------------------------
path               /path/to/id_rsa
```

Overview of S3-related methods that were added:
```
$ eta s3 --help
usage: eta s3 [-h] {info,list,upload,upload-dir,download,download-dir,delete,delete-dir} ...

Tools for working with S3.

optional arguments:
  -h, --help            show this help message and exit

available commands:
  {info,list,upload,upload-dir,download,download-dir,delete,delete-dir}
    info                Get information about files/folders in S3.
    list                List contents of an S3 folder.
    upload              Upload file to S3.
    upload-dir          Upload directory to S3.
    download            Download file from S3.
    download-dir        Download directory from S3.
    delete              Delete file from S3.
    delete-dir          Delete directory from S3.
```

Overview of GCS-related methods that were added:
```
$ eta gcs --help
usage: eta gcs [-h] {info,list,upload,upload-dir,download,download-dir,delete,delete-dir} ...

Tools for working with Google Cloud Storage.

optional arguments:
  -h, --help            show this help message and exit

available commands:
  {info,list,upload,upload-dir,download,download-dir,delete,delete-dir}
    info                Get information about files/folders in GCS.
    list                List contents of a GCS folder.
    upload              Upload file to GCS.
    upload-dir          Upload directory to GCS.
    download            Download file from GCS.
    download-dir        Download directory from GCS.
    delete              Delete file from GCS.
    delete-dir          Delete directory from GCS.
```

Overview of Google Drive-related methods that were added:
```
$ eta gdrive --help
usage: eta gdrive [-h] {info,list,upload,upload-dir,download,download-dir,delete,delete-dir} ...

Tools for working with Google Drive.

optional arguments:
  -h, --help            show this help message and exit

available commands:
  {info,list,upload,upload-dir,download,download-dir,delete,delete-dir}
    info                Get information about files/folders in Google Drive.
    list                List contents of a Google Drive folder.
    upload              Upload file to Google Drive.
    upload-dir          Upload directory to Google Drive.
    download            Download file from Google Drive.
    download-dir        Download directory from Google Drive.
    delete              Delete file from Google Drive.
    delete-dir          Delete directory from Google Drive.
```

Overview of HTTP-related methods that were added:
```
$ eta http --help
usage: eta http [-h] {upload,download,delete} ...

Tools for working with HTTP storage.

optional arguments:
  -h, --help            show this help message and exit

available commands:
  {upload,download,delete}
    upload              Upload file via HTTP.
    download            Download file via HTTP.
    delete              Delete file via HTTP.
```

Overview of SFTP-related methods that were added:
```
$ eta sftp --help
usage: eta sftp [-h] {upload,upload-dir,download,download-dir,delete,delete-dir} ...

Tools for working with SFTP storage.

optional arguments:
  -h, --help            show this help message and exit

available commands:
  {upload,upload-dir,download,download-dir,delete,delete-dir}
    upload              Upload file via SFTP.
    upload-dir          Upload directory via SFTP.
    download            Download file via SFTP.
    download-dir        Download directory via SFTP.
    delete              Delete file via SFTP.
    delete-dir          Delete directory via SFTP.
```