### PR TITLE
Image/VideoSetLabels from glob pattern

### DIFF
--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -834,9 +834,8 @@ class ImageSetLabels(Set):
             a `cls` instance
         '''
         logger.warning("Using deprecated method `from_image_labels_patt`. Use"
-                       " `from_element_patt` instead.")
-        return cls.from_element_patt(
-            image_labels_patt, pattern_type=etas.NUMERIC)
+                       " `from_element_numeric_patt` instead.")
+        return cls.from_element_numeric_patt(image_labels_patt)
 
     @classmethod
     def from_dict(cls, d):

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -834,7 +834,7 @@ class ImageSetLabels(Set):
             a `cls` instance
         '''
         logger.warning("Using deprecated method `from_image_labels_patt`. Use"
-                       " `from_element_numeric_patt` instead.")
+                       " `from_numeric_patt` instead.")
         return cls.from_numeric_patt(image_labels_patt)
 
     @classmethod

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -835,7 +835,7 @@ class ImageSetLabels(Set):
         '''
         logger.warning("Using deprecated method `from_image_labels_patt`. Use"
                        " `from_element_numeric_patt` instead.")
-        return cls.from_element_numeric_patt(image_labels_patt)
+        return cls.from_numeric_patt(image_labels_patt)
 
     @classmethod
     def from_dict(cls, d):

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -29,6 +29,7 @@ from future.utils import iteritems
 from collections import defaultdict
 import colorsys
 import errno
+import glob
 import os
 import operator
 from subprocess import Popen, PIPE
@@ -830,6 +831,22 @@ class ImageSetLabels(Set):
         '''
         image_set_labels = cls()
         for labels_path in etau.get_pattern_matches(image_labels_patt):
+            image_set_labels.add(cls._ELE_CLS.from_json(labels_path))
+        return image_set_labels
+
+    @classmethod
+    def from_image_labels_glob_patt(cls, image_labels_patt):
+        '''Creates an instance of `cls` from a pattern of `_ELE_CLS` files.
+
+        Args:
+             image_labels_patt: a glob pattern:
+                example: "/path/to/labels/*.json"
+
+        Returns:
+            a `cls` instance
+        '''
+        image_set_labels = cls()
+        for labels_path in glob.glob(image_labels_patt):
             image_set_labels.add(cls._ELE_CLS.from_json(labels_path))
         return image_set_labels
 

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -29,7 +29,7 @@ from future.utils import iteritems
 from collections import defaultdict
 import colorsys
 import errno
-import glob
+import logging
 import os
 import operator
 from subprocess import Popen, PIPE
@@ -42,8 +42,12 @@ from eta.core.data import AttributeContainer, AttributeContainerSchema, \
     AttributeContainerSchemaError
 from eta.core.objects import DetectedObjectContainer
 from eta.core.serial import Serializable, Set, BigSet
+import eta.core.serial as etas
 import eta.core.utils as etau
 import eta.core.web as etaw
+
+
+logger = logging.getLogger(__name__)
 
 
 #
@@ -829,26 +833,10 @@ class ImageSetLabels(Set):
         Returns:
             a `cls` instance
         '''
-        image_set_labels = cls()
-        for labels_path in etau.get_pattern_matches(image_labels_patt):
-            image_set_labels.add(cls._ELE_CLS.from_json(labels_path))
-        return image_set_labels
-
-    @classmethod
-    def from_image_labels_glob_patt(cls, image_labels_patt):
-        '''Creates an instance of `cls` from a pattern of `_ELE_CLS` files.
-
-        Args:
-             image_labels_patt: a glob pattern:
-                example: "/path/to/labels/*.json"
-
-        Returns:
-            a `cls` instance
-        '''
-        image_set_labels = cls()
-        for labels_path in glob.glob(image_labels_patt):
-            image_set_labels.add(cls._ELE_CLS.from_json(labels_path))
-        return image_set_labels
+        logger.warning("Using deprecated method `from_image_labels_patt`. Use"
+                       " `from_element_patt` instead.")
+        return cls.from_element_patt(
+            image_labels_patt, pattern_type=etas.NUMERIC)
 
     @classmethod
     def from_dict(cls, d):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -50,7 +50,6 @@ import eta.core.utils as etau
 logger = logging.getLogger(__name__)
 
 
-
 def load_json(path_or_str):
     '''Loads JSON from the input argument.
 

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -853,7 +853,7 @@ class Set(Serializable):
         if pattern_type not in PATTERN_TYPES:
             raise ValueError("Invalid `pattern_type` '%s'" % pattern_type)
 
