### PR TITLE
Google drive download bug

### DIFF
--- a/eta/core/web.py
+++ b/eta/core/web.py
@@ -146,7 +146,7 @@ class WebSessionError(Exception):
 class GoogleDriveSession(WebSession):
     '''Class for downloading Google Drive files.'''
 
-    BASE_URL = "https://drive.google.com/uc?export=download"
+    BASE_URL = "https://drive.google.com/open?export=download"
 
     def get(self, fid):
         return WebSession.get(self, self.BASE_URL, params={"id": fid})


### PR DESCRIPTION
Getting the following error when deploying a new sense version:
```
Downloading model from Google Drive ID '1pC9WX7Ol2cy4ERAcLQ-a2Dd04d91vJxj' to '/Users/tylerganter/source/theta/eta/eta/models/ssd-resnet50-fpn-coco.pb'                                                                                                                         
print(os.path.exists(model_path))                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                
Uncaught exception                                                                                                                                                                                                                                                              
Traceback (most recent call last):                                                                                                                                                                                                                                              
  File "<stdin>", line 1, in <module>                                                                                                                                                                                                                                           
  File "/Users/tylerganter/source/theta/eta/eta/core/models.py", line 180, in download_model                                                                                                                                                                                    
    model.manager.download_model(model_path, force=force)                                                                                                                                                                                                                       
  File "/Users/tylerganter/source/theta/eta/eta/core/models.py", line 1018, in download_model                                                                                                                                                                                   
    self._download_model(model_path)                                                                                                                                                                                                                                            
  File "/Users/tylerganter/source/theta/eta/eta/core/models.py", line 1074, in _download_model                                                                                                                                                                                  
    etaw.download_google_drive_file(gid, path=model_path)                                                                                                                                                                                                                       
  File "/Users/tylerganter/source/theta/eta/eta/core/web.py", line 69, in download_google_drive_file                                                                                                                                                                            
    return sess.write(path, fid) if path else sess.get(fid)                                                                                                                                                                                                                     
  File "/Users/tylerganter/source/theta/eta/eta/core/web.py", line 155, in write                                                                                                                                                                                                
    return WebSession.write(self, path, self.BASE_URL, params={"id": fid})                                                                                                                                                                                                      
  File "/Users/tylerganter/source/theta/eta/eta/core/web.py", line 120, in write                                                                                                                                                                                                
    r = self._get_streaming_response(url, params=params)                                                                                                                                                                                                                        
  File "/Users/tylerganter/source/theta/eta/eta/core/web.py", line 158, in _get_streaming_response                                                                                                                                                                              
    r = WebSession._get_streaming_response(self, url, params=params)                                                                                                                                                                                                            
  File "/Users/tylerganter/source/theta/eta/eta/core/web.py", line 136, in _get_streaming_response                                                                                                                                                                              
    raise WebSessionError("Unable to get '%s'" % url)                                                                                                                                                                                                                           
eta.core.web.WebSessionError: Unable to get 'https://drive.google.com/uc?export=download'    
```

You can replicate the bug with the following:
```
import eta.core.web as etaw

gid = "1pC9WX7Ol2cy4ERAcLQ-a2Dd04d91vJxj"
model_path = "/Users/tylerganter/source/theta/eta/eta/models/ssd-resnet50-fpn-coco.pb"

print(os.path.exists(model_path))
etaw.download_google_drive_file(gid, path=model_path)
print(os.path.exists(model_path))
```

Note that this is only happening for certain models.

It seems to be an issue with too many requests to download the file? I found this article here:
https://www.ghacks.net/2017/04/14/fix-google-drive-sorry-you-cant-view-or-download-this-file-error/
and a few others with similar suggestion to replace
```
https://drive.google.com/uc
```
with
```
https://drive.google.com/open
```

This change fixed my problem, the catch is...is this just a different route? and if it gets too much traffic the same issue will occur here? Not too sure on this...