### PR TITLE
Making FrameRange and FrameRanges Serializable

### DIFF
--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -2127,7 +2127,7 @@ class BuilderVideoRecord(BuilderDataRecord):
         else:
             args = (
                 self.data_path,
-                etav.FrameRanges([(start_frame, end_frame)])
+                etav.FrameRanges.build_simple(start_frame, end_frame)
             )
             with etav.VideoProcessor(*args, out_video_path=data_path) as p:
                 for img in p:

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -30,7 +30,6 @@ import six
 # pragma pylint: enable=wildcard-import
 
 from collections import defaultdict, OrderedDict
-import dateutil.parser
 import errno
 import logging
 import os
@@ -38,6 +37,7 @@ from subprocess import Popen, PIPE
 import threading
 
 import cv2
+import dateutil.parser
 import numpy as np
 
 from eta.core.data import AttributeContainer, AttributeContainerSchema
@@ -3816,7 +3816,7 @@ class FrameRangesError(Exception):
 
 
 class FrameRange(Serializable):
-    '''An iterator over a range of frames.'''
+    '''Class representing a range of frames.'''
 
     def __init__(self, first, last):
         '''Creates a FrameRange instance.
@@ -3824,9 +3824,6 @@ class FrameRange(Serializable):
         Args:
             first: the first frame in the range (inclusive)
             last: the last frame in the range (inclusive)
-
-        Raises:
-            FrameRangeError: if last < first
         '''
         self.first = first
         self.last = last

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -3651,6 +3651,19 @@ class FrameRanges(Serializable):
 
         return False
 
+    @property
+    def is_contiguous(self):
+        '''Determines whether the frame range is contiguous, i.e., whether it
+        consists of a single `FrameRange`.
+
+        If you want to ensure that this instance does not contain trivial
+        adjacent `FrameRange`s, then call `simplify()` first.
+
+        Returns:
+            True/False
+        '''
+        return self.num_ranges == 1
+
     def reset(self):
         '''Resets the FrameRanges instance so that the next frame will be the
         first.
@@ -3680,8 +3693,8 @@ class FrameRanges(Serializable):
         self._ingest_range(new_range)
 
     def simplify(self):
-        '''Simplifies the FrameRanges, if possible, by merging any adjacent
-        ranges into a single range.
+        '''Simplifies the frame ranges, if possible, by merging any adjacent
+        `FrameRange` instances into a single range.
 
         This operation will `reset()` the instance.
         '''

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -3776,6 +3776,32 @@ class FrameRanges(Serializable):
         '''
         return ",".join([fr.to_human_str() for fr in self._ranges])
 
+    def to_bools(self, total_frame_count=None):
+        '''Returns a boolean array indicating the frames described by this
+        object.
+
+        Note that the boolean array uses 0-based indexing. Thus, the returned
+        array satisfies `bools[idx] == True` iff frame `idx + 1` is in this
+        object.
+
+        Args:
+            total_frame_count: an optional total frame count. Can be less or
+                greater than the maximum frame in this object, if desired. By
+                default, `self.limits[1]` is used.
+
+        Returns:
+            a boolean numpy array of length `total_frame_count`
+        '''
+        if total_frame_count is None:
+            total_frame_count = self.limits[1]
+
+        bools = np.zeros(total_frame_count, dtype=bool)
+
+        inds = [i - 1 for i in self.to_list() if i <= total_frame_count]
+        bools[inds] = True
+
+        return bools
+
     @staticmethod
     def build_simple(first, last):
         '''Builds a FrameRanges from a simple [first, last] range.
