### PR TITLE
Utility function to take a window snap-shot programmatically.

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -3412,13 +3412,17 @@ def get_terminal_size():
         return w, h
 
 
-def save_window_snapshot(window_name=None, file_path=None):
+def save_window_snapshot(window_name, file_path):
     """Take a screenshot of a window of a given name and save it to an image on
     disk.
+
+    Args:
+        window_name: the name of the window
+        file_path: the path to write the image on disk
     """
     if window_name is None:
         raise ValueError("window_name cannot be None")
     if file_path is None:
-        raise ValueError("window_name cannot be None")
+        raise ValueError("file_path cannot be None")
 
     _run_system_os_cmd(["import", "-window", window_name, file_path])

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -2889,3 +2889,15 @@ def get_terminal_size():
             ),
         )
         return w, h
+
+
+def save_window_snapshot(window_name=None, file_path=None):
+    """Take a screenshot of a window of a given name and save it to an image on
+    disk.
+    """
+    if window_name is None:
+        raise ValueError("window_name cannot be None")
+    if file_path is None:
+        raise ValueError("window_name cannot be None")
+
+    _run_system_os_cmd(["import", "-window", window_name, file_path])


### PR DESCRIPTION
`eta.core.utils.save_window_snapshot` is now available to programmatically save a window to an image file.  Only tested on Linux but works like a charm there.