### PR TITLE
Adding support for reseting VideoReaders

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2805,9 +2805,6 @@ class FFmpegVideoReader(VideoReader):
 class SampledFramesVideoReader(VideoReader):
     '''Class for reading video stored as sampled frames on disk.
 
-    A frames string like "1-5,10-15" can optionally be passed to only read
-    certain frame ranges.
-
     This class uses 1-based indexing for all frame operations.
     '''
 
@@ -2826,16 +2823,22 @@ class SampledFramesVideoReader(VideoReader):
                 - an iterable, e.g., [1, 2, 3, 6, 8, 9, 10]. The frames do not
                     need to be in sorted order
         '''
-        self._frames_dir = None
-        self._frames_patt = None
-        self._frame_size = None
-        self._total_frame_count = None
-
+        # Parse args
         all_frames = self._init_for_frames_dir(frames_dir)
         if frames is None or frames == "*":
             frames = all_frames
 
         super(SampledFramesVideoReader, self).__init__(frames_dir, frames)
+
+        self._frames_dir = None
+        self._frames_patt = None
+        self._frame_size = None
+        self._total_frame_count = None
+
+    def reset(self):
+        '''Resets the SampledFramesVideoReader.'''
+        self.close()
+        self._reset()
 
     @property
     def encoding_str(self):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -454,7 +454,7 @@ class VideoFrameLabels(Serializable):
     @property
     def is_empty(self):
         '''Whether the frame has no labels of any kind.'''
-        return (not self.has_frame_attributes and not self.has_objects)
+        return not self.has_frame_attributes and not self.has_objects
 
     def add_frame_attribute(self, frame_attr):
         '''Adds the attribute to the frame.
