### PR TITLE
Adding support for searching/getting info for models/modules/pipelines via the ETA CLI

### DIFF
--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -411,8 +411,17 @@ class ModulesCommand(Command):
         # List all available modules
         eta modules --list
 
+        # Search for modules whose names contain the given string
+        eta modules --search <search-str>
+
         # Find metadata file for module
         eta modules --find <module-name>
+
+        # Find executable file for module
+        eta modules --find-exe <module-name>
+
+        # Show metadata for module
+        eta modules --info <module-name>
 
         # Generate block diagram for module
         eta modules --diagram <module-name>
@@ -430,8 +439,17 @@ class ModulesCommand(Command):
             "-l", "--list", action="store_true",
             help="list all modules on search path")
         parser.add_argument(
+            "-s", "--search", metavar="SEARCH",
+            help="search for modules whose names contain the given string")
+        parser.add_argument(
             "-f", "--find", metavar="NAME",
             help="find metadata file for module with the given name")
+        parser.add_argument(
+            "-e", "--find-exe", metavar="NAME",
+            help="find the module executable for module with the given name")
+        parser.add_argument(
+            "-i", "--info", metavar="NAME",
+            help="show metadata for module with the given name")
         parser.add_argument(
             "-d", "--diagram", metavar="NAME",
             help="generate block diagram for module with the given name")
@@ -448,9 +466,22 @@ class ModulesCommand(Command):
             modules = etamodu.find_all_metadata()
             logger.info(_render_names_in_dirs_str(modules))
 
+        if args.search:
+            modules = etamodu.find_all_metadata()
+            modules = {k: v for k, v in iteritems(modules) if args.search in k}
+            logger.info(_render_names_in_dirs_str(modules))
+
         if args.find:
             metadata_path = etamodu.find_metadata(args.find)
             logger.info(metadata_path)
+
+        if args.find_exe:
+            exe_path = etamodu.find_exe(args.find_exe)
+            logger.info(exe_path)
+
+        if args.info:
+            metadata = etamodu.load_metadata(args.info)
+            logger.info(metadata.config)
 
         if args.diagram:
             metadata = etamodu.load_metadata(args.diagram)

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -506,8 +506,14 @@ class PipelinesCommand(Command):
         # List all available pipelines
         eta pipelines --list
 
+        # Search for pipelines whose names contain the given string
+        eta pipelines --search <search-str>
+
         # Find metadata file for pipeline
         eta pipelines --find <pipeline-name>
+
+        # Show metadata for pipeline
+        eta pipelines --info <pipeline-name>
 
         # Generate block diagram for pipeline
         eta pipelines --diagram <pipeline-name>
@@ -519,8 +525,14 @@ class PipelinesCommand(Command):
             "-l", "--list", action="store_true",
             help="list all ETA pipelines on the current search path")
         parser.add_argument(
+            "-s", "--search", metavar="NAME",
+            help="search for pipelines whose names contain the given string")
+        parser.add_argument(
             "-f", "--find", metavar="NAME",
             help="find metadata file for pipeline with the given name")
+        parser.add_argument(
+            "-i", "--info", metavar="NAME",
+            help="show metadata for pipeline with the given name")
         parser.add_argument(
             "-d", "--diagram", metavar="NAME",
             help="generate block diagram for pipeline with the given name")
@@ -531,9 +543,19 @@ class PipelinesCommand(Command):
             pipelines = etap.find_all_metadata()
             logger.info(_render_names_in_dirs_str(pipelines))
 
+        if args.search:
+            pipelines = etap.find_all_metadata()
+            pipelines = {
+                k: v for k, v in iteritems(pipelines) if args.search in k}
+            logger.info(_render_names_in_dirs_str(pipelines))
+
         if args.find:
             metadata_path = etap.find_metadata(args.find)
             logger.info(metadata_path)
+
+        if args.info:
+            metadata = etap.load_metadata(args.info)
+            logger.info(metadata.config)
 
         if args.diagram:
             metadata = etap.load_metadata(args.diagram)

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -316,8 +316,14 @@ class ModelsCommand(Command):
         # List all available models
         eta models --list
 
