### PR TITLE
Small enhancements to modules/pipelines

### DIFF
--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -60,7 +60,7 @@ def find_last_built_pipeline():
     if not builds:
         return None
 
-    config_dir = max(builds, key=lambda b: os.path.basename(b))
+    config_dir = max(builds, key=os.path.basename)
     return os.path.join(config_dir, PIPELINE_CONFIG_FILE)
 
 
@@ -301,7 +301,22 @@ class PipelineBuilder(object):
             request: a PipelineBuildRequest instance
         '''
         self.request = request
+
+        self.optimized = None
+        self.timestamp = None
+        self.config_dir = None
+        self.output_dir = None
+        self.pipeline_config_path = None
+        self.pipeline_status_path = None
+        self.pipeline_logfile_path = None
+        self.execution_order = None
+        self.module_inputs = None
+        self.module_outputs = None
+        self.module_parameters = None
+        self.pipeline_outputs = None
+
         self._concrete_data_params = etat.ConcreteDataParams()
+
         self.reset()
 
     def reset(self):
@@ -371,9 +386,9 @@ class PipelineBuilder(object):
         '''
         if not self.pipeline_config_path:
             raise PipelineBuilderError(
-                "You must build the pipeline before running it")
+                "No pipeline config found; you must build the pipeline before "
+                "running it")
 
-        # Run pipeline
         return etap.run(self.pipeline_config_path)
 
     def cleanup(self):
@@ -587,8 +602,7 @@ class PipelineBuilder(object):
 
 
 class PipelineBuilderError(Exception):
-    '''Exception raised when an invalid action is taken with a
-    PipelineBuilder.
+    '''Exception raised when an invalid action is taken with a PipelineBuilder.
     '''
     pass
 

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -1,7 +1,7 @@
 '''
 Core pipeline building system.
 
-Copyright 2018, Voxel51, Inc.
+Copyright 2018-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
@@ -32,6 +32,7 @@ import eta.core.job as etaj
 import eta.core.logging as etal
 import eta.core.module as etam
 import eta.core.pipeline as etap
+import eta.core.status as etas
 import eta.core.types as etat
 import eta.core.utils as etau
 
@@ -118,6 +119,19 @@ def cleanup_all_pipelines():
     '''Cleans up all built pipelines.'''
     for pipeline_config_path in find_all_built_pipelines():
         cleanup_pipeline(pipeline_config_path)
+
+
+class ModuleConfig(etam.BaseModuleConfig):
+    '''Module configuration class.
+
+    This generic class is used by `PipelineBuilder` to build module
+    configuration files of any type.
+    '''
+
+    def __init__(self, d):
+        super(ModuleConfig, self).__init__(d)
+        self.data = self.parse_array(d, "data", default=[])
+        self.parameters = self.parse_dict(d, "parameters", default={})
 
 
 class PipelineBuildRequestConfig(Config):
@@ -531,7 +545,7 @@ class PipelineBuilder(object):
             # Build module config
             data = etau.join_dicts(
                 self.module_inputs[module], self.module_outputs[module])
-            module_config = (etam.GenericModuleConfig.builder()
+            module_config = (ModuleConfig.builder()
                 .set(data=[data])
                 .set(parameters=self.module_parameters[module])
                 .validate())

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -391,6 +391,22 @@ class PipelineBuilder(object):
 
         return etap.run(self.pipeline_config_path)
 
+    def get_status(self):
+        '''Gets the PipelineStatus for the last run pipeline.
+
+        Returns:
+            a PipelineStatus instance
+
+        Raises:
+            PipelineBuilderError: if the pipeline hasn't been built and run
+        '''
+        if not os.path.exists(self.pipeline_status_path):
+            raise PipelineBuilderError(
+                "No pipeline status found; you must build and run the "
+                "pipeline before getting its status")
+
+        return etas.PipelineStatus.from_json(self.pipeline_status_path)
+
     def cleanup(self):
         '''Cleans up the configs and output files generated when the pipeline
         was run, if necessary. Published outputs are NOT deleted.

--- a/eta/core/module.py
+++ b/eta/core/module.py
@@ -4,7 +4,7 @@ Core module infrastructure.
 See `docs/modules_dev_guide.md` for detailed information about the design and
 usage of ETA modules.
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
@@ -38,8 +38,8 @@ import eta.core.utils as etau
 logger = logging.getLogger(__name__)
 
 
-def run(module_name, module_config_path):
-    '''Runs the specified module with the given ModuleConfig.
+def run(module_name, module_config_or_path):
+    '''Runs the specified module with the given config.
 
     This is a convenience function for running modules programmatically. This
     function is not used directly by pipelines when running modules, and, as
@@ -47,11 +47,25 @@ def run(module_name, module_config_path):
 
     Args:
         module_name: the name of the module
-        module_config_path: path to a ModuleConfig to run
+        module_config_or_path: a ModuleConfig or path to one on disk. If a
+            ModuleConfig is provided in-memory, it is written to a temporary
+            directory on disk while the module executes
 
     Returns:
         True/False whether the module completed successfully
     '''
+    if etau.is_str(module_config_or_path):
+        # Found a path to a module config on disk
+        return _run(module_name, module_config_or_path)
+
+    # Found an in-memory module config
+    with etau.TempDir() as d:
+        module_config_path = os.path.join(d, "config.json")
+        module_config_or_path.write_json(module_config_path)
+        return _run(module_name, module_config_path)
+
+
+def _run(module_name, module_config_path):
     module_exe = find_exe(module_name)
     args = ["python", module_exe, module_config_path]
     return etau.call(args)

--- a/eta/core/module.py
+++ b/eta/core/module.py
@@ -257,18 +257,6 @@ class BaseModuleConfigSettings(Config):
             default=etal.LoggingConfig.default())
 
 
