### PR TITLE
Version for startup message

### DIFF
--- a/eta/__init__.py
+++ b/eta/__init__.py
@@ -155,6 +155,9 @@ def is_python3():
     return sys.version_info[0] == 3
 
 
+# Version string
+version = "%s v%s, %s" % (etac.NAME, etac.VERSION, etac.AUTHOR)
+
 # Default logging behavior
 etal.basic_setup()
 


### PR DESCRIPTION
https://github.com/voxel51/eta/commit/6e0c657e54abdb5aef3a39c094f84c3fa89e7c19#diff-ec068de7500d585b97cec0e9f04c5cd9 removed `version`, but `startup_message()` in `__init__.py` still uses it.