@@ -3788,6 +3814,23 @@ class FrameRanges(Serializable):
             a FrameRanges instance
         '''
         return FrameRanges(ranges=[(first, last)])
+
+    @classmethod
+    def from_bools(cls, bools):
+        '''Constructs a FrameRanges object from a boolean array describing the
+        frames in the ranges.
+
+        Note that the 0-based indexes in the boolean array are converted to
+        1-based frame numbers. In other words, the returned FrameRanges
+        contains `frame` iff `bools[frame - 1] == True`.
+
+        Args:
+            bools: a boolean array
+
+        Returns:
+            a FrameRanges instance
+        '''
+        return cls.from_iterable(1 + np.flatnonzero(bools))
 
     @classmethod
     def from_human_str(cls, frames_str):
@@ -4001,10 +4044,13 @@ class FrameRangeError(Exception):
 
 
 def _iterable_to_ranges(vals):
+    # This will convert numpy arrays to list, and its important to do this
+    # before checking for falseness below, since numpy arrays don't support it
+    vals = sorted(vals)
+
     if not vals:
         return
 
-    vals = sorted(vals)
     first = last = vals[0]
     for val in vals[1:]:
         if val == last + 1:

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -3548,37 +3548,51 @@ class FOURCC(object):
                chr((i & 0xFF000000) >> 24)
 
 
-class FrameRanges(object):
+class FrameRanges(Serializable):
     '''Class representing a monotonically increasing and disjoint series of
     frames.
     '''
 
-    def __init__(self, ranges):
+    def __init__(self, ranges=None):
         '''Creates a FrameRanges instance.
 
         Args:
-            ranges: an iterable of (first, last) tuples, which must be disjoint
-                and monotonically increasing
+            ranges: an optional iterable of (first, last) tuples, which must be
+                disjoint and monotonically increasing. By default, an empty
+                instance is created
 
         Raises:
             FrameRangesError: if the series is not disjoint and monotonically
                 increasing
         '''
-        self._idx = 0
+        self.ranges = []
         self._ranges = []
+        self._idx = 0
         self._started = False
 
-        # Parse args
-        end = -1
-        for first, last in ranges:
-            if first <= end:
-                raise FrameRangesError(
-                    "Expected first:%d > last:%d" % (first, end))
+        if ranges is not None:
+            for new_range in ranges:
+                self._ingest_range(new_range)
 
-            self._ranges.append(FrameRange(first, last))
-            end = last
+    def _ingest_range(self, new_range):
+        first, last = new_range
+        end = self.limits[1]
+
+        if end is not None and first <= end:
+            raise FrameRangesError(
+                "Expected first:%d > end:%d" % (first, end))
+
+        self.ranges.append((first, last))
+        self._ranges.append(FrameRange(first, last))
+
+    def __len__(self):
+        return sum(len(r) for r in self._ranges)
+
+    def __bool__(self):
+        return bool(self._ranges)
 
     def __iter__(self):
+        self.reset()
         return self
 
     def __next__(self):
@@ -3593,15 +3607,20 @@ class FrameRanges(object):
 
         return frame
 
-    def reset(self):
-        '''Resets the FrameRanges instance so that the next frame will be the
-        first.
-        '''
-        for r in self._ranges[:(self._idx + 1)]:
-            r.reset()
+    @property
+    def limits(self):
+        '''A (first, last) tuple describing the limits of the frame ranges.'''
+        if not bool(self):
+            return (None, None)
 
-        self._started = False
-        self._idx = 0
+        first = self._ranges[0].limits[0]
+        last = self._ranges[-1].limits[1]
+        return (first, last)
+
+    @property
+    def num_ranges(self):
+        '''The number of `FrameRange`s in this object.'''
+        return len(self._ranges)
 
     @property
     def frame(self):
@@ -3629,6 +3648,62 @@ class FrameRanges(object):
 
         return False
 
+    def reset(self):
+        '''Resets the FrameRanges instance so that the next frame will be the
+        first.
+        '''
+        for r in self._ranges[:(self._idx + 1)]:
+            r.reset()
+
+        self._started = False
+        self._idx = 0
+
+    def clear(self):
+        '''Clears the FrameRanges instance.'''
+        self.ranges = []
+        self._ranges = []
+        self.reset()
+
+    def add_range(self, new_range):
+        '''Adds the given frame range to the instance.
+
+        Args:
+            new_range: a (first, last) tuple describing the range
+
+        Raises:
+            FrameRangesError: if the new range is not disjoint and
+                monotonically increasing
+        '''
+        self._ingest_range(new_range)
+
+    def simplify(self):
+        '''Simplifies the FrameRanges, if possible, by merging any adjacent
+        ranges into a single range.
+
+        This operation will `reset()` the instance.
+        '''
+        if not self:
+            return
+
+        did_something = False
+        last_range = list(self.ranges[0])
+        new_ranges = [last_range]
+        for old_range in self.ranges[1:]:
+            if old_range[0] <= last_range[1] + 1:
+                did_something = True
+                last_range[1] = old_range[1]
+            else:
+                last_range = list(old_range)
+                new_ranges.append(last_range)
+
+        if not did_something:
+            self.reset()
+            return
+
+        self.clear()
+        for new_range in new_ranges:
+            self.add_range(new_range)
+
     def to_list(self):
         '''Returns the list of frames, in sorted order, described by this
         object.