-class GenericModuleConfig(Config):
-    '''Generic module configuration class.
-
-    This class is used by `eta.core.builder.PipelineBuilder` to build
-    module configuration files.
-    '''
-
-    def __init__(self, d):
-        self.data = self.parse_array(d, "data", default=[])
-        self.parameters = self.parse_dict(d, "parameters", default={})
-
-
 class ModuleMetadataConfig(Config):
     '''Module metadata configuration class.'''
 

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -4,7 +4,7 @@ Core pipeline infrastructure.
 See `docs/pipelines_dev_guide.md` for detailed information about the design of
 the ETA pipeline system.
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
@@ -48,12 +48,14 @@ PIPELINE_OUTPUT_NAME = "OUTPUT"
 
 
 def run(
-        pipeline_config_path, pipeline_status=None, mark_as_complete=True,
+        pipeline_config_or_path, pipeline_status=None, mark_as_complete=True,
         handle_failures=True, rotate_logs=True, force_overwrite=False):
     '''Run the pipeline specified by the PipelineConfig.
 
     Args:
-        pipeline_config_path: path to a PipelineConfig file
+        pipeline_config_or_path: a PipelineConfig or a path to one on disk. If
+            a PipelineConfig is provided in-memory, it is written to a
+            temporary directory on disk while the pipeline executes
         pipeline_status: an optional PipelineStatus instance. By default, a
             PipelineStatus object is created that logs its status to the path
             specified in the provided PipelineConfig
@@ -76,8 +78,21 @@ def run(
         PipelineExecutionError: if the pipeline failed and `handle_failures` is
             False
     '''
-    # Load pipeline config
-    pipeline_config = PipelineConfig.from_json(pipeline_config_path)
+    # Parse PipelineConfig
+    if etau.is_str(pipeline_config_or_path):
+        # Found a path to a pipeline config on disk
+        temp_dir = None
+        pipeline_config_path = pipeline_config_or_path
+        pipeline_config = PipelineConfig.from_json(pipeline_config_path)
+    else:
+        # Found an in-memory pipeline config
+        temp_dir = etau.TempDir()
+        pipeline_config_path = os.path.join(
+            temp_dir.__enter__(), "pipeline.json")
+        pipeline_config = pipeline_config_or_path
+        pipeline_config.write_json(pipeline_config_path)
+
+    # Force overwrite, if requested
     if force_overwrite:
         pipeline_config.overwrite = True
 
@@ -96,9 +111,15 @@ def run(
     pipeline_config_path = os.path.abspath(pipeline_config_path)
 
     # Run pipeline
-    return _run(
+    status = _run(
         pipeline_config, pipeline_config_path, pipeline_status,
         mark_as_complete, handle_failures)
+
+    # Cleanup, if necessary
+    if temp_dir is not None:
+        temp_dir.__exit__()
+
+    return status
 
 
 def _make_pipeline_status(pipeline_config):

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -474,8 +474,10 @@ class PipelineParameter(object):
             raise PipelineMetadataError(
                 "Pipeline parameter '%s' is required, so it has no default "
                 "value" % self.param_str)
-        elif self.has_set_value:
+
+        if self.has_set_value:
             return self.set_value
+
         return self.param.default_value
 
     @property

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -107,6 +107,20 @@ def has_gpu():
         return False
 
 
+def get_int_pattern_with_capacity(max_number):
+    '''Gets a zero-padded integer pattern like "%%02d" or "%%03d" with
+    sufficient capacity for the given number.
+
+    Args:
+        max_number: the maximum number you intend to pass to the pattern
+
+    Returns:
+        a zero-padded integer formatting pattern
+    '''
+    num_digits = max(1, math.ceil(math.log10(1 + max_number)))
+    return "%%0%dd" % num_digits
+
+
 def fill_patterns(string, patterns):
     '''Fills the patterns, if any, in the given string.
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -22,7 +22,8 @@ import six
 # pragma pylint: enable=wildcard-import
 
 from collections import defaultdict
-import datetime
+from datetime import datetime
+import dateutil.parser
 import errno
 import glob
 import glob2
@@ -82,8 +83,24 @@ def standarize_strs(arg):
 
 
 def get_isotime():
-    '''Gets the local time in ISO 8601 format: "YYYY-MM-DD HH:MM:SS".'''
-    return str(datetime.datetime.now().replace(microsecond=0))
+    '''Gets the local time in "YYYY-MM-DD HH:MM:SS" format.
+
+    Returns:
+        an "YYYY-MM-DD HH:MM:SS" string
+    '''
+    return str(datetime.now().replace(microsecond=0))
+
+
+def parse_isotime(isotime_str):
+    '''Parses the ISO time string into a datetime.
+
+    Args:
+        isotime_str: an ISO time string like "YYYY-MM-DD HH:MM:SS"
+
+    Returns:
+        a datetime
+    '''
+    return dateutil.parser.parse(isotime_str)
 
 
 def get_eta_rev():

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -1,7 +1,7 @@
 '''
 Core system and file I/O utilities.
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com


### PR DESCRIPTION
Change log:
- support for loading the `PipelineStatus` of a pipeline built + run via `eta.core.builder.PipelineBuilder`
- support for passing a `ModuleConfig` directly to `eta.core.module.run`
- support for passing a `PipelineConfig` directly to `eta.core.pipeline.run`