### PR TITLE
Enhancements to annotation rendering via ETA

### DIFF
--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -535,7 +535,7 @@ def _annotate_object(img, obj, annotation_config):
 
             attr_strs.append(
                 _render_attr_value(
-                    a, show_confidence=show_object_attr_confidences))
+                    attr, show_confidence=show_object_attr_confidences))
 
         # Draw attributes
         attrs_str = ", ".join(attr_strs)

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -397,8 +397,9 @@ def _annotate_image(img, labels, more_attrs, annotation_config):
     # Render frame attributes
     labels.attrs.sort_by_name()  # alphabetize
     attr_strs.extend(
-        labels.attrs, hide_attr_values, hide_false_boolean_attrs,
-        show_frame_attr_confidences)
+        _render_attrs(
+            labels.attrs, hide_attr_values, hide_false_boolean_attrs,
+            show_frame_attr_confidences))
 
     # Draw attributes panel
     if attr_strs:

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -46,6 +46,7 @@ class AnnotationConfig(Config):
             render the annotation boxes
         show_object_boxes: whether to show object bounding boxes, if available.
             If this is false, all attributes, confidences, etc. are also hidden
+        show_object_attrs: whether to show object attributes, if available.
         show_object_confidences: whether to show object label confidences, if
             available
         show_object_attr_confidences: whether to show object attribute
@@ -96,6 +97,8 @@ class AnnotationConfig(Config):
             d, "colormap_config", ColormapConfig, default=None)
         self.show_object_boxes = self.parse_bool(
             d, "show_object_boxes", default=True)
+        self.show_object_attrs = self.parse_bool(
+            d, "show_object_attrs", default=True)
         self.show_object_confidences = self.parse_bool(
             d, "show_object_confidences", default=False)
         self.show_object_attr_confidences = self.parse_bool(
@@ -429,6 +432,7 @@ def _annotate_frame_attrs(img, attr_strs, annotation_config):
 def _annotate_object(img, obj, annotation_config):
     # Parse config
     show_object_boxes = annotation_config.show_object_boxes
+    show_object_attrs = annotation_config.show_object_attrs
     show_object_confidences = (
         annotation_config.show_object_confidences or
         annotation_config.show_all_confidences)
@@ -525,7 +529,7 @@ def _annotate_object(img, obj, annotation_config):
     # Render object attributes
     #
 
-    if not obj.has_attributes:
+    if not show_object_attrs or not obj.has_attributes:
         return np.asarray(img_pil)
 
     # Render object attribute strings

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -68,8 +68,7 @@ class AnnotationConfig(Config):
         font_path: the path to the `PIL.ImageFont` to use
         font_size: the font size to use
         linewidth: the linewidth, in pixels, of the object bounding boxes
-        alpha: the transparency of the object bounding boxes and frame
-            attributes
+        alpha: the transparency of the object bounding boxes
         confidence_scaled_alpha: True will scale `alpha` and `mask_fill_alpha`
             by the object confidence
         text_color: the annotation text color
@@ -77,6 +76,8 @@ class AnnotationConfig(Config):
         object_text_pad_pixels: the padding, in pixels, around the text in the
             object labels
         attrs_bg_color: the background color for attributes boxes
+        attrs_bg_alpha: the transparency of the video/frame/object attributes
+            panel boxes
         attrs_box_gap: the gap between the frame attributes box and the upper
             left corner of the image
         attrs_text_pad_pixels: the padding, in pixels, around the text in the
@@ -122,6 +123,7 @@ class AnnotationConfig(Config):
         self.font_size = self.parse_number(d, "font_size", default=16)
         self.linewidth = self.parse_number(d, "linewidth", default=2)
         self.alpha = self.parse_number(d, "alpha", default=0.75)
+
         self.confidence_scaled_alpha = self.parse_bool(
             d, "confidence_scaled_alpha", default=False)
         self.text_color = self.parse_string(d, "text_color", default="#FFFFFF")
@@ -131,6 +133,8 @@ class AnnotationConfig(Config):
             d, "object_text_pad_pixels", default=2)
         self.attrs_bg_color = self.parse_string(
             d, "attrs_bg_color", default="#000000")