@@ -2027,12 +2027,12 @@ def _sample_select_frames_fast(
 
             if exception_if_incomplete:
                 raise SampleSelectFramesError(msg)
-            else:
-                # Analogous to FFmpegVideoReader, our approach here is to
-                # gracefully fail and just give the user however many frames we
-                # can...
-                logger.warning(msg)
-                frames = frames[:num_frames]
+
+            # Analogous to FFmpegVideoReader, our approach here is to
+            # gracefully fail and just give the user however many frames we
+            # can...
+            logger.warning(msg)
+            frames = frames[:num_frames]
 
         if output_patt is not None:
             # Move frames into place with correct output names
@@ -3225,8 +3225,8 @@ class FFprobe(object):
         except EnvironmentError as e:
             if e.errno == errno.ENOENT:
                 raise etau.ExecutableNotFoundError("ffprobe")
-            else:
-                raise
+
+            raise
 
         out, err = self._p.communicate()
         if self._p.returncode != 0:
@@ -3378,8 +3378,8 @@ class FFmpeg(object):
         except EnvironmentError as e:
             if e.errno == errno.ENOENT:
                 raise etau.ExecutableNotFoundError("ffmpeg")
-            else:
-                raise
+
+            raise
 
         # Run non-streaming jobs immediately
         if not (self.is_input_streaming or self.is_output_streaming):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2931,7 +2931,9 @@ class OpenCVVideoReader(VideoReader):
         Raises:
             OpenCVVideoReaderError: if the input video could not be opened
         '''
-        self._cap = self._open_capture(inpath)
+        self._cap = None
+
+        self._open_stream(inpath)
         super(OpenCVVideoReader, self).__init__(inpath, frames)
 
     def close(self):
@@ -2944,7 +2946,7 @@ class OpenCVVideoReader(VideoReader):
         '''Resets the OpenCVVideoReader.'''
         self.close()
         self._reset()
-        self._cap = self._open_capture(self.inpath)
+        self._open_stream(self.inpath)
 
     @property
     def encoding_str(self):
@@ -3033,13 +3035,10 @@ class OpenCVVideoReader(VideoReader):
                 self.frame_number)
             raise StopIteration
 
-    @staticmethod
-    def _open_capture(inpath):
-        cap = cv2.VideoCapture(inpath)
-        if not cap.isOpened():
+    def _open_stream(self, inpath):
+        self._cap = cv2.VideoCapture(inpath)
+        if not self._cap.isOpened():
             raise OpenCVVideoReaderError("Unable to open '%s'" % inpath)
-
-        return cap
 
 
 class OpenCVVideoReaderError(VideoReaderError):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2537,7 +2537,7 @@ class VideoProcessor(object):
 
 
 class VideoProcessorError(Exception):
-    '''Exception raised when an error occurs within a VideoProcessor.'''
+    '''Exception raised when a problem with a VideoProcessor is encountered.'''
     pass
 
 
@@ -2655,7 +2655,7 @@ class VideoReader(object):
 
 
 class VideoReaderError(Exception):
-    '''Exception raised when an error occured while reading a video.'''
+    '''Exception raised when a problem with a VideoReader is encountered.'''
     pass
 
 
@@ -3036,8 +3036,21 @@ class OpenCVVideoReader(VideoReader):
             raise StopIteration
 
 
+class OpenCVVideoReaderError(VideoReaderError):
+    '''Error raised when a problem with an OpenCVVideoReader is encountered.'''
+    pass
+
+
 class VideoWriter(object):
-    '''Base class for writing videos.'''
+    '''Base class for writing videos.
+
+    This class declares the following conventions:
+
+        (a) `VideoWriter`s implement the context manager interface. This means
+            that subclasses can optionally use context to perform any necessary
+            setup and teardown, and so any code that uses a `VideoWriter`
+            should use the `with` syntax
+    '''
 
     def __enter__(self):
         return self
@@ -3054,12 +3067,12 @@ class VideoWriter(object):
         raise NotImplementedError("subclass must implement write()")
 
     def close(self):
-        '''Closes the video writer.'''
-        raise NotImplementedError("subclass must implement close()")
+        '''Closes the VideoWriter.'''
+        pass
 
 
 class VideoWriterError(Exception):
-    '''Exception raised when a VideoWriter encounters an error.'''
+    '''Exception raised when a problem with a VideoWriter is encountered.'''
     pass
 
 
@@ -3101,7 +3114,7 @@ class FFmpegVideoWriter(VideoWriter):
         self._ffmpeg.stream(img.tostring())
 
     def close(self):
-        '''Closes the video writer.'''
+        '''Closes the FFmpegVideoWriter.'''
         self._ffmpeg.close()
 
 
@@ -3121,7 +3134,7 @@ class OpenCVVideoWriter(VideoWriter):
             size: the (width, height) of each frame
 
         Raises:
-            VideoWriterError: if the writer failed to open
+            OpenCVVideoWriterError: if the writer failed to open
         '''
         self.outpath = outpath
         self.fps = fps
@@ -3131,7 +3144,7 @@ class OpenCVVideoWriter(VideoWriter):
         etau.ensure_path(self.outpath)
         self._writer.open(self.outpath, -1, self.fps, self.size, True)
         if not self._writer.isOpened():
-            raise VideoWriterError("Unable to open '%s'" % self.outpath)
+            raise OpenCVVideoWriterError("Unable to open '%s'" % self.outpath)
 
     def write(self, img):
         '''Appends the image to the output video.
@@ -3145,6 +3158,13 @@ class OpenCVVideoWriter(VideoWriter):
         '''Closes the video writer.'''
         # self._writer.release()  # warns to use a separate thread
         threading.Thread(target=self._writer.release, args=()).start()
+
+
+class OpenCVVideoWriterError(VideoWriterError):
+    '''Exception raised when a problem with an OpenCVVideoWriter is
+    encountered.
+    '''
+    pass
 
 
 class FFprobe(object):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2698,6 +2698,8 @@ class FFmpegVideoReader(VideoReader):
         else:
             in_opts = None
 
+        super(FFmpegVideoReader, self).__init__(inpath, frames)
+
         self._stream_info = VideoStreamInfo.build_for(inpath)
         self._ffmpeg = FFmpeg(
             in_opts=in_opts,
@@ -2708,10 +2710,20 @@ class FFmpegVideoReader(VideoReader):
                 "-pix_fmt", "rgb24",        # pixel format
             ],
         )
-        self._ffmpeg.run(inpath, "-")
         self._raw_frame = None
 
-        super(FFmpegVideoReader, self).__init__(inpath, frames)
+        self.reset()
+
+    def close(self):
+        '''Closes the FFmpegVideoReader.'''
+        self._ffmpeg.close()
+
+    def reset(self):
+        '''Resets the FFmpegVideoReader.'''
+        self.close()
+        self._reset()
+        self._ffmpeg.run(self.inpath, "-")
+        self._raw_frame = None
 
     @property
     def encoding_str(self):
@@ -2756,10 +2768,6 @@ class FFmpegVideoReader(VideoReader):
                     self.frame_number)
                 raise StopIteration
         return self._retrieve()
-
-    def close(self):
-        '''Closes the video reader.'''
-        self._ffmpeg.close()
 
     def _grab(self):
         try:

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2928,13 +2928,25 @@ class OpenCVVideoReader(VideoReader):
                     need to be in sorted order
 
         Raises:
-            VideoReaderError: if the input video could not be opened.
+            OpenCVVideoReaderError: if the input video could not be opened
         '''
-        self._cap = cv2.VideoCapture(inpath)
-        if not self._cap.isOpened():
-            raise VideoReaderError("Unable to open '%s'" % inpath)
-
         super(OpenCVVideoReader, self).__init__(inpath, frames)
+        self._cap = None
+        self.reset()
+
+    def close(self):
+        '''Closes the OpenCVVideoReader.'''
+        if self._cap is not None:
+            self._cap.release()
+            self._cap = None
+
+    def reset(self):
+        '''Resets the OpenCVVideoReader.'''
+        self.close()
+        self._reset()
+        self._cap = cv2.VideoCapture(self.inpath)
+        if not self._cap.isOpened():
+            raise OpenCVVideoReaderError("Unable to open '%s'" % self.inpath)
 
     @property
     def encoding_str(self):
@@ -3004,10 +3016,6 @@ class OpenCVVideoReader(VideoReader):
                     self.frame_number)
                 raise StopIteration
         return self._retrieve()
