### PR TITLE
Adding more logging to core video-input modules

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -92,6 +92,38 @@ def standarize_strs(arg):
     return arg
 
 
+def summarize_long_str(s, max_len, mode="middle"):
+    '''Renders a shorter version of a long string (if necessary) to meet a
+    given length requirement by replacing part of the string with "..."
+
+    Args:
+        s: a string
+        max_len: the desired maximum length
+        mode: the summary mode, which controls which portion of long strings
+            is deleted. Supported values are ("first", "middle", "last")
+
+    Returns:
+        the summarized string
+    '''
+    if len(s) <= max_len:
+        return s
+
+    _mode = mode.lower()
+
+    if _mode == "first":
+        return "... " + s[-(max_len - 4):]
+
+    if _mode == "middle":
+        len1 = math.ceil(0.5 * (max_len - 5))
+        len2 = math.floor(0.5 * (max_len - 5))
+        return s[:len1] + " ... " + s[-len2:]
+
+    if _mode == "last":
+        return s[:(max_len - 4)] + " ..."
+
+    raise ValueError("Unsupported mode '%s'" % mode)
+
+
 def get_localtime():
     '''Gets the local time in "YYYY-MM-DD HH:MM:SS" format.
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -100,7 +100,8 @@ def summarize_long_str(s, max_len, mode="middle"):
         s: a string
         max_len: the desired maximum length
         mode: the summary mode, which controls which portion of long strings
-            is deleted. Supported values are ("first", "middle", "last")
+            are deleted. Supported values are ("first", "middle", "last"). The
+            default is "middle"
 
     Returns:
         the summarized string

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -162,7 +162,7 @@ def glob_videos(dir_):
 
 
 def get_video_metadata(video_path, log=False):
-    '''Gets VideoMetadata for the given path, and log generously.
+    '''Builds a VideoMetadata for the given video.
 
     Args:
         video_path: the path to the video

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2925,8 +2925,7 @@ def _sample_select_frames_fast(video_path, frames, output_patt, size):
             ffmpeg.run(video_path, tmp_patt)
         except etau.ExecutableRuntimeError as e:
             # Graceful failure if frames couldn't be sampled
-            msg = etau.summarize_long_str(str(e), 500)
-            logger.warning(msg)
+            logger.warning(etau.summarize_long_str(str(e), 500))
             logger.warning(
                 "A sampling error occured; attempting to gracefully continue")
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2925,7 +2925,8 @@ def _sample_select_frames_fast(video_path, frames, output_patt, size):
             ffmpeg.run(video_path, tmp_patt)
         except etau.ExecutableRuntimeError as e:
             # Graceful failure if frames couldn't be sampled
-            logger.warning(e, exc_info=True)
+            msg = etau.summarize_long_str(str(e), 500)
+            logger.warning(msg)
             logger.warning(
                 "A sampling error occured; attempting to gracefully continue")
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -194,7 +194,8 @@ class VideoMetadata(etas.Serializable):
     '''Class encapsulating metadata about a video.
 
     Attributes:
-        start_time: a datetime describing the start (world) time of the video
+        start_time: (optional) a datetime describing the start (world) time of
+            the video
         frame_size: the [width, height] of the video frames
         frame_rate: the frame rate of the video
         total_frame_count: the total number of frames in the video
@@ -202,8 +203,8 @@ class VideoMetadata(etas.Serializable):
         size_bytes: the size of the video file on disk, in bytes
         mime_type: the MIME type of the video
         encoding_str: the encoding string for the video
-        gps_waypoints: a GPSWaypoints instance describing the GPS coordinates
-            for the video
+        gps_waypoints: (optional) a GPSWaypoints instance describing the GPS
+            coordinates for the video
     '''
 
     def __init__(
@@ -213,7 +214,8 @@ class VideoMetadata(etas.Serializable):
         '''Creates a VideoMetadata instance.
 
         Args:
-            start_time: a datetime describing
+            start_time: (optional) a datetime describing the start (world) time
+                of the video
             frame_size: the [width, height] of the video frames
             frame_rate: the frame rate of the video
             total_frame_count: the total number of frames in the video