@@ -3642,20 +3717,33 @@ class FrameRanges(object):
 
         return frames
 
-    def to_str(self):
-        '''Returns a string representation of this object.
+    def to_human_str(self):
+        '''Returns a human-readable string representation of this object.
 
         Returns:
             a string like "1-3,6,8-10" describing the frame ranges
         '''
-        return ",".join([r.to_str() for r in self._ranges])
+        return ",".join([fr.to_human_str() for fr in self._ranges])
 
-    @classmethod
-    def from_str(cls, frames_str):
-        '''Constructs a FrameRanges object from a frames string.
+    @staticmethod
+    def build_simple(first, last):
+        '''Builds a FrameRanges from a simple [first, last] range.
 
         Args:
-            frames_str: a frames string like "1-3,6,8-10"
+            first: the first frame
+            last: the last frame
+
+        Returns:
+            a FrameRanges instance
+        '''
+        return FrameRanges(ranges=[(first, last)])
+
+    @classmethod
+    def from_human_str(cls, frames_str):
+        '''Constructs a FrameRanges object from a human-readable frames string.
+
+        Args:
+            frames_str: a human-readable frames string like "1-3,6,8-10"
 
         Returns:
             a FrameRanges instance
@@ -3688,13 +3776,30 @@ class FrameRanges(object):
         '''
         return cls(_iterable_to_ranges(frames))
 
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs a FrameRanges from a JSON dictionary.
+
+        Args:
+            d: a JSON dictionary
+
+        Returns:
+            a FrameRanges instance
+        '''
+        ranges = []
+        for frd in d.get("ranges", []):
+            frame_range = FrameRange.from_dict(frd)
+            ranges.append(frame_range.limits)
+
+        return cls(ranges=ranges)
+
 
 class FrameRangesError(Exception):
     '''Exception raised when an invalid FrameRanges is encountered.'''
     pass
 
 
-class FrameRange(object):
+class FrameRange(Serializable):
     '''An iterator over a range of frames.'''
 
     def __init__(self, first, last):
@@ -3707,16 +3812,29 @@ class FrameRange(object):
         Raises:
             FrameRangeError: if last < first
         '''
-        # Parse args
-        if last < first:
-            raise FrameRangeError(
-                "Expected first:%d <= last:%d" % (first, last))
-
         self.first = first
         self.last = last
         self._frame = -1
 
+        self._validate_range(first, last)
+
+    @staticmethod
+    def _validate_range(first, last):
+        if first < 1:
+            raise FrameRangeError("Expected first:%d >= 1" % first)
+
+        if last < first:
+            raise FrameRangeError(
+                "Expected first:%d <= last:%d" % (first, last))
+
+    def __len__(self):
+        return self.last + 1 - self.first
+
+    def __bool__(self):
+        return True
+
     def __iter__(self):
+        self.reset()
         return self
 
     def __next__(self):
@@ -3744,6 +3862,11 @@ class FrameRange(object):
         return self._frame
 
     @property
