### PR TITLE
Optionally include filepath when getting metadata about Google Drive files

### DIFF
--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -2590,10 +2590,10 @@ def _print_gcs_folder_info_table(metadata):
 
 def _print_google_drive_file_info_table(metadata):
     records = [(
-            m["drive_name"], m["path"], _render_bytes(m["size"]),
-            _parse_google_drive_mime_type(m["mime_type"]),
-            _render_datetime(m["last_modified"]))
-        for m in metadata]
+        m["drive_name"], m["path"], _render_bytes(m["size"]),
+        _parse_google_drive_mime_type(m["mime_type"]),
+        _render_datetime(m["last_modified"])
+    ) for m in metadata]
 
     table_str = tabulate(
         records,

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1890,6 +1890,7 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
         '''
         # List folder contents
         files, folders = self._list_folder_contents(folder_id)
+        files = [self._parse_file_metadata(f) for f in files]
 
         if recursive:
             # Recursively traverse subfolders
@@ -1901,7 +1902,7 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
                     f["name"] = os.path.join(folder["name"], f["name"])
                     files.append(f)
 
-        return [self._parse_file_metadata(f) for f in files]
+        return files
 
     def upload_files_in_folder(
             self, local_dir, folder_id, skip_failures=False,


### PR DESCRIPTION
Have you ever thought to yourself: "where in the world is this file whose ID I see in my code located in the Google Drive ether???"

The ETA CLI now comes to your rescue!

Example:

```
$ eta gdrive info 14ZclqNXJXSct6O0sqcUoxFpzt_CnZuGP
drive name    path                               size    type       last modified
------------  ---------------------------------  ------  ---------  -----------------------
public        eta/README/eta-infrastructure.png  142KB   image/png  2018-09-07 14:00:00 EDT
```
