### PR TITLE
Adding method to read video as in-memory array

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2766,7 +2766,7 @@ def get_raw_frame_number(raw_frame_rate, raw_frame_count, fps, sampled_frame):
 def read_video_as_array(video_path):
     '''Reads the video from the given path into an in-memory array.
 
-    CAUTION: in-memory videos are hude; use this at your own risk!
+    CAUTION: in-memory videos are huge; use this at your own risk!
 
     Args:
         video_path: the path to the video to load

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2772,7 +2772,7 @@ def read_video_as_array(video_path):
         video_path: the path to the video to load
 
     Returns:
-        a numpy array of size [num_frames, height, width, num_channels]
+        a numpy array of size (num_frames, height, width, num_channels)
     '''
     with FFmpegVideoReader(video_path) as vr:
         return np.asarray([img for img in vr])
@@ -3020,7 +3020,7 @@ def sample_first_frames(imgs_or_video_path, k, stride=1, size=None):
 
     Args:
         imgs_or_video_path: can be either the path to the input video or an
-            array of frames of size [num_frames, height, width, num_channels]
+            array of frames of size (num_frames, height, width, num_channels)
         k: number of frames to extract
         stride: number of frames to be skipped in between. By default, a
             contiguous array of frames in extracted
@@ -3066,7 +3066,7 @@ def uniformly_sample_frames(imgs_or_video_path, k, size=None):
 
     Args:
         imgs_or_video_path: can be either the path to the input video or an
-            array of frames of size [num_frames, height, width, num_channels]
+            array of frames of size (num_frames, height, width, num_channels)
         k: the number of frames to extract
         size: an optional (width, height) to resize the sampled frames. By
             default, the native dimensions of the frames are used
@@ -3109,7 +3109,7 @@ def sliding_window_sample_frames(imgs_or_video_path, k, stride, size=None):
 
     Args:
         imgs_or_video_path: can be either the path to the input video or an
-            array of frames of size [num_frames, height, width, num_channels]
+            array of frames of size (num_frames, height, width, num_channels)
         k: the size of each window
         stride: the stride for sliding window
         size: an optional (width, height) to resize the sampled frames. By

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2763,6 +2763,21 @@ def get_raw_frame_number(raw_frame_rate, raw_frame_count, fps, sampled_frame):
     return int(raw_frame)
 
 
+def read_video_as_array(video_path):
+    '''Reads the video from the given path into an in-memory array.
+
+    CAUTION: in-memory videos are hude; use this at your own risk!
+
+    Args:
+        video_path: the path to the video to load
+
+    Returns:
+        a numpy array of size [num_frames, height, width, num_channels]
+    '''
+    with FFmpegVideoReader(video_path) as vr:
+        return np.asarray([img for img in vr])
+
+
 def extract_clip(
         video_path, output_path, start_time=None, duration=None, fast=False):
     '''Extracts the specified clip from the video.


### PR DESCRIPTION
Self explanatory.

Test code:
```py
'''
# Download test video to work with
eta gdrive download 1mhlzOXgcmQJtjnEHpu2g1o-Zk2n0QNXn /path/to/test.mp4
'''

import eta.core.video as etav

inpath = "/path/to/test.mp4"

imgs = etav.read_video_as_array(inpath)

print(etav.VideoMetadata.build_for(inpath))
print(imgs.shape)
```

Test output:
```shell
{
    "frame_size": [
        1920,
        1080
    ],
    "frame_rate": 30.0,
    "total_frame_count": 30,
    "duration": 1.0,
    "size_bytes": 1526755,
    "mime_type": "video/mp4",
    "encoding_str": "avc1"
}
(30, 1080, 1920, 3)
```