-        if not isinstance(cls.get_element_class(), Serializable):
+        if not issubclass(cls.get_element_class(), Serializable):
             raise TypeError(
                 "Element class '%s' is not serializable and cannot be loaded"
                 " via the 'from_json' method." % cls.get_element_class_name())

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -827,7 +827,7 @@ class Set(Serializable):
         return cls(**etau.join_dicts({cls._ELE_ATTR: elements}, kwargs))
 
     @classmethod
-    def from_element_numeric_patt(cls, pattern, *args, **kwargs):
+    def from_numeric_patt(cls, pattern, *args, **kwargs):
         '''Creates an instance of `cls` from a numeric pattern of `_ELE_CLS`
         files.
 
@@ -845,7 +845,7 @@ class Set(Serializable):
         return cls._from_element_patt(pattern, parse_method, *args, *kwargs)
 
     @classmethod
-    def from_element_glob_patt(cls, pattern, *args, **kwargs):
+    def from_glob_patt(cls, pattern, *args, **kwargs):
         '''Creates an instance of `cls` from a numeric pattern of `_ELE_CLS`
         files.
 

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -836,7 +836,7 @@ class Set(Serializable):
         return cls(**etau.join_dicts({cls._ELE_ATTR: elements}, kwargs))
 
     @classmethod
-    def from_element_patt(cls, pattern, pattern_type=NUMERIC):
+    def from_element_patt(cls, pattern, pattern_type=NUMERIC, *args, **kwargs):
         '''Creates an instance of `cls` from a pattern of `_ELE_CLS` files.
 
         Args:
@@ -846,6 +846,9 @@ class Set(Serializable):
                     GLOB:    "/path/to/labels/*.json"
             pattern_type: one of the PATTERN_TYPES enums (NUMERIC, GLOB, ...)
                 specifying how to parse the pattern
+            *args: optional positional arguments for `cls.from_json()`
+            **kwargs: optional keyword arguments for `cls.from_json()`
+
 
         Returns:
             a `cls` instance
@@ -862,7 +865,7 @@ class Set(Serializable):
 
         instance = cls()
         for element_path in parse_method(pattern):
-            instance.add(cls._ELE_CLS.from_json(element_path))
+            instance.add(cls._ELE_CLS.from_json(element_path, *args, **kwargs))
         return instance
 
     def _get_elements(self, keys):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -867,7 +867,8 @@ class Set(Serializable):
     def _from_element_patt(cls, pattern, parse_method, *args, **kwargs):
         instance = cls()
         for element_path in parse_method(pattern):
-            instance.add(cls._ELE_CLS.from_json(element_path, *args, **kwargs))
+            instance.add(cls.get_element_class().from_json(
+                element_path, *args, **kwargs))
         return instance
 
     def _get_elements(self, keys):
@@ -1906,7 +1907,8 @@ class Container(Serializable):
     def _from_element_patt(cls, pattern, parse_method, *args, **kwargs):
         instance = cls()
         for element_path in parse_method(pattern):
-            instance.add(cls._ELE_CLS.from_json(element_path, *args, **kwargs))
+            instance.add(cls.get_element_class().from_json(
+                element_path, *args, **kwargs))
         return instance
 
     def _get_elements(self, inds):

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -833,8 +833,10 @@ class Set(Serializable):
         Args:
              pattern: a pattern with one or more numeric sequences
                 example: "/path/to/labels/%05d.json"
-            *args: optional positional arguments for `cls.from_json()`
-            **kwargs: optional keyword arguments for `cls.from_json()`
+            *args: optional positional arguments for
+                `cls.get_element_class().from_json()`
+            **kwargs: optional keyword arguments for
+                `cls.get_element_class().from_json()`
 
         Returns:
             a `cls` instance
@@ -850,8 +852,10 @@ class Set(Serializable):
         Args:
              pattern: a glob pattern
                 example: "/path/to/labels/*.json"
-            *args: optional positional arguments for `cls.from_json()`
-            **kwargs: optional keyword arguments for `cls.from_json()`
+            *args: optional positional arguments for
+                `cls.get_element_class().from_json()`
+            **kwargs: optional keyword arguments for
+                `cls.get_element_class().from_json()`
 
         Returns:
             a `cls` instance
@@ -1868,8 +1872,10 @@ class Container(Serializable):
         Args:
              pattern: a pattern with one or more numeric sequences
                 example: "/path/to/labels/%05d.json"
-            *args: optional positional arguments for `cls.from_json()`
-            **kwargs: optional keyword arguments for `cls.from_json()`
+            *args: optional positional arguments for
+                `cls.get_element_class().from_json()`
+            **kwargs: optional keyword arguments for
+                `cls.get_element_class().from_json()`
 
         Returns:
             a `cls` instance
@@ -1885,8 +1891,10 @@ class Container(Serializable):
         Args:
              pattern: a glob pattern
                 example: "/path/to/labels/*.json"
-            *args: optional positional arguments for `cls.from_json()`
-            **kwargs: optional keyword arguments for `cls.from_json()`
+            *args: optional positional arguments for
+                `cls.get_element_class().from_json()`
+            **kwargs: optional keyword arguments for
+                `cls.get_element_class().from_json()`
 
         Returns:
             a `cls` instance

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -837,7 +837,6 @@ class Set(Serializable):
             *args: optional positional arguments for `cls.from_json()`
             **kwargs: optional keyword arguments for `cls.from_json()`
 
-
         Returns:
             a `cls` instance
         '''
