### PR TITLE
Pass `**kwargs` to `subprocess.call()` in `eta.core.utils.call()`

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -919,12 +919,15 @@ class ProgressBar(object):
 def call(args, **kwargs):
     """Runs the command via `subprocess.call()`.
 
-    stdout and stderr are streamed live during execution. `**kwargs` may be used to
-    override this. Or, if you want to capture these streams, use `communicate()`.
+    stdout and stderr are streamed live during execution. `**kwargs` may be
+    used to override this. Or, if you want to capture these streams, use
+    `communicate()`.
+
 
     Args:
         args: the command specified as a ["list", "of", "strings"]
-        **kwargs: keyword arguments to be passed through to `subprocess.call()`.
+        **kwargs: keyword arguments to be passed through to
+            `subprocess.call()`.
 
     Returns:
         True/False: if the command executed successfully

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -916,19 +916,20 @@ class ProgressBar(object):
         return " " + suffix if suffix else ""
 
 
-def call(args):
+def call(args, **kwargs):
     """Runs the command via `subprocess.call()`.
 
-    stdout and stderr are streamed live during execution. If you want to
-    capture these streams, use `communicate()`.
+    stdout and stderr are streamed live during execution. `**kwargs` may be used to
+    override this. Or, if you want to capture these streams, use `communicate()`.
 
     Args:
         args: the command specified as a ["list", "of", "strings"]
+        **kwargs: keyword arguments to be passed through to `subprocess.call()`.
 
     Returns:
         True/False: if the command executed successfully
     """
-    return subprocess.call(args) == 0
+    return subprocess.call(args, **kwargs) == 0
 
 
 def communicate(args, decode=False):


### PR DESCRIPTION
Adding this pass through allows for more configuration on a case-by-case basis.