+    def limits(self):
+        '''A (first, last) tuple describing the frame range.'''
+        return (self.first, self.last)
+
+    @property
     def is_first_frame(self):
         '''Whether the current frame is first in the range.'''
         return self._frame == self.first
@@ -3756,8 +3879,8 @@ class FrameRange(object):
         '''
         return list(range(self.first, self.last + 1))
 
-    def to_str(self):
-        '''Returns a string representation of the range.
+    def to_human_str(self):
+        '''Returns a human-readable string representation of the range.
 
         Returns:
             a string like "1-5"
@@ -3768,11 +3891,11 @@ class FrameRange(object):
         return "%d-%d" % (self.first, self.last)
 
     @classmethod
-    def from_str(cls, frames_str):
-        '''Constructs a FrameRange object from a string.
+    def from_human_str(cls, frames_str):
+        '''Constructs a FrameRange object from a human-readable string.
 
         Args:
-            frames_str: a frames string like "1-5"
+            frames_str: a human-readable frames string like "1-5"
 
         Returns:
             a FrameRange instance
@@ -3808,6 +3931,18 @@ class FrameRange(object):
             raise FrameRangeError("Invalid frame range list %s" % frames)
 
         return cls(*ranges[0])
+
+    @classmethod
+    def from_dict(cls, d):
+        '''Constructs a FrameRange from a JSON dictionary.
+
+        Args:
+            d: a JSON dictionary
+
+        Returns:
+            a FrameRange instance
+        '''
+        return cls(d["first"], d["last"])
 
 
 class FrameRangeError(Exception):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -3557,33 +3557,21 @@ class FrameRanges(Serializable):
         '''Creates a FrameRanges instance.
 
         Args:
-            ranges: an optional iterable of (first, last) tuples, which must be
-                disjoint and monotonically increasing. By default, an empty
+            ranges: can either be a human-readable frames string like
+                "1-3,6,8-10" or an iterable of (first, last) tuples, which must
+                be disjoint and monotonically increasing. By default, an empty
                 instance is created
-
-        Raises:
-            FrameRangesError: if the series is not disjoint and monotonically
-                increasing
         '''
-        self.ranges = []
         self._ranges = []
         self._idx = 0
         self._started = False
 
         if ranges is not None:
+            if isinstance(ranges, six.string_types):
+                ranges = self._parse_frames_str(ranges)
+
             for new_range in ranges:
                 self._ingest_range(new_range)
-
-    def _ingest_range(self, new_range):
-        first, last = new_range
-        end = self.limits[1]
-
-        if end is not None and first <= end:
-            raise FrameRangesError(
-                "Expected first:%d > end:%d" % (first, end))
-
-        self.ranges.append((first, last))
-        self._ranges.append(FrameRange(first, last))
 
     def __len__(self):
         return sum(len(r) for r in self._ranges)
@@ -3606,6 +3594,26 @@ class FrameRanges(Serializable):
             raise StopIteration
 
         return frame
+
+    @staticmethod
+    def _parse_frames_str(frames_str):
+        ranges = []
+        for r in frames_str.split(","):
+            if r:
+                fr = FrameRange.from_human_str(r)
+                ranges.append((fr.first, fr.last))
+
+        return ranges
+
+    def _ingest_range(self, new_range):
+        first, last = new_range
+        end = self.limits[1]
+
+        if end is not None and first <= end:
+            raise FrameRangesError(
+                "Expected first:%d > end:%d" % (first, end))
+
+        self._ranges.append(FrameRange(first, last))
 
     @property
     def limits(self):
@@ -3632,6 +3640,13 @@ class FrameRanges(Serializable):
             return self._ranges[self._idx].frame
 
         return -1
+
+    @property
+    def ranges(self):
+        '''A serialized string representation of this object.'''
+        # This controls how `FrameRanges` instances are serialized
+        #return self.to_range_tuples()  # can be used if strings aren't liked
+        return self.to_human_str()
 
     @property
     def frame_range(self):
@@ -3676,7 +3691,6 @@ class FrameRanges(Serializable):
 
     def clear(self):
         '''Clears the FrameRanges instance.'''
-        self.ranges = []
         self._ranges = []
         self.reset()
 
@@ -3702,14 +3716,15 @@ class FrameRanges(Serializable):
             return
 
         did_something = False
-        last_range = list(self.ranges[0])
+        last_range = list(self._ranges[0].limits)
         new_ranges = [last_range]
-        for old_range in self.ranges[1:]:
-            if old_range[0] <= last_range[1] + 1:
+        for old_range in self._ranges[1:]:
+            ofirst, olast = old_range.limits
+            if ofirst <= last_range[1] + 1:
                 did_something = True
-                last_range[1] = old_range[1]
+                last_range[1] = olast
             else:
-                last_range = list(old_range)
+                last_range = [ofirst, olast]
                 new_ranges.append(last_range)
 
         if not did_something:
@@ -3719,6 +3734,23 @@ class FrameRanges(Serializable):
         self.clear()
         for new_range in new_ranges:
             self.add_range(new_range)
+
+    def attributes(self):
+        '''Returns the list of class attributes that will be serialized.
+
+        Returns:
+            a list of attributes
+        '''
+        return ["ranges"]
+
+    def to_range_tuples(self):
+        '''Returns the list of (first, last) tuples defining the frame ranges
+        in this instance.
+
+        Returns:
+            a list of (first, last) tuples
+        '''
+        return [r.limits for r in self._ranges]
 
     def to_list(self):
         '''Returns the list of frames, in sorted order, described by this
