### PR TITLE
Fix ProgressBar errors when stdout isn't UTF-8

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -1534,6 +1534,10 @@ class ProgressBar(object):
 
         self._max_len = min(max(pstr_len, self._max_len), self._max_width)
         pstr += " " * (self._max_len - pstr_len)
+        # substitute any characters that can't be printed to stdout
+        pstr = pstr.encode(sys.stdout.encoding, errors="replace").decode(
+            sys.stdout.encoding
+        )
 
         return pstr
 


### PR DESCRIPTION
Notably, occurs in some Windows environments, but can be reproduced on Linux by setting the `LC_CTYPE=C` environment variable.

See https://github.com/voxel51/fiftyone/runs/1227722383?check_suite_focus=true#step:16:111 for an example error from before this change