### PR TITLE
Add `__getitem__()` method to LabeledDataset and LabeledDatasetIndex

### DIFF
--- a/eta/core/datasets.py
+++ b/eta/core/datasets.py
@@ -627,6 +627,15 @@ class LabeledDataset(object):
         '''Returns the number of data elements in the dataset'''
         return len(self.dataset_index)
 
+    def __getitem__(self, key):
+        '''Returns a LabeledDataRecord from `self.dataset_index` with the
+        given key.
+
+        Args:
+            key: an integer index into `self.dataset_index`
+        '''
+        return self.dataset_index[key]
+
     def iter_data(self):
         '''Iterates over the data in the dataset.
 
@@ -1686,6 +1695,9 @@ class LabeledDatasetIndex(Serializable):
 
     def __len__(self):
         return len(self.index)
+
+    def __getitem__(self, key):
+        return self.index[key]
 
     def append(self, labeled_data_record):
         '''Appends an entry to the index.


### PR DESCRIPTION
This allows you to access `LabeledDataRecord`s using the `__getitem__()` method on a `LabeledDataset`.  E.g. the following code should work.

```python
import eta.core.datasets as etad

dataset = etad.LabeledImageDataset("/path/to/image/dataset/manifest.json")
print(dataset[2])
```