### PR TITLE
fixing split fraction bug in `core/datasets.py` when empty list is passed. adding docstring…

### DIFF
--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -198,8 +198,17 @@ def _split_in_order(item_list, split_fractions):
     return sample_lists
 
 
-def _validate_split_fractions(split_fractions):
-    if split_fractions is None:
+def _validate_split_fractions(split_fractions=None):
+    '''Validate the `split_fractions` are non-negative and sum to one.
+
+    @todo Function currently assumes a two-class setting when generating a
+    split fraction if one does not exist.
+
+    @todo Improve Function Contract -- "validate" implies the function will
+    only check the inputted data, not generate one if none are given.
+    '''
+    # bool is used here to allow for both None and empty-list inputs
+    if not bool(split_fractions):
         split_fractions = [0.5, 0.5]
 
     negative = [frac for frac in split_fractions if frac < 0]


### PR DESCRIPTION
…. adding todos

Some other code was passing in empty-lists and this is a more general way of testing for what you want.  Note the general splitting code does not fail gracefully and hence empty `split_fractions` were getting through.