### PR TITLE
Adding two useful help-related features to the CLI

### DIFF
--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -68,14 +68,15 @@ class Command(object):
         raise NotImplementedError("subclass must implement setup()")
 
     @staticmethod
-    def run(args):
-        '''Execute the command on the given args.
+    def run(parser, args):
+        '''Executes the command on the given args.
 
         args:
+            parser: the `argparse.ArgumentParser` instance for the command
             args: an `argparse.Namespace` instance containing the arguments
                 for the command
         '''
-        pass
+        raise NotImplementedError("subclass must implement run()")
 
 
 class ETACommand(Command):
@@ -98,6 +99,10 @@ class ETACommand(Command):
         _register_command(subparsers, "gdrive", GoogleDriveStorageCommand)
         _register_command(subparsers, "http", HTTPStorageCommand)
         _register_command(subparsers, "sftp", SFTPStorageCommand)
+
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
 
 
 class BuildCommand(Command):
@@ -156,7 +161,7 @@ class BuildCommand(Command):
             help="set pipeline logging level to DEBUG")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         # Load pipeline request
         d = args.request or {
             "inputs": {},
@@ -240,7 +245,7 @@ class RunCommand(Command):
             help="run last built pipeline")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         if args.module:
             print("Running module '%s'" % args.module)
             etamodu.run(args.module, args.config)
@@ -291,7 +296,7 @@ class CleanCommand(Command):
             help="cleanup all built pipelines")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         if args.config:
             etab.cleanup_pipeline(args.config)
 
@@ -373,7 +378,7 @@ class ModelsCommand(Command):
             "--flush-all", action="store_true", help="flush all models")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         if args.list:
             models = etamode.find_all_models()
             print(_render_names_in_dirs_str(models))
@@ -470,7 +475,7 @@ class ModulesCommand(Command):
             help="refresh all module metadata files")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         if args.list:
             modules = etamodu.find_all_metadata()
             print(_render_names_in_dirs_str(modules))
@@ -546,7 +551,7 @@ class PipelinesCommand(Command):
             help="generate block diagram for pipeline with the given name")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         if args.list:
             pipelines = etap.find_all_metadata()
             print(_render_names_in_dirs_str(pipelines))
@@ -591,7 +596,7 @@ class ConstantsCommand(Command):
             help="print all available constants")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         if args.all:
             d = {
                 k: v for k, v in iteritems(vars(etac))
@@ -629,7 +634,7 @@ class ConfigCommand(Command):
             "-p", "--print", action="store_true", help="print your ETA config")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         if args.print:
             if args.field:
                 field = getattr(eta.config, args.field)
@@ -647,6 +652,10 @@ class AuthCommand(Command):
         _register_command(subparsers, "show", ShowAuthCommand)
         _register_command(subparsers, "activate", ActivateAuthCommand)
         _register_command(subparsers, "deactivate", DeactivateAuthCommand)
+
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
 
 
 class ShowAuthCommand(Command):
@@ -679,7 +688,7 @@ class ShowAuthCommand(Command):
             help="show info about SSH credentials")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         if args.google:
             _print_google_credentials_info()
 
@@ -770,7 +779,7 @@ class ActivateAuthCommand(Command):
             "--ssh", metavar="PATH", help="path to SSH private key")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         if args.google:
             etas.NeedsGoogleCredentials.activate_credentials(args.google)
 
@@ -813,7 +822,7 @@ class DeactivateAuthCommand(Command):
             "--all", action="store_true", help="delete all active credentials")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         if args.google or args.all:
             etas.NeedsGoogleCredentials.deactivate_credentials()
 
@@ -840,6 +849,10 @@ class S3Command(Command):
         _register_command(subparsers, "delete", S3DeleteCommand)
         _register_command(subparsers, "delete-dir", S3DeleteDirCommand)
 
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
+
 
 class S3InfoCommand(Command):
     '''Get information about files/folders in S3.
@@ -862,7 +875,7 @@ class S3InfoCommand(Command):
             "paths are folders, not files")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.S3StorageClient()
 
         if args.folder:
@@ -997,7 +1010,7 @@ class S3ListCommand(Command):
             help="whether to show the number of files in the list")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.S3StorageClient()
 
         metadata = client.list_files_in_folder(
@@ -1032,7 +1045,7 @@ class S3UploadCommand(Command):
             "filename")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.S3StorageClient()
 
         print("Uploading '%s' to '%s'" % (args.local_path, args.cloud_path))
@@ -1070,7 +1083,7 @@ class S3UploadDirectoryCommand(Command):
             "recursively upload the contents of subdirecotires")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.S3StorageClient()
 
         if args.sync:
@@ -1107,7 +1120,7 @@ class S3DownloadCommand(Command):
             "download to stdout. If true, a file is NOT written to disk")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.S3StorageClient()
 
         if args.print:
@@ -1151,7 +1164,7 @@ class S3DownloadDirectoryCommand(Command):
             "recursively download the contents of subdirecotires")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.S3StorageClient()
 
         if args.sync:
@@ -1177,7 +1190,7 @@ class S3DeleteCommand(Command):
             "cloud_path", metavar="CLOUD_PATH", help="the S3 file to delete")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.S3StorageClient()
 
         print("Deleting '%s'" % args.cloud_path)
@@ -1198,7 +1211,7 @@ class S3DeleteDirCommand(Command):
             "cloud_dir", metavar="CLOUD_DIR", help="the S3 folder to delete")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.S3StorageClient()
 
         print("Deleting '%s'" % args.cloud_dir)
@@ -1220,6 +1233,10 @@ class GCSCommand(Command):
             subparsers, "download-dir", GCSDownloadDirectoryCommand)
         _register_command(subparsers, "delete", GCSDeleteCommand)
         _register_command(subparsers, "delete-dir", GCSDeleteDirCommand)
+
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
 
 
 class GCSInfoCommand(Command):
@@ -1243,7 +1260,7 @@ class GCSInfoCommand(Command):
             "paths are folders, not files")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleCloudStorageClient()
 
         if args.folder:
@@ -1378,7 +1395,7 @@ class GCSListCommand(Command):
             help="whether to show the number of files in the list")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleCloudStorageClient()
 
         metadata = client.list_files_in_folder(
@@ -1416,7 +1433,7 @@ class GCSUploadCommand(Command):
             "chunk size (in bytes) to use")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleCloudStorageClient(chunk_size=args.chunk_size)
 
         print("Uploading '%s' to '%s'" % (args.local_path, args.cloud_path))
@@ -1457,7 +1474,7 @@ class GCSUploadDirectoryCommand(Command):
             "chunk size (in bytes) to use")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleCloudStorageClient(chunk_size=args.chunk_size)
 
         if args.sync:
@@ -1497,7 +1514,7 @@ class GCSDownloadCommand(Command):
             "chunk size (in bytes) to use")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleCloudStorageClient(chunk_size=args.chunk_size)
 
         if args.print:
@@ -1544,7 +1561,7 @@ class GCSDownloadDirectoryCommand(Command):
             "chunk size (in bytes) to use")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleCloudStorageClient(chunk_size=args.chunk_size)
 
         if args.sync:
@@ -1570,7 +1587,7 @@ class GCSDeleteCommand(Command):
             "cloud_path", metavar="CLOUD_PATH", help="the GCS file to delete")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleCloudStorageClient()
 
         print("Deleting '%s'" % args.cloud_path)
@@ -1592,7 +1609,7 @@ class GCSDeleteDirCommand(Command):
             "delete")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleCloudStorageClient()
 
         print("Deleting '%s'" % args.cloud_dir)
@@ -1617,6 +1634,10 @@ class GoogleDriveStorageCommand(Command):
         _register_command(
             subparsers, "delete-dir", GoogleDriveDeleteDirCommand)
 
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
+
 
 class GoogleDriveInfoCommand(Command):
     '''Get information about files/folders in Google Drive.
@@ -1639,7 +1660,7 @@ class GoogleDriveInfoCommand(Command):
             "interest are folders")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleDriveStorageClient()
 
         if args.folder:
@@ -1776,7 +1797,7 @@ class GoogleDriveListCommand(Command):
             help="whether to show the number of files in the list")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleDriveStorageClient()
 
         metadata = client.list_files_in_folder(
@@ -1818,7 +1839,7 @@ class GoogleDriveUploadCommand(Command):
             "chunk size (in bytes) to use")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleDriveStorageClient(chunk_size=args.chunk_size)
 
         print("Uploading '%s' to '%s'" % (args.path, args.folder_id))
@@ -1857,7 +1878,7 @@ class GoogleDriveUploadDirectoryCommand(Command):
             "chunk size (in bytes) to use")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleDriveStorageClient(chunk_size=args.chunk_size)
 
         client.upload_files_in_folder(
@@ -1899,7 +1920,7 @@ class GoogleDriveDownloadCommand(Command):
             "chunk size (in bytes) to use")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         #
         # Download publicly available file
         #
@@ -1965,7 +1986,7 @@ class GoogleDriveDownloadDirectoryCommand(Command):
             "chunk size (in bytes) to use")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleDriveStorageClient(chunk_size=args.chunk_size)
 
         client.download_files_in_folder(
@@ -1987,7 +2008,7 @@ class GoogleDriveDeleteCommand(Command):
             "id", metavar="ID", help="the ID of the file to delete")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleDriveStorageClient()
 
         print("Deleting '%s'" % args.id)
@@ -2017,7 +2038,7 @@ class GoogleDriveDeleteDirCommand(Command):
             "skip failures")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.GoogleDriveStorageClient()
 
         if args.contents_only:
@@ -2037,6 +2058,10 @@ class HTTPStorageCommand(Command):
         _register_command(subparsers, "upload", HTTPUploadCommand)
         _register_command(subparsers, "download", HTTPDownloadCommand)
         _register_command(subparsers, "delete", HTTPDeleteCommand)
+
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
 
 
 class HTTPUploadCommand(Command):
@@ -2064,7 +2089,7 @@ class HTTPUploadCommand(Command):
             "filename")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         set_content_type = bool(args.content_type)
         client = etas.HTTPStorageClient(set_content_type=set_content_type)
 
@@ -2101,7 +2126,7 @@ class HTTPDownloadCommand(Command):
             "chunk size (in bytes) to use")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.HTTPStorageClient(chunk_size=args.chunk_size)
 
         if args.print:
@@ -2125,7 +2150,7 @@ class HTTPDeleteCommand(Command):
         parser.add_argument("url", metavar="URL", help="the URL to DELETE")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         client = etas.HTTPStorageClient()
         print("Deleting '%s'" % args.url)
         client.delete(args.url)
@@ -2143,6 +2168,10 @@ class SFTPStorageCommand(Command):
         _register_command(subparsers, "download-dir", SFTPDownloadDirCommand)
         _register_command(subparsers, "delete", SFTPDeleteCommand)
         _register_command(subparsers, "delete-dir", SFTPDeleteDirCommand)
+
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
 
 
 class SFTPUploadCommand(Command):
@@ -2169,7 +2198,7 @@ class SFTPUploadCommand(Command):
             "(default = 22)")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         hostname, username, remote_path = _parse_remote_path(
             args.remote_path, args.host, args.user)
 
@@ -2203,7 +2232,7 @@ class SFTPUploadDirCommand(Command):
             "(default = 22)")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         hostname, username, remote_dir = _parse_remote_path(
             args.remote_dir, args.host, args.user)
 
@@ -2244,7 +2273,7 @@ class SFTPDownloadCommand(Command):
             "download to stdout. If true, a file is NOT written to disk")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         hostname, username, remote_path = _parse_remote_path(
             args.remote_path, args.host, args.user)
 
@@ -2282,7 +2311,7 @@ class SFTPDownloadDirCommand(Command):
             "(default = 22)")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         hostname, username, remote_dir = _parse_remote_path(
             args.remote_dir, args.host, args.user)
 
@@ -2313,7 +2342,7 @@ class SFTPDeleteCommand(Command):
             "(default = 22)")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         hostname, username, remote_path = _parse_remote_path(
             args.remote_path, args.host, args.user)
 
@@ -2344,7 +2373,7 @@ class SFTPDeleteDirCommand(Command):
             "(default = 22)")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         hostname, username, remote_dir = _parse_remote_path(
             args.remote_dir, args.host, args.user)
 
@@ -2719,6 +2748,10 @@ def _group_by_dir(d):
 
 def _register_main_command(command, version=None):
     parser = argparse.ArgumentParser(description=command.__doc__.rstrip())
+
+    parser.set_defaults(run=lambda args: command.run(parser, args))
+    command.setup(parser)
+
     if version:
         parser.add_argument(
             "-v", "--version", action="version", version=version,
@@ -2734,7 +2767,8 @@ def _register_command(parent, name, command):
         name, help=command.__doc__.splitlines()[0],
         description=command.__doc__.rstrip(),
         formatter_class=argparse.RawTextHelpFormatter)
-    parser.set_defaults(run=command.run)
+
+    parser.set_defaults(run=lambda args: command.run(parser, args))
     command.setup(parser)
     return parser
 
@@ -2742,10 +2776,5 @@ def _register_command(parent, name, command):
 def main():
     '''Executes the `eta` tool with the given command-line args.'''
     parser = _register_main_command(ETACommand, version=eta.version)
-
-    if len(sys.argv) == 1:
-        parser.print_help()
-        return
-
     args = parser.parse_args()
     args.run(args)

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -26,7 +26,6 @@ import logging
 import operator
 import os
 import re
-import sys
 
 import dateutil.parser
 from tabulate import tabulate


### PR DESCRIPTION
This PR adds two convenient features:

1. Running a naked `eta <command>` will now print help for that command. Previously, it would just execute the command, which may do something, do nothing, or give an error.

This is useful because a typical pattern for exploring a CLI is to:
- Run `eta` to see what the tool is all about (expecting to get help info)
- See an interesting command in the above list
- Run `eta <command>` to learn more about that command (expecting to get help info)

2. Automagically adding an `--all-help` flag for all commands that have subcommands. This is useful for seeing everything that one can do with a given command. Or, if one is so inclined, running `eta --all-help` to see EVERYTHING