### PR TITLE
Adding support for parsing GoPro GPS data

### DIFF
--- a/eta/core/frames.py
+++ b/eta/core/frames.py
@@ -1,7 +1,7 @@
 '''
 Core utilities for working with frame numbers of videos.
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
@@ -19,11 +19,10 @@ import six
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
-import pytz
-
 import numpy as np
 
 from eta.core.serial import Serializable
+import eta.core.utils as etau
 
 
 def frame_number_to_timestamp(frame_number, total_frame_count, duration):
@@ -88,44 +87,7 @@ def world_time_to_timestamp(world_time, start_time):
     Returns:
         the corresponding timestamp (in seconds) in the video
     '''
-    try:
-        return (world_time - start_time).total_seconds()
-    except (TypeError, ValueError):
-        world_time = add_utc_timezone_if_necessary(world_time)
-        start_time = add_utc_timezone_if_necessary(start_time)
-        return (world_time - start_time).total_seconds()
-
-
-def add_local_timezone_if_necessary(dt):
-    '''Makes the datetime timezone-aware, if necessary, by setting its timezone
-    to the local timezone.
-
-    Args:
-        dt: a datetime
-
-    Returns:
-        a timezone-aware datetime
-    '''
-    if dt.tzinfo is None:
-        dt = dt.astimezone()  # empty ==> local timezone
-
-    return dt
-
-
-def add_utc_timezone_if_necessary(dt):
-    '''Makes the datetime timezone-aware, if necessary, by setting its timezone
-    to UTC.
-
-    Args:
-        dt: a datetime
-
-    Returns:
-        a timezone-aware datetime
-    '''
-    if dt.tzinfo is None:
-        dt = dt.astimezone(pytz.utc)
-
-    return dt
+    return etau.datetime_delta_seconds(start_time, world_time)
 
 
 def world_time_to_frame_number(

--- a/eta/core/frames.py
+++ b/eta/core/frames.py
@@ -78,7 +78,7 @@ def world_time_to_timestamp(world_time, start_time):
     '''Converts the given world time to a timestamp in a video.
 
     If one (but not both) of the datetimes are timezone-aware, the other
-    datetime is assumed to be expressed in UTC time
+    datetime is assumed to be expressed in UTC time.
 
     Args:
         world_time: a datetime describing a time of interest

--- a/eta/core/gps.py
+++ b/eta/core/gps.py
@@ -2,7 +2,7 @@
 '''
 Core utilities for working with GPS coordinates.
 
-Copyright 2019, Voxel51, Inc.
+Copyright 2019-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
@@ -50,6 +50,14 @@ class GPSWaypoints(etas.Serializable):
         self._flat = None
         self._flon = None
         self._init_gps()
+
+    def __len__(self):
+        '''The number of waypoints in this instance.'''
+        return len(self.points)
+
+    def __bool__(self):
+        '''Whether this instance contains any waypoints.'''
+        return bool(self.points)
 
     @property
     def has_points(self):

--- a/eta/core/gps.py
+++ b/eta/core/gps.py
@@ -276,8 +276,8 @@ def parse_gopro_geojson(geojson_path, video_metadata):
     # Load GeoJSON
     g = etas.load_json(geojson_path)
     coordinates = g["geometry"]["coordinates"]
-    # Note that, despite `MicroSec` in the name, this seems to actually
-    # be expressed in millisecones...
+    # Note that, despite `MicroSec` in the name, this seems to be expressed in
+    # milliseconds...
     timestamps = g["properties"]["RelativeMicroSec"]
 
     # Convert to GPSWaypoints

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -34,6 +34,7 @@ import logging
 import math
 import mimetypes
 import os
+import pytz
 import random
 import re
 import shutil
@@ -102,6 +103,63 @@ def parse_isotime(isotime_str):
     '''
     return dateutil.parser.parse(isotime_str)
 
+
+def datetime_delta_seconds(time1, time2):
+    '''Computes the difference between the two datetimes, in seconds.
+
+    If either time is None, a delta of None is returned.
+
+    If one (but not both) of the datetimes are timezone-aware, the other
+    datetime is assumed to be expressed in UTC time.
+
+    Args:
+        time1: a datetime
+        time2: a datetime
+
+    Returns:
+        the time difference, in seconds
+    '''
+    if time1 is None or time2 is None:
+        return None
+
+    try:
+        return (time2 - time1).total_seconds()
+    except (TypeError, ValueError):
+        time1 = add_utc_timezone_if_necessary(time1)
+        time2 = add_utc_timezone_if_necessary(time2)
+        return (time2 - time1).total_seconds()
+
+
+def add_local_timezone_if_necessary(dt):
+    '''Makes the datetime timezone-aware, if necessary, by setting its timezone
+    to the local timezone.
+
+    Args:
+        dt: a datetime
+
+    Returns:
+        a timezone-aware datetime
+    '''
+    if dt.tzinfo is None:
+        dt = dt.astimezone()  # empty ==> local timezone
+
+    return dt
+
+
+def add_utc_timezone_if_necessary(dt):
+    '''Makes the datetime timezone-aware, if necessary, by setting its timezone
+    to UTC.
+
+    Args:
+        dt: a datetime
+
+    Returns:
+        a timezone-aware datetime
+    '''
+    if dt.tzinfo is None:
+        dt = dt.astimezone(pytz.utc)
+
+    return dt
 
 def get_eta_rev():
     '''Returns the hash of the last commit to the current ETA branch or "" if


### PR DESCRIPTION
Convert GPS data from a GoPro camera to `GPSWaypoints` format:

```py
import eta.core.gps as etag
import eta.core.video as etav

video_path = "/path/to/video.mp4"
video_metadata = etav.VideoMetadata.build_for(video_path)

# Parse GPS in GeoJSON format
gopro_geojson_path = "/path/to/video.geojson"
gps_waypoints1 = etag.parse_gopro_geojson(gopro_geojson_path, video_metadata)

# Parse GPS in GPS5 format
gopro_gps5_json_path = "/path/to/video.json"
gps_waypoints2 = etag.parse_gopro_gps5(gopro_gps5_json_path, video_metadata)
```