@@ -854,7 +853,6 @@ class Set(Serializable):
                 example: "/path/to/labels/*.json"
             *args: optional positional arguments for `cls.from_json()`
             **kwargs: optional keyword arguments for `cls.from_json()`
-
 
         Returns:
             a `cls` instance
@@ -1862,6 +1860,47 @@ class Container(Serializable):
         cls = cls._validate_dict(d)
         elements = [cls._ELE_CLS.from_dict(dd) for dd in d[cls._ELE_ATTR]]
         return cls(**etau.join_dicts({cls._ELE_ATTR: elements}, kwargs))
+
+    @classmethod
+    def from_numeric_patt(cls, pattern, *args, **kwargs):
+        '''Creates an instance of `cls` from a numeric pattern of `_ELE_CLS`
+        files.
+
+        Args:
+             pattern: a pattern with one or more numeric sequences
+                example: "/path/to/labels/%05d.json"
+            *args: optional positional arguments for `cls.from_json()`
+            **kwargs: optional keyword arguments for `cls.from_json()`
+
+        Returns:
+            a `cls` instance
+        '''
+        parse_method = etau.get_pattern_matches
+        return cls._from_element_patt(pattern, parse_method, *args, *kwargs)
+
+    @classmethod
+    def from_glob_patt(cls, pattern, *args, **kwargs):
+        '''Creates an instance of `cls` from a numeric pattern of `_ELE_CLS`
+        files.
+
+        Args:
+             pattern: a glob pattern
+                example: "/path/to/labels/*.json"
+            *args: optional positional arguments for `cls.from_json()`
+            **kwargs: optional keyword arguments for `cls.from_json()`
+
+        Returns:
+            a `cls` instance
+        '''
+        parse_method = glob.glob
+        return cls._from_element_patt(pattern, parse_method, *args, *kwargs)
+
+    @classmethod
+    def _from_element_patt(cls, pattern, parse_method, *args, **kwargs):
+        instance = cls()
+        for element_path in parse_method(pattern):
+            instance.add(cls._ELE_CLS.from_json(element_path, *args, **kwargs))
+        return instance
 
     def _get_elements(self, inds):
         if isinstance(inds, numbers.Integral):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1933,7 +1933,7 @@ class VideoSetLabels(Set):
             a `cls` instance
         '''
         logger.warning("Using deprecated method `from_video_labels_patt`. Use"
-                       " `from_element_numeric_patt` instead.")
+                       " `from_numeric_patt` instead.")
         return cls.from_numeric_patt(video_labels_patt)
 
     @classmethod

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1934,7 +1934,7 @@ class VideoSetLabels(Set):
         '''
         logger.warning("Using deprecated method `from_video_labels_patt`. Use"
                        " `from_element_numeric_patt` instead.")
