### PR TITLE
Omitting GPU options from ETA config when GPU is not available on mac…

### DIFF
--- a/eta/core/tfutils.py
+++ b/eta/core/tfutils.py
@@ -207,7 +207,7 @@ def make_tf_config(config_proto=None):
     config = copy(config_proto) if config_proto else tf.ConfigProto()
 
     if eta.config.tf_config:
-        tf_config = copy(eta.config.tf_config)
+        tf_config = eta.config.tf_config
         if not is_gpu_available():
             # Remove GPU options, just for clarity
             tf_config = {

--- a/eta/core/tfutils.py
+++ b/eta/core/tfutils.py
@@ -20,7 +20,7 @@ from future.utils import iteritems
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
-import copy
+from copy import copy
 import logging
 import os
 import re
@@ -204,10 +204,10 @@ def make_tf_config(config_proto=None):
     Returns:
         a tf.ConfigProto
     '''
-    config = copy.copy(config_proto) if config_proto else tf.ConfigProto()
+    config = copy(config_proto) if config_proto else tf.ConfigProto()
 
     if eta.config.tf_config:
-        tf_config = copy.copy(eta.config.tf_config)
+        tf_config = copy(eta.config.tf_config)
         if not is_gpu_available():
             # Remove GPU options, just for clarity
             tf_config = {


### PR DESCRIPTION
Previously, if one's ETA config included something like this:

```
    "tf_config": {
        "gpu_options.per_process_gpu_memory_fraction": 0.95
    },
```

then one would get logging messages like the following when creating a TF session, even when using a machine with no GPU:

```
Applying `tf_config` settings from ETA config: {"gpu_options.per_process_gpu_memory_fraction": 0.95}
```

I find this misleading/confusing. So, now `eta.core.tfutils.make_tf_config()` will ignore `tf.Config.GPUOptions` settings when no GPU is available.