+        # Search for models whose names contains the given string
+        eta models --search <search-str>
+
         # Find model
         eta models --find <model-name>
+
+        # Print info about model
+        eta models --info <model-name>
 
         # Download model
         eta models --download <model-name>
@@ -341,13 +347,19 @@ class ModelsCommand(Command):
             "-l", "--list", action="store_true",
             help="list all published models on the current search path")
         parser.add_argument(
+            "-s", "--search", metavar="SEARCH",
+            help="search for models whose names contain the given string")
+        parser.add_argument(
             "-f", "--find", metavar="NAME",
             help="find the model with the given name")
+        parser.add_argument(
+            "-i", "--info", metavar="NAME",
+            help="get info about the model with the given name")
         parser.add_argument(
             "-d", "--download", metavar="NAME",
             help="download the model with the given name")
         parser.add_argument(
-            "-i", "--init", metavar="DIR",
+            "--init", metavar="DIR",
             help="initialize the given models directory")
         parser.add_argument(
             "--flush", metavar="NAME",
@@ -363,9 +375,18 @@ class ModelsCommand(Command):
             models = etamode.find_all_models()
             logger.info(_render_names_in_dirs_str(models))
 
+        if args.search:
+            models = etamode.find_all_models()
+            models = {k: v for k, v in iteritems(models) if args.search in k}
+            logger.info(_render_names_in_dirs_str(models))
+
         if args.find:
             model_path = etamode.find_model(args.find)
             logger.info(model_path)
+
+        if args.info:
+            model = etamode.get_model(args.info)
+            logger.info(model)
 
         if args.download:
             etamode.download_model(args.download)

--- a/eta/core/module.py
+++ b/eta/core/module.py
@@ -566,6 +566,7 @@ class ModuleMetadata(Configurable, HasBlockDiagram):
             ModuleMetadataError: if the module definition was invalid
         '''
         self.validate(config)
+        self.config = config
 
         self.info = None
         self.inputs = OrderedDict()

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -676,6 +676,7 @@ class PipelineMetadata(Configurable, HasBlockDiagram):
             PipelineMetadataError: if the pipeline definition was invalid
         '''
         self.validate(config)
+        self.config = config
 
         self.info = None
         self.inputs = {}


### PR DESCRIPTION
Examples of things you can do now:

Modules:

```
$ eta modules --search detect
[ /Users/Brian/dev/theta/eta/eta/modules ]
  apply_object_detector
```

```
$ eta modules --find-exe apply_object_detector
/Users/Brian/dev/theta/eta/eta/modules/apply_object_detector.py
```

Pipelines:

```
$ eta pipelines --search object_detector
[ /Users/Brian/dev/theta/eta/eta/pipelines ]
  object_detector
```

Models:

```
$ eta models --search faster-rcnn
[ /Users/Brian/dev/theta/eta/eta/models ]
  faster-rcnn-inception-resnet-atrous-v2-coco
  faster-rcnn-inception-v2-coco
  faster-rcnn-resnet101-coco
  faster-rcnn-resnet50-coco
  faster-rcnn-resnet50-lowproposals-coco
```

```
$ eta models --info faster-rcnn-inception-resnet-atrous-v2-coco
{
    "base_name": "faster-rcnn-inception-resnet-atrous-v2-coco",
    "base_filename": "faster-rcnn-inception-resnet-atrous-v2-coco.pb",
    "version": null,
    "description": "A Faster-RCNN Atrous Inception ResNet object detector trained on COCO",
    "manager": {
        "type": "eta.core.models.ETAModelManager",
        "config": {
            "google_drive_id": "1tbDgXKYWBKazY6U6whRHhR4OsxZS9LOP"
        }
    },
    "default_deployment_config_dict": {
        "type": "eta.detectors.TFModelsDetector",
        "config": {
            "model_name": "faster-rcnn-inception-resnet-atrous-v2-coco",
            "labels_path": "{{eta}}/tensorflow/models/research/object_detection/data/mscoco_label_map.pbtxt"
        }
    },
    "date_created": "2018-12-23 14:37:38"
}
```