@@ -3767,13 +3799,7 @@ class FrameRanges(Serializable):
         Raises:
             FrameRangesError: if the frames string is invalid
         '''
-        ranges = []
-        for r in frames_str.split(","):
-            if r:
-                fr = FrameRange.from_human_str(r)
-                ranges.append((fr.first, fr.last))
-
-        return cls(ranges)
+        return cls(ranges=frames_str)
 
     @classmethod
     def from_iterable(cls, frames):
@@ -3790,7 +3816,19 @@ class FrameRanges(Serializable):
         Raises:
             FrameRangesError: if the frames list is invalid
         '''
-        return cls(_iterable_to_ranges(frames))
+        return cls(ranges=_iterable_to_ranges(frames))
+
+    @classmethod
+    def from_frame_range(cls, frame_range):
+        '''Constructs a FrameRanges instance from a FrameRange instance.
+
+        Args:
+            frame_range: a FrameRange instance
+
+        Returns:
+            a FrameRanges instance
+        '''
+        return cls(ranges=[(frame_range.first, frame_range.last)])
 
     @classmethod
     def from_dict(cls, d):
@@ -3802,11 +3840,7 @@ class FrameRanges(Serializable):
         Returns:
             a FrameRanges instance
         '''
-        ranges = []
-        for frd in d.get("ranges", []):
-            frame_range = FrameRange.from_dict(frd)
-            ranges.append(frame_range.limits)
-
+        ranges = d.get("ranges", None)
         return cls(ranges=ranges)
 
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2327,13 +2327,16 @@ def parse_frame_ranges(frames):
                 need to be in sorted order
 
     Returns:
-        a FrameRanges instance describing the frame ranges
+        a FrameRanges instance describing the frames
     '''
     if isinstance(frames, six.string_types):
         # Human-readable frames string
         frame_ranges = FrameRanges.from_human_str(frames)
