### PR TITLE
Removes dependency of `setup.py` on `eta` package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *

--- a/eta/__init__.py
+++ b/eta/__init__.py
@@ -155,9 +155,6 @@ def is_python3():
     return sys.version_info[0] == 3
 
 
-# Version string
-version = "%s v%s, %s" % (etac.NAME, etac.VERSION, etac.AUTHOR)
-
 # Default logging behavior
 etal.basic_setup()
 

--- a/eta/constants.py
+++ b/eta/constants.py
@@ -1,9 +1,7 @@
 '''
 ETA package-wide constants.
 
-IMPORTANT: this module should not import any ETA modules!
-
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
@@ -20,8 +18,12 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
-import json
 import os
+
+try:
+    from importlib.metadata import metadata  # Python 3.8
+except ModuleNotFoundError:
+    from importlib_metadata import metadata  # Python < 3.8
 
 
 # Directories
@@ -38,20 +40,19 @@ TF_SLIM_DIR = os.path.join(TF_RESEARCH_DIR, "slim")
 
 # Paths
 CONFIG_JSON_PATH = os.path.join(BASE_DIR, "config.json")
-VERSION_JSON_PATH = os.path.join(ETA_DIR, "version.json")
 ASCII_ART_PATH = os.path.join(RESOURCES_DIR, "eta-ascii.txt")
 DEFAULT_FONT_PATH = os.path.join(RESOURCES_DIR, "lato-regular.ttf")
 DEFAULT_LOGO_CONFIG_PATH = os.path.join(
     RESOURCES_DIR, "default-logo-config.json")
 
 
-# Version
-with open(VERSION_JSON_PATH, "rt") as f:
-    _VER = json.load(f)
-NAME = _VER["name"]
-VERSION = _VER["version"]
-DESCRIPTION = _VER["description"]
-AUTHOR = _VER["author"]
-CONTACT = _VER["contact"]
-URL = _VER["url"]
-LICENSE = _VER["license"]
+# Package metadata
+_META = metadata("ETA")
+NAME = _META["name"]
+VERSION = _META["version"]
+DESCRIPTION = _META["description"]
+AUTHOR = _META["author"]
+CONTACT = _META["contact"]
+URL = _META["url"]
+LICENSE = _META["license"]
+VERSION_LONG = "%s v%s, %s" % (NAME, VERSION, AUTHOR)

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -2841,6 +2841,6 @@ _ADD_RECURSIVE_HELP_FLAGS = True
 
 def main():
     '''Executes the `eta` tool with the given command-line args.'''
-    parser = _register_main_command(ETACommand, version=eta.version)
+    parser = _register_main_command(ETACommand, version=etac.VERSION_LONG)
     args = parser.parse_args()
     args.run(args)

--- a/eta/version.json
+++ b/eta/version.json
@@ -1,9 +1,0 @@
-{
-    "name": "ETA",
-    "version": "0.1.0",
-    "description": "Extensible Toolkit for Analytics",
-    "author": "Voxel51, Inc.",
-    "contact": "info@voxel51.com",
-    "url": "https://github.com/voxel51/eta",
-    "license": "BSD-4-Clause"
-}

--- a/eta/version.json
+++ b/eta/version.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "Extensible Toolkit for Analytics",
     "author": "Voxel51, Inc.",
-    "contact": "support@voxel51.com",
+    "contact": "info@voxel51.com",
     "url": "https://github.com/voxel51/eta",
     "license": "BSD 4-clause"
 }

--- a/eta/version.json
+++ b/eta/version.json
@@ -5,5 +5,5 @@
     "author": "Voxel51, Inc.",
     "contact": "info@voxel51.com",
     "url": "https://github.com/voxel51/eta",
-    "license": "BSD 4-clause"
+    "license": "BSD-4-Clause"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ google-api-python-client==1.6.5
 google-auth-httplib2==0.0.3
 google-cloud-storage==1.7.0
 h5py==2.10.0
+importlib-metadata==1.3.0; python_version<"3.8"
 Jinja2==2.10.1
 lxml==4.3.0
 numpy==1.16.3

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ Brian Moore, brian@voxel51.com
 from setuptools import setup, find_packages
 
 
-# @note the version info below should be kept in-sync with `eta/version.json`
+# @note version info should be kept in-sync with `eta/version.json`
 setup(
     name="ETA",
     version="0.1.0",
@@ -18,7 +18,7 @@ setup(
     author="Voxel51, Inc.",
     author_email="info@voxel51.com",
     url="https://github.com/voxel51/eta",
-    license="BSD 4-clause",
+    license="BSD-4-Clause",
     packages=find_packages(),
     include_package_data=True,
     classifiers=[
@@ -28,4 +28,5 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     scripts=["eta/eta"],
+    python_requires=">=2.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,24 @@
 #!/usr/bin/env python
 '''
-Installs the ETA package.
+Installs ETA.
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
 '''
 from setuptools import setup, find_packages
 
-import eta.constants as etac
 
-
+# @note the version info below should be kept in-sync with `eta/version.json`
 setup(
-    name=etac.NAME,
-    version=etac.VERSION,
-    description=etac.DESCRIPTION,
-    author=etac.AUTHOR,
-    author_email=etac.CONTACT,
-    url=etac.URL,
-    license=etac.LICENSE,
+    name="ETA",
+    version="0.1.0",
+    description="Extensible Toolkit for Analytics",
+    author="Voxel51, Inc.",
+    author_email="info@voxel51.com",
+    url="https://github.com/voxel51/eta",
+    license="BSD 4-clause",
     packages=find_packages(),
     classifiers=[
         "Operating System :: MacOS :: MacOS X",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ Brian Moore, brian@voxel51.com
 from setuptools import setup, find_packages
 
 
-# @note version info should be kept in-sync with `eta/version.json`
 setup(
     name="ETA",
     version="0.1.0",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     url="https://github.com/voxel51/eta",
     license="BSD 4-clause",
     packages=find_packages(),
+    include_package_data=True,
     classifiers=[
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
`setup.py` cannot depend on `eta/constants.py`, which implicitly imports `eta/__init__.py`, which requires ETA to already be installed!