@@ -221,8 +223,8 @@ class VideoMetadata(etas.Serializable):
             size_bytes: the size of the video file on disk, in bytes
             mime_type: the MIME type of the video
             encoding_str: the encoding string for the video
-            gps_waypoints: a GPSWaypoints instance describing the GPS
-                coordinates for the video
+            gps_waypoints: (optional) a GPSWaypoints instance describing the
+                GPS coordinates for the video
         '''
         self.start_time = start_time
         self.frame_size = frame_size
@@ -235,8 +237,14 @@ class VideoMetadata(etas.Serializable):
         self.gps_waypoints = gps_waypoints
 
     @property
+    def aspect_ratio(self):
+        '''The aspect ratio of the video.'''
+        width, height = self.frame_size
+        return width * 1.0 / height
+
+    @property
     def has_gps(self):
-        '''Returns True/False if this object has GPS waypoints.'''
+        '''Whether this object has GPS waypoints.'''
         return self.gps_waypoints is not None
 
     def get_timestamp(self, frame_number=None, world_time=None):
@@ -362,8 +370,10 @@ class VideoMetadata(etas.Serializable):
         if isinstance(gps_waypoints, dict):
             gps_waypoints = etag.GPSWaypoints.from_dict(gps_waypoints)
         elif isinstance(gps_waypoints, list):
-            # this supports a list of GPSWaypoint instances rather than a
+            #
+            # This supports a list of GPSWaypoint instances rather than a
             # serialized GPSWaypoints instance. for backwards compatability
+            #
             points = [etag.GPSWaypoint.from_dict(p) for p in gps_waypoints]
             gps_waypoints = etag.GPSWaypoints(points=points)
 
@@ -2165,7 +2175,6 @@ class VideoLabelsSchema(etal.LabelsSchema):
             _attrs.append("objects")
         if self.events:
             _attrs.append("events")
-
         return _attrs
 
     @classmethod
@@ -2533,7 +2542,7 @@ class VideoStreamInfo(etas.Serializable):
         '''The (width, height) of each frame.
 
         Raises:
-            VideoStreamInfoError if the frame size could not be determined
+            VideoStreamInfoError: if the frame size could not be determined
         '''
         try:
             return (
@@ -2548,8 +2557,8 @@ class VideoStreamInfo(etas.Serializable):
     def aspect_ratio(self):
         '''The aspect ratio of the video.
 