+        self.attrs_bg_alpha = self.parse_number(
+            d, "attrs_bg_alpha", default=0.5)
         self.attrs_box_gap = self.parse_string(
             d, "attrs_box_gap", default="1%")
         self.attrs_text_pad_pixels = self.parse_number(
@@ -563,12 +567,12 @@ def _annotate_object(img, obj, annotation_config):
 def _draw_attrs_panel(img, attr_strs, top_left_coords, annotation_config):
     # Parse config
     font = annotation_config.font
-    alpha = annotation_config.alpha
     box_pad = annotation_config.attrs_text_pad_pixels
     line_gap = annotation_config.attrs_text_line_spacing_pixels
     text_size = _compute_max_text_size(font, attr_strs)  # width, height
     text_color = tuple(_parse_hex_color(annotation_config.text_color))
     bg_color = _parse_hex_color(annotation_config.attrs_bg_color)
+    bg_alpha = annotation_config.attrs_bg_alpha
     num_attrs = len(attr_strs)
 
     overlay = img.copy()
@@ -582,7 +586,7 @@ def _draw_attrs_panel(img, attr_strs, top_left_coords, annotation_config):
     cv2.rectangle(overlay, (bgtlx, bgtly), (bgbrx, bgbry), bg_color, -1)
 
     # Overlay translucent box
-    img_anno = cv2.addWeighted(overlay, alpha, img, 1 - alpha, 0)
+    img_anno = cv2.addWeighted(overlay, bg_alpha, img, 1 - bg_alpha, 0)
 
     img_pil = Image.fromarray(img_anno)
     draw = ImageDraw.Draw(img_pil)

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -550,8 +550,8 @@ def _annotate_object(img, obj, annotation_config):
     # Method 2: draw attributes as panel
     if attrs_render_method == "panel":
         # Compute upper-left corner of attrs panel
-        atxttlx = objtlx + linewidth
-        atxttly = objtly - 1
+        atxttlx = objtlx + 2 * linewidth
+        atxttly = objtly + 2 * linewidth - 1
         top_left_coords = (atxttlx, atxttly)
 
         img_anno = _draw_attrs_panel(

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -46,7 +46,7 @@ class AnnotationConfig(Config):
             render the annotation boxes
         show_object_boxes: whether to show object bounding boxes, if available.
             If this is false, all attributes, confidences, etc. are also hidden
-        show_object_attrs: whether to show object attributes, if available.
+        show_object_attrs: whether to show object attributes, if available
         show_object_confidences: whether to show object label confidences, if
             available
         show_object_attr_confidences: whether to show object attribute
@@ -128,7 +128,8 @@ class AnnotationConfig(Config):
             d, "confidence_scaled_alpha", default=False)
         self.text_color = self.parse_string(d, "text_color", default="#FFFFFF")
         self.object_attrs_render_method = self.parse_categorical(
-            d, "object_attrs_render_method", ["list", "panel"], default="list")
+            d, "object_attrs_render_method", ["list", "panel"],
+            default="panel")
         self.object_text_pad_pixels = self.parse_number(
             d, "object_text_pad_pixels", default=2)
         self.attrs_bg_color = self.parse_string(

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -1,7 +1,7 @@
 '''
 Core utilities for rendering annotations on media.
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
@@ -94,7 +94,6 @@ class AnnotationConfig(Config):
     def __init__(self, d):
         self.colormap_config = self.parse_object(
             d, "colormap_config", ColormapConfig, default=None)
-
         self.show_object_boxes = self.parse_bool(
             d, "show_object_boxes", default=True)
         self.show_object_confidences = self.parse_bool(
@@ -117,13 +116,11 @@ class AnnotationConfig(Config):
             d, "hide_attr_values", default=None)
         self.hide_false_boolean_attrs = self.parse_bool(
             d, "hide_false_boolean_attrs", default=False)
-
         self.font_path = self.parse_string(
             d, "font_path", default=etac.DEFAULT_FONT_PATH)
         self.font_size = self.parse_number(d, "font_size", default=16)
         self.linewidth = self.parse_number(d, "linewidth", default=2)
         self.alpha = self.parse_number(d, "alpha", default=0.75)
-
         self.confidence_scaled_alpha = self.parse_bool(
             d, "confidence_scaled_alpha", default=False)
         self.text_color = self.parse_string(d, "text_color", default="#FFFFFF")


### PR DESCRIPTION
The following new parameters have been added to `eta.core.annotations.AnnotationConfig` (and thereby usable when running the `visualize_labels` module or `visualize_labels` pipeline):

The only non-backwards compatible change is that all object attributes will now be rendered as a `panel`.

**Object attribute rendering**
- `object_attrs_render_method = ["list", "panel"]`: the method used to render object attributes. Previous behavior was `list`. New option is `panel`, which renders object attributes in a panel in the same way that frame attributes are rendered. I find this far easier to grok, so I made `panel` the new default

**Handling of occluded objects**
- `occluded_object_attr`: the name of the boolean attribute indicating whether an object is occluded. Typically this is `occluded`
- `hide_occluded_objects = True/False`: whether to hide objects when their `occluded_object_attr` takes the value `False`

**Handling of boolean attributes**
- `hide_false_boolean_attrs = True/False`: whether to hide boolean attributes when they are `False`, rather than rendering `<attr>: False`

**Hiding of specific attribute values**
- `hide_attr_values = <list>`: an optional list of video/frame/object attribute values to NOT RENDER if they appear in the labels. A typical use of this is to hide attributes whose value is `unclear`

Example of how object attributes now look in panel-mode (the new default):
<img width="2555" alt="Screen Shot 2020-01-17 at 1 36 21 PM" src="https://user-images.githubusercontent.com/25985824/72637485-735de180-392f-11ea-99f1-6f32a77ba509.png">

Same labels as above, but hiding `unclear` attributes:
<img width="2545" alt="Screen Shot 2020-01-17 at 1 37 02 PM" src="https://user-images.githubusercontent.com/25985824/72637491-7658d200-392f-11ea-9c57-537d5d4ee1c4.png">
