### PR TITLE
Adding CLI command for printing your ETA config

### DIFF
--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -94,6 +94,7 @@ class ETACommand(Command):
         _register_command(subparsers, "modules", ModulesCommand)
         _register_command(subparsers, "pipelines", PipelinesCommand)
         _register_command(subparsers, "constants", ConstantsCommand)
+        _register_command(subparsers, "config", ConfigCommand)
         _register_command(subparsers, "auth", AuthCommand)
         _register_command(subparsers, "s3", S3Command)
         _register_command(subparsers, "gcs", GCSCommand)
@@ -600,6 +601,34 @@ def _print_constants_table(d):
     table_str = tabulate(
         contents, headers=["constant", "value"], tablefmt=TABLE_FORMAT)
     logger.info(table_str)
+
+
+class ConfigCommand(Command):
+    '''Tools for working with your ETA config.
+
+    Examples:
+        # Print your entire ETA config
+        eta config --print
+
+        # Print a specific config field
+        eta config --print <field>
+    '''
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument(
+            "field", nargs="?", metavar="FIELD", help="a config field")
+        parser.add_argument(
+            "-p", "--print", action="store_true", help="print your ETA config")
+
+    @staticmethod
+    def run(args):
+        if args.print:
+            if args.field:
+                field = getattr(eta.config, args.field)
+                logger.info(json_to_str(field))
+            else:
+                logger.info(eta.config)
 
 
 class AuthCommand(Command):


### PR DESCRIPTION
Now the `eta` CLI can print your ETA config:

```
$ eta config --help
usage: eta config [-h] [-p] [FIELD]

Tools for working with your ETA config.

    Examples:
        # Print your entire ETA config
        eta config --print

        # Print a specific config field
        eta config --print <field>

positional arguments:
  FIELD        a config field

optional arguments:
  -h, --help   show this help message and exit
  -p, --print  print your ETA config
```

This is useful because, for example, it will render any patterns so you can see exactly what values of various fields your code will be using.

Example: actual `pythonpath_dirs` from ETA config:

```
    "pythonpath_dirs": [
        "{{eta}}/tensorflow/models/research",
        "{{eta}}/tensorflow/models/research/slim"
    ],
```

Output from `eta config --print pythonpath_dirs`:

```
$ eta config --print pythonpath_dirs
[
    "/path/to/eta/tensorflow/models/research",
    "/path/to/eta/tensorflow/models/research/slim"
]
```