### PR TITLE
Classifier bugfix

### DIFF
--- a/eta/classifiers/tfslim_classifiers.py
+++ b/eta/classifiers/tfslim_classifiers.py
@@ -287,7 +287,7 @@ class TFSlimClassifier(
         in_tensor = self._input_op.outputs[0]
         out_tensors = [op.outputs[0] for op in ops]
         results = self._sess.run(out_tensors, feed_dict={in_tensor: imgs})
-        return map(np.squeeze, results)
+        return list(map(np.squeeze, results))
 
     def _parse_prediction(self, probs):
         idx = np.argmax(probs)


### PR DESCRIPTION
Bugfix. A map(fcn, iter) returns a map object. Needed to be converted back into a list.