### PR TITLE
Added subschema validation

### DIFF
--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -7,11 +7,12 @@ Notes:
         produced outside of this library must be converted to RGB. This
         conversion can be done via `eta.core.image.bgr_to_rgb()`
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
 Jason Corso, jason@voxel51.com
+Ian Timmis, ian@voxel51.com
 '''
 # pragma pylint: disable=redefined-builtin
 # pragma pylint: disable=unused-wildcard-import
@@ -484,6 +485,32 @@ class ImageLabelsSchema(Serializable):
             return True
         except (ImageLabelsSchemaError, AttributeContainerSchemaError):
             return False
+
+    def is_valid_subset_schema(self, schema):
+        '''Validates that the provided schema is a subset of self
+        
+        Args:
+            schema: an ImageLabelsSchema
+        Returns:
+            True/False
+        '''
+
+        # Validate frame attributes
+        for attr in schema.attrs:
+            if not self.is_valid_image_attribute(attr):
+                return False
+
+        # Validate objects
+        for obj in schema.objects:
+            if not self.is_valid_object_label(obj):
+                return False
+
+            # Validate object attributes
+            for attr in schema.objecs[obj].schema
+                if not self.is_valid_object_attribute(attr):
+                    return False
+
+        return True
 
     def validate_image_attribute(self, image_attr):
         '''Validates that the image attribute is compliant with the schema.

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -9,11 +9,12 @@ Notes:
         produced outside of this library must be converted to RGB. This
         conversion can be done via `eta.core.image.bgr_to_rgb()`
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
 Jason Corso, jason@voxel51.com
+Ian Timmis, ian@voxel51.com
 '''
 # pragma pylint: disable=redefined-builtin
 # pragma pylint: disable=unused-wildcard-import
@@ -1502,6 +1503,48 @@ class VideoLabelsSchema(Serializable):
             return True
         except:
             return False
+
+    def is_valid_subset_schema(self, schema):
+        '''Validates that the provided schema is a subset of self
+        
+        Args:
+            schema: a VideoLabelsSchema
+
+        Returns:
+            True/False
+        '''
+
+        # Validate video attributes
+        for attr in schema.attrs:
+            if not self.is_valid_video_attribute(attr):
+                return False
+
+        # Validate frame attributes
+        for attr in schema.frames:
+            if not self.is_valid_frame_attribute(attr):
+                return False
+
+        # Validate objects
+        for obj in schema.objects:
+            if not self.is_valid_object_label(obj):
+                return False
+
+            # Validate object attributes
+            for attr in schema.objecs[obj].schema
+                if not self.is_valid_object_attribute(attr):
+                    return False
+
+        # Validate events
+        for event in schema.events:
+            if not self.is_valid_event_label(event):
+                return False
+
+            # Validate event attributes
+            for attr in schema.events[event].schema:
+                if not self.is_valid_event_attribute(attr):
+                    return False
+
+        return True
 
     def validate_video_attribute(self, video_attr):
         '''Validates that the video attribute is compliant with the schema.


### PR DESCRIPTION
Added functionality to determine whether a VideoLabelsSchema is a subset of another VideoLabelsSchema. Likewise with ImageLabelsSchema.

```py
from eta.core.video import VideoLabelsSchema

ont_schema = VideoLabelsSchema.from_json('ontology.json')
cov_schema = VideoLabelsSchema.from_json('coverage.json')

print(ont_schema.is_valid_subset_schema(cov_schema)) # Prints True
```