### PR TITLE
Handling rotated videos properly when computing frame size

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2520,11 +2520,23 @@ class VideoStreamInfo(etas.Serializable):
             VideoStreamInfoError: if the frame size could not be determined
         '''
         try:
-            return (
-                int(self.stream_info["width"]),
-                int(self.stream_info["height"]),
-            )
-        except KeyError:
+            # Must check if the video is rotated!
+            rotation = int(self.stream_info["tags"]["rotate"])
+        except (KeyError, ValueError):
+            rotation = 0
+
+        try:
+            width = int(self.stream_info["width"])
+            height = int(self.stream_info["height"])
+
+            if (rotation // 90) % 2:
+                logger.debug(
+                    "Found video with rotation %d; swapping width and height",
+                    rotation)
+                width, height = height, width
+
+            return width, height
+        except (KeyError, ValueError):
             raise VideoStreamInfoError(
                 "Unable to determine frame size of the video")
 


### PR DESCRIPTION
This PR resolves https://github.com/voxel51/eta/issues/446. The underlying issue here was that `ffmpeg` was able to correctly handle rotated videos, but `VideoStreamInfo` was not handling this, which led to incorrect `width x height`s being reported and then used by `FFmpegVideoReader`, `VideoProcessor`, etc.

Shoutout to Ben for tracking down the `rotate` tag in video streams!

Verified by running on the video linked in https://github.com/voxel51/eta/issues/446 and confirming that it correctly interprets the dimensions.