-    elif isinstance(frames, (FrameRange, FrameRanges)):
-        # FrameRange or FrameRanges
+    elif isinstance(frames, FrameRange):
+        # FrameRange
+        frame_ranges = FrameRanges.from_frame_range(frames)
+    elif isinstance(frames, FrameRanges):
+        # FrameRanges
         frame_ranges = frames
     elif hasattr(frames, "__iter__"):
         # Frames iterable

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2330,8 +2330,8 @@ def parse_frame_ranges(frames):
         a FrameRanges instance describing the frame ranges
     '''
     if isinstance(frames, six.string_types):
-        # Frames string
-        frame_ranges = FrameRanges.from_str(frames)
+        # Human-readable frames string
+        frame_ranges = FrameRanges.from_human_str(frames)
     elif isinstance(frames, (FrameRange, FrameRanges)):
         # FrameRange or FrameRanges
         frame_ranges = frames
@@ -2584,7 +2584,7 @@ class VideoReader(object):
         if frames is None or frames == "*":
             frames = "1-%d" % self.total_frame_count
         self._ranges = parse_frame_ranges(frames)
-        self.frames = self._ranges.to_str()
+        self.frames = self._ranges.to_human_str()
 
     def __enter__(self):
         return self
@@ -3754,7 +3754,7 @@ class FrameRanges(Serializable):
         ranges = []
         for r in frames_str.split(","):
             if r:
-                fr = FrameRange.from_str(r)
+                fr = FrameRange.from_human_str(r)
                 ranges.append((fr.first, fr.last))
 
         return cls(ranges)

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -3609,7 +3609,10 @@ class FrameRanges(Serializable):
 
     @property
     def limits(self):
-        '''A (first, last) tuple describing the limits of the frame ranges.'''
+        '''A (first, last) tuple describing the limits of the frame ranges.
+
+        Returns (None, None) if the instance is empty.
+        '''
         if not bool(self):
             return (None, None)
 


### PR DESCRIPTION
This PR makes the `FrameRange` and `FrameRanges` classes from `eta.core.video` implement the `Serializable` interface, so that they can be included as fields in other Serializable classes.

It also adds a few other niceties:
- `FrameRanges` can now be expanded and cleared
- support for `len`, `bool`, `limits`
- support for simplifying `FrameRanges` if possible (merging adjacent ranges)

Testing `FrameRange`:
```py
import eta.core.video as etav

frame_range = etav.FrameRange.from_human_str("1-5")
print(etav.FrameRange.from_human_str("1"))

def _inspect_frame_range(frame_range):
    print("frame: %s" % frame_range.frame)
    print("limits: %s" % (frame_range.limits,))
    print("len: %d" % len(frame_range))
    print("bool: %s" % bool(frame_range))
    print("to_str: %s" % frame_range.to_str())
    print("to_human_str: %s" % frame_range.to_human_str())

_inspect_frame_range(frame_range)

for idx in frame_range:
    print("frame: %s" % frame_range.frame)

# Should fail
frame_range = etav.FrameRange.from_human_str("-5-10")
frame_range = etav.FrameRange.from_human_str("0-10")
```

Testing `FrameRanges`:
```py
import eta.core.video as etav

frame_ranges = etav.FrameRanges.from_human_str("1-5,7,10-15")

def _inspect_frame_ranges(frame_ranges):
    print("frame: %s" % frame_ranges.frame)
    print("frame_range: %s" % (frame_ranges.frame_range,))
    print("is_new_frame_range: %d\n" % frame_ranges.is_new_frame_range)
    print("limits: %s" % (frame_ranges.limits,))
    print("num_ranges: %s" % frame_ranges.num_ranges)
    print("len: %d" % len(frame_ranges))
    print("bool: %s" % bool(frame_ranges))
    print("to_str: %s" % frame_ranges.to_str())
    print("to_human_str: %s" % frame_ranges.to_human_str())

_inspect_frame_ranges(frame_ranges)

for idx in frame_ranges:
    print("frame: %s" % frame_ranges.frame)
    print("frame_range: %s" % (frame_ranges.frame_range,))
    print("is_new_frame_range: %d\n" % frame_ranges.is_new_frame_range)

frame_ranges.clear()
_inspect_frame_ranges(frame_ranges)

# Test `simplify()`
frame_ranges = etav.FrameRanges.from_human_str("1,2,3,5-10,11-13")
print(frame_ranges.to_human_str())
frame_ranges.simplify()
print(frame_ranges.to_human_str())
frame_ranges.simplify()
print(frame_ranges.to_human_str())

# Should fail
frame_range = etav.FrameRanges.from_human_str("5-10,7-12")
```