-        return cls.from_element_numeric_patt(video_labels_patt)
+        return cls.from_numeric_patt(video_labels_patt)
 
     @classmethod
     def from_dict(cls, d):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -31,6 +31,7 @@ import six
 
 from collections import defaultdict, OrderedDict
 import errno
+import glob
 import logging
 import os
 from subprocess import Popen, PIPE
@@ -1933,6 +1934,22 @@ class VideoSetLabels(Set):
         '''
         image_set_labels = cls()
         for labels_path in etau.get_pattern_matches(video_labels_patt):
+            image_set_labels.add(cls._ELE_CLS.from_json(labels_path))
+        return image_set_labels
+
+    @classmethod
+    def from_video_labels_glob_patt(cls, video_labels_patt):
+        '''Creates an instance of `cls` from a pattern of `_ELE_CLS` files.
+
+        Args:
+             video_labels_patt: a glob pattern:
+                example: "/path/to/labels/*.json"
+
+        Returns:
+            a `cls` instance
+        '''
+        image_set_labels = cls()
+        for labels_path in glob.glob(video_labels_patt):
             image_set_labels.add(cls._ELE_CLS.from_json(labels_path))
         return image_set_labels
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -31,7 +31,6 @@ import six
 
 from collections import defaultdict, OrderedDict
 import errno
-import glob
 import logging
 import os
 from subprocess import Popen, PIPE
@@ -48,6 +47,7 @@ import eta.core.gps as etag
 import eta.core.image as etai
 from eta.core.objects import DetectedObjectContainer
 from eta.core.serial import load_json, Serializable, Set, BigSet
+import eta.core.serial as etas
 import eta.core.utils as etau
 
 
@@ -1932,26 +1932,10 @@ class VideoSetLabels(Set):
         Returns:
             a `cls` instance
         '''
-        image_set_labels = cls()
-        for labels_path in etau.get_pattern_matches(video_labels_patt):
-            image_set_labels.add(cls._ELE_CLS.from_json(labels_path))
-        return image_set_labels
-
-    @classmethod
-    def from_video_labels_glob_patt(cls, video_labels_patt):
-        '''Creates an instance of `cls` from a pattern of `_ELE_CLS` files.
-
-        Args:
-             video_labels_patt: a glob pattern:
-                example: "/path/to/labels/*.json"
-
-        Returns:
-            a `cls` instance
-        '''
-        video_set_labels = cls()
-        for labels_path in glob.glob(video_labels_patt):
-            video_set_labels.add(cls._ELE_CLS.from_json(labels_path))
-        return video_set_labels
+        logger.warning("Using deprecated method `from_video_labels_patt`. Use"
+                       " `from_element_patt` instead.")
+        return cls.from_element_patt(
+            video_labels_patt, pattern_type=etas.NUMERIC)
 
     @classmethod
     def from_dict(cls, d):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1948,10 +1948,10 @@ class VideoSetLabels(Set):
         Returns:
             a `cls` instance
         '''
-        image_set_labels = cls()
+        video_set_labels = cls()
         for labels_path in glob.glob(video_labels_patt):
-            image_set_labels.add(cls._ELE_CLS.from_json(labels_path))
-        return image_set_labels
+            video_set_labels.add(cls._ELE_CLS.from_json(labels_path))
+        return video_set_labels
 
     @classmethod
     def from_dict(cls, d):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1933,9 +1933,8 @@ class VideoSetLabels(Set):
             a `cls` instance
         '''
         logger.warning("Using deprecated method `from_video_labels_patt`. Use"
-                       " `from_element_patt` instead.")
-        return cls.from_element_patt(
-            video_labels_patt, pattern_type=etas.NUMERIC)
+                       " `from_element_numeric_patt` instead.")
+        return cls.from_element_numeric_patt(video_labels_patt)
 
     @classmethod
     def from_dict(cls, d):


### PR DESCRIPTION
Any instance of `Set` that has an element class that is serializable may be loaded from a numeric or glob element pattern. I also deprecated the class methods in `eta.core.{image, video}`

Example usage:

```
set_labels = etav.VideoSetLabels.from_numeric_patt("%d_tele.json")
set_labels2 = etav.VideoSetLabels.from_glob_patt("*.json")
```