### PR TITLE
initial draft of schema differencing

### DIFF
--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -740,12 +740,14 @@ class AttributeContainerSchema(Serializable):
         for name, attr_schema in iteritems(schema.schema):
             if name not in self.schema:
                 diff[name] = attr_schema
-            if name not in schema.schema:
-                diff[name] = schema.schema
             else:
                 attr_diff = self.schema[name].diff_schema(attr_schema)
                 if attr_diff:
                     diff[name] = attr_dif
+
+        for name, attr_schema in iteritems(self.schema):
+            if name not in diff:
+                diff[name] = attr_schema
 
         return AttributeContainerSchema(diff) if diff else None
 

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -7,6 +7,7 @@ voxel51.com
 Brian Moore, brian@voxel51.com
 Jason Corso, jason@voxel51.com
 Tyler Ganter, tyler@voxel51.com
+Ian Timmis, ian@voxel51.com
 '''
 # pragma pylint: disable=redefined-builtin
 # pragma pylint: disable=unused-wildcard-import

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -7,11 +7,12 @@ Notes:
         produced outside of this library must be converted to RGB. This
         conversion can be done via `eta.core.image.bgr_to_rgb()`
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
 Jason Corso, jason@voxel51.com
+Ian Timmis, ian@voxel51.com
 '''
 # pragma pylint: disable=redefined-builtin
 # pragma pylint: disable=unused-wildcard-import

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -423,6 +423,31 @@ class ImageLabelsSchema(Serializable):
         for k, v in iteritems(schema.objects):
             self.objects[k].merge_schema(v)
 
+    def diff_schema(self, schema):
+        '''Constructs a schema computed from the difference between self and 
+        the target ImageLabelsSchema object.
+            
+        Args:
+            target: an ImageLabelsSchema
+
+        Returns:
+            an ImageLabelsSchema or None
+        '''
+        attrs = self.attrs.diff_schema(schema.attrs)
+        objects = defaultdict(lambda: AttributeContainerSchema())
+
+        for k, v in iteritems(schema.objects):
+            if k in self.objects:
+                objects[k] = self.objects[k].diff_schema(schema.objects[k])
+            else:
+                objects[k].merge_schema(v)
+
+        for k, v in iteritems(self.objects):
+            if k not in objects:
+                objects[k].merge_schema(v)
+
+        return ImageLabelsSchema(attrs, objects)
+
     def is_valid_image_attribute(self, image_attr):
         '''Whether the image attribute is compliant with the schema.
 

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -438,7 +438,9 @@ class ImageLabelsSchema(Serializable):
 
         for k, v in iteritems(schema.objects):
             if k in self.objects:
-                objects[k] = self.objects[k].diff_schema(schema.objects[k])
+                diff = self.objects[k].diff_schema(schema.objects[k])
+                if diff:
+                    objects[k] = diff
             else:
                 objects[k].merge_schema(v)
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -9,11 +9,12 @@ Notes:
         produced outside of this library must be converted to RGB. This
         conversion can be done via `eta.core.image.bgr_to_rgb()`
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
 Jason Corso, jason@voxel51.com
+Ian Timmis, ian@voxel51.com
 '''
 # pragma pylint: disable=redefined-builtin
 # pragma pylint: disable=unused-wildcard-import

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1379,6 +1379,45 @@ class VideoLabelsSchema(Serializable):
         for k, v in iteritems(schema.objects):
             self.objects[k].merge_schema(v)
 
+    def diff_schema(self, schema):
+        '''Constructs a schema computed from the difference between self and 
+        the target VideoLabelsSchema object.
+            
+        Args:
+            target: an VideoLabelsSchema
+
+        Returns:
+            an VideoLabelsSchema or None
+        '''
+        attrs = self.attrs.diff_schema(schema.attrs)
+        frames = self.frames.diff_schema(schema.frames)
+        objects = defaultdict(lambda: AttributeContainerSchema())
+        events = defaultdict(lambda: AttributeContainerSchema())
+
+        # Objects
+        for k, v in iteritems(schema.objects):
+            if k in self.objects:
+                objects[k] = self.objects[k].diff_schema(schema.objects[k])
+            else:
+                objects[k].merge_schema(v)
+
+        for k, v in iteritems(self.objects):
+            if k not in objects:
+                objects[k].merge_schema(v)
+
+        # Events
+        for k, v in iteritems(schema.events):
+            if k in self.events:
+                events[k] = self.events[k].diff_schema(schema.events[k])
+            else:
+                events[k].merge_schema(v)
+
+        for k, v in iteritems(self.events):
+            if k not in events:
+                events[k].merge_schema(v)
+        
+        return VideoLabelsSchema(attrs, frames, objects, events)
+
     def is_valid_video_attribute(self, video_attr):
         '''Whether the video attribute is compliant with the schema.
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1397,7 +1397,9 @@ class VideoLabelsSchema(Serializable):
         # Objects
         for k, v in iteritems(schema.objects):
             if k in self.objects:
-                objects[k] = self.objects[k].diff_schema(schema.objects[k])
+                diff = self.objects[k].diff_schema(schema.objects[k])
+                if diff:
+                    objects[k] = diff
             else:
                 objects[k].merge_schema(v)
 
@@ -1408,7 +1410,9 @@ class VideoLabelsSchema(Serializable):
         # Events
         for k, v in iteritems(schema.events):
             if k in self.events:
-                events[k] = self.events[k].diff_schema(schema.events[k])
+                diff = self.events[k].diff_schema(schema.events[k])
+                if diff:
+                    events[k] = diff
             else:
                 events[k].merge_schema(v)
 


### PR DESCRIPTION
[DRAFT: This feels done, but haven't tested yet. Doing that now]

A new function `diff_schema` has been as a method of comparing schemas. It has been added to the following classes:

AttributeSchemaContainer
AttributeSchema
BooleanAttributeSchema
NumericAttributeSchema
CategoricalAttributeSchema
ImageLabelsSchema
VideoLabelsSchema

(Anywhere where we find merge_schema)

Example:
```py
# Constructs a schema containing the set difference between schema_1 and schema_2
diff_set = schema_1.diff_schema(schema_2)

# Constructs schemas for attributes only contained in schema_1  and in schema_2 respectively
schema_1_only = schema_1.diff_schema(diff_set)
schema_2_only = schema_2.diff_schema(diff_set)

# If no difference is found, then None is returned
empty_schema = schema_1.diff_schema(schema_1)
```