### PR TITLE
Using version from `eta.constants`

### DIFF
--- a/eta/__init__.py
+++ b/eta/__init__.py
@@ -136,7 +136,7 @@ def set_config_settings(**kwargs):
 def startup_message():
     '''Logs ETA startup message.'''
     logger.info("Starting...\n" + _load_ascii_art())
-    logger.info(version)
+    logger.info(etac.VERSION_LONG)
     logger.info("Revision %s", etau.get_eta_rev())
 
 
@@ -154,9 +154,6 @@ def is_python3():
     '''Returns True/False whether the Python version running is 3.X.'''
     return sys.version_info[0] == 3
 
-
-# Version string
-version = "%s v%s, %s" % (etac.NAME, etac.VERSION, etac.AUTHOR)
 
 # Default logging behavior
 etal.basic_setup()


### PR DESCRIPTION
This was what I intended when removing `version` from `__init__` in https://github.com/voxel51/eta/commit/6e0c657e54abdb5aef3a39c094f84c3fa89e7c19#diff-ec068de7500d585b97cec0e9f04c5cd9.

I replaced all occurrences of `eta.version` with `etac.VERSION_LONG`, but missed `version` in `__init__.py` itself!