-        Raises a VideoStreamInfoError if the frame size could not be
-        determined.
+        Raises:
+            VideoStreamInfoError: if the frame size could not be determined
         '''
         width, height = self.frame_size
         return width * 1.0 / height
@@ -2682,7 +2691,14 @@ class VideoStreamInfo(etas.Serializable):
 
     @classmethod
     def from_dict(cls, d):
-        '''Constructs a VideoStreamInfo from a JSON dictionary.'''
+        '''Constructs a VideoStreamInfo from a JSON dictionary.
+
+        Args:
+            d: a JSON dictionary
+
+        Returns:
+            a VideoStreamInfo
+        '''
         stream_info = d["stream_info"]
         format_info = d["format_info"]
         mime_type = d.get("mime_type", None)
@@ -2690,9 +2706,7 @@ class VideoStreamInfo(etas.Serializable):
 
 
 class VideoStreamInfoError(Exception):
-    '''Exception raised when an invalid video stream info dictionary is
-    encountered.
-    '''
+    '''Exception raised when a problem with a VideoStreamInfo occurs.'''
     pass
 
 

--- a/eta/modules/format_videos.py
+++ b/eta/modules/format_videos.py
@@ -175,10 +175,13 @@ def _process_video(input_path, output_path, parameters):
     max_size = parameters.max_size
     ffmpeg_out_opts = parameters.ffmpeg_out_opts
 
-    # Get input video details
-    stream_info = etav.VideoStreamInfo.build_for(input_path)
-    ifps = stream_info.frame_rate
-    isize = stream_info.frame_size
+    # Get input video metadata
+    video_metadata = etav.VideoMetadata.build_for(input_path)
+    logger.info("Processing video '%s'", input_path)
+    logger.info("Found video metadata: %s", str(video_metadata))
+
+    ifps = video_metadata.frame_rate
+    isize = video_metadata.frame_size
 
     # Compute output frame rate
     ofps = fps or -1

--- a/eta/modules/format_videos.py
+++ b/eta/modules/format_videos.py
@@ -175,10 +175,8 @@ def _process_video(input_path, output_path, parameters):
     max_size = parameters.max_size
     ffmpeg_out_opts = parameters.ffmpeg_out_opts
 
-    # Get input video metadata
-    video_metadata = etav.VideoMetadata.build_for(input_path)
-    logger.info("Processing video '%s'", input_path)
-    logger.info("Found video metadata: %s", str(video_metadata))
+    # Get video metadata, logging generously
+    video_metadata = etav.get_video_metadata(input_path, log=True)
 
     ifps = video_metadata.frame_rate
     isize = video_metadata.frame_size

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -124,15 +124,18 @@ def _sample_videos(config):
 
 
 def _process_video(input_path, output_frames_dir, parameters):
-    stream_info = etav.VideoStreamInfo.build_for(input_path)
+    # Get video metadata
+    video_metadata = etav.VideoMetadata.build_for(input_path)
+    logger.info("Processing video '%s'", input_path)
+    logger.info("Found video metadata: %s" % str(video_metadata))
 
     _check_input_video_size(
-        stream_info, parameters.max_video_file_size,
+        video_metadata, parameters.max_video_file_size,
         parameters.max_video_duration)
 
-    ifps = stream_info.frame_rate
-    isize = stream_info.frame_size
-    iframe_count = stream_info.total_frame_count
+    ifps = video_metadata.frame_rate
+    isize = video_metadata.frame_size
+    iframe_count = video_metadata.total_frame_count
 
     #
     # Compute acceleration using the following strategy:
@@ -201,20 +204,20 @@ def _process_video(input_path, output_frames_dir, parameters):
 
 
 def _check_input_video_size(
-        stream_info, max_video_file_size, max_video_duration):
+        video_metadata, max_video_file_size, max_video_duration):
     if (max_video_file_size is not None
-            and stream_info.size_bytes > max_video_file_size):
+            and video_metadata.size_bytes > max_video_file_size):
         raise ValueError(
             "Input video file size must be less than %s; found %s" % (
                 etau.to_human_bytes_str(max_video_file_size),
-                etau.to_human_bytes_str(stream_info.size_bytes)))
+                etau.to_human_bytes_str(video_metadata.size_bytes)))
 
     if (max_video_duration is not None
-            and stream_info.duration > max_video_duration):
+            and video_metadata.duration > max_video_duration):
         raise ValueError(
             "Input video duration must be less than %s; found %s" % (
                 etau.to_human_time_str(max_video_duration),
-                etau.to_human_time_str(stream_info.duration)))
+                etau.to_human_time_str(video_metadata.duration)))
 
 
 def run(config_path, pipeline_config_path=None):

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -127,7 +127,7 @@ def _process_video(input_path, output_frames_dir, parameters):
     # Get video metadata
     video_metadata = etav.VideoMetadata.build_for(input_path)
     logger.info("Processing video '%s'", input_path)
-    logger.info("Found video metadata: %s" % str(video_metadata))
+    logger.info("Found video metadata: %s", str(video_metadata))
 
     _check_input_video_size(
         video_metadata, parameters.max_video_file_size,

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -124,10 +124,8 @@ def _sample_videos(config):
 
 
 def _process_video(input_path, output_frames_dir, parameters):
-    # Get video metadata
-    video_metadata = etav.VideoMetadata.build_for(input_path)
-    logger.info("Processing video '%s'", input_path)
-    logger.info("Found video metadata: %s", str(video_metadata))
+    # Get video metadata, logging generously
+    video_metadata = etav.get_video_metadata(input_path, log=True)
 
     _check_input_video_size(
         video_metadata, parameters.max_video_file_size,


### PR DESCRIPTION
Weird things can happen when reading videos from the wild. This PR logs the `VideoMetadata` for all videos read by `sample_videos` and `format_videos`, which are the two primary video ingestion modules in ETA.

With this PR, it would be easier to detect when, for example, `ffprobe` thinks a video's `height` and `width` are (inexplicably) reversed from what they should be...

This PR also includes a convenient `eta.core.utils.summarize_long_str` method:

```py
import eta.core.utils as etau

s = "abcdefghijklmnopqrstuvwxyz"
max_len = 20

print(etau.summarize_long_str(s, max_len, mode="first"))
print(etau.summarize_long_str(s, max_len, mode="middle"))
print(etau.summarize_long_str(s, max_len, mode="last"))
```

Output:

```
... klmnopqrstuvwxyz
abcdefgh ... tuvwxyz
abcdefghijklmnop ...
```

Example of using the new `eta.core.video.get_video_metadata()` function with `log=True`:

```py
video_path = "/Users/Brian/Desktop/bdd100k_dd5e0167-fe59b827.mov"
etav.get_video_metadata(video_path, log=True)
```

Output:

```
Getting stream info for '/Users/Brian/Desktop/bdd100k_dd5e0167-fe59b827.mov'
Executing 'ffprobe -loglevel error -show_format -show_streams -print_format json -i /Users/Brian/Desktop/bdd100k_dd5e0167-fe59b827.mov'
Found format info: {
    "filename": "/Users/Brian/Desktop/bdd100k_dd5e0167-fe59b827.mov",
    "nb_streams": 1,
    "nb_programs": 0,
    "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
    "format_long_name": "QuickTime / MOV",
    "start_time": "0.000000",
    "duration": "63.247000",
    "size": "32841746",
    "bit_rate": "4154093",
    "probe_score": 100,
    "tags": {
        "major_brand": "qt  ",
        "minor_version": "512",
        "compatible_brands": "qt  ",
        "encoder": "Lavf57.71.100"
    }
}
Found video stream: {
    "index": 0,
    "codec_name": "h264",
    "codec_long_name": "H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10",
    "profile": "High",
    "codec_type": "video",
    "codec_time_base": "9487/570900",
    "codec_tag_string": "avc1",
    "codec_tag": "0x31637661",
    "width": 720,
    "height": 1280,
    "coded_width": 720,
    "coded_height": 1280,
    "has_b_frames": 7,
    "pix_fmt": "yuv420p",
    "level": 41,
    "color_range": "tv",
    "color_space": "smpte170m",
    "color_transfer": "bt709",
    "color_primaries": "bt709",
    "chroma_location": "center",
    "refs": 1,
    "is_avc": "true",
    "nal_length_size": "4",
    "r_frame_rate": "30000/1001",
    "avg_frame_rate": "285450/9487",
    "time_base": "1/19200",
    "start_pts": 0,
    "start_time": "0.000000",
    "duration_ts": 1214336,
    "duration": "63.246667",
    "bit_rate": "4151066",
    "bits_per_raw_sample": "8",
    "nb_frames": "1903",
    "disposition": {
        "default": 1,
        "dub": 0,
        "original": 0,
        "comment": 0,
        "lyrics": 0,
        "karaoke": 0,
        "forced": 0,
        "hearing_impaired": 0,
        "visual_impaired": 0,
        "clean_effects": 0,
        "attached_pic": 0,
        "timed_thumbnails": 0
    },
    "tags": {
        "rotate": "270",
        "language": "eng",
        "handler_name": "VideoHandler",
        "encoder": "H.264"
    },
    "side_data_list": [
        {
            "side_data_type": "Display Matrix",
            "displaymatrix": "\n00000000:            0      -65536           0\n00000001:        65536           0           0\n00000002:            0           0  1073741824\n",
            "rotation": 90
        }
    ]
}
Extracted video metadata: {
    "frame_size": [
        720,
        1280
    ],
    "frame_rate": 30.08854221566354,
    "total_frame_count": 1903,
    "duration": 63.246667,
    "size_bytes": 32841746,
    "mime_type": "video/quicktime",
    "encoding_str": "avc1"
}
```