-
-    def close(self):
-        '''Closes the video reader.'''
-        self._cap.release()
 
     def _grab(self):
         try:

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2542,7 +2542,18 @@ class VideoProcessorError(Exception):
 
 
 class VideoReader(object):
-    '''Base class for reading videos.'''
+    '''Base class for reading videos.
+
+    This class declares the following conventions:
+
+        (a) `VideoReader`s implement the context manager interface. This means
+            that models can optionally use context to perform any necessary
+            setup and teardown, and so any code that uses a `VideoReader`
+            should use the `with` syntax
+
+        (b) `VideoReader`s support a `reset()` method that allows them to be
+            reset back to their first frame, on demand
+    '''
 
     def __init__(self, inpath, frames):
         '''Initializes a VideoReader base instance.
@@ -2579,8 +2590,23 @@ class VideoReader(object):
         return self.read()
 
     def close(self):
-        '''Closes the VideoReader.'''
+        '''Closes the VideoReader.
+
+        Subclasses can override this method if necessary.
+        '''
         pass
+
+    def reset(self):
+        '''Resets the VideoReader so that the next call to `read()` will return
+        the first frame.
+        '''
+        raise NotImplementedError("subclass must implement reset()")
+
+    def _reset(self):
+        '''Base VideoReader implementation of `reset()`. Subclasses must call
+        this method internally within `reset()`.
+        '''
+        self._ranges.reset()
 
     @property
     def frame_number(self):


### PR DESCRIPTION
All `VideoReader`s now implement a `reset()` method, which allows them to be reset at any time such that the next frame read will the first frame.

This addresses the second half of https://github.com/voxel51/eta/issues/373, which has been updated to reflect that the only remaining need is an efficient implementation of `seek`ing to a specific frame.

Test code:
```py
import eta.core.video as etav

video_path = "/path/to/video.mp4"
frames_dir = "/path/to/video/frames"

max_frames = [10, 20, 15]

video_reader = etav.FFmpegVideoReader(video_path)
#video_reader = etav.OpenCVVideoReader(video_path)
#video_reader = etav.SampledFramesVideoReader(frames_dir)

with video_reader as vr:
    for max_frame in max_frames:
        vr.reset()
        frames = []
        for img in vr:
            frames.append(vr.frame_number)
            if vr.frame_number >= max_frame:
                print(frames)
                break
```