### PR TITLE
Adding support for storing multiple shapes in a Polyline instance

### DIFF
--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -975,7 +975,8 @@ def _draw_polyline(img, polyline, annotation_config):
 
     # Render coordinates for image
     # Note: OpenCV expects numpy arrays
-    points = np.array(polyline.coords_in(img=img), dtype=np.int32)
+    points = polyline.coords_in(img=img)
+    points = [np.array(shape, dtype=np.int32) for shape in points]
 
     #
     # Draw polyline
@@ -1000,7 +1001,7 @@ def _draw_polyline(img, polyline, annotation_config):
     # Draw title string
     #
 
-    tcx, tcy = tuple(np.mean(points, axis=(0, 1)))
+    tcx, tcy = np.mean([np.mean(shape, axis=0) for shape in points], axis=0)
     ttlx, ttly, tw, th = _get_panel_coords(
         [title_str], annotation_config, center_coords=(tcx, tcy)
     )

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -954,7 +954,7 @@ def _draw_polyline(img, polyline, annotation_config):
         if polyline.label in labels_blacklist:
             return_now = True
 
-    if not polyline.points:
+    if not polyline.has_vertices:
         return_now = True
 
     if return_now:
@@ -985,10 +985,10 @@ def _draw_polyline(img, polyline, annotation_config):
 
     if polyline.filled and fill_polylines:
         # Note: this function handles closed vs not closed automatically
-        overlay = cv2.fillPoly(overlay, [points], color)
+        overlay = cv2.fillPoly(overlay, points, color)
     else:
         overlay = cv2.polylines(
-            overlay, [points], polyline.closed, color, thickness=thickness
+            overlay, points, polyline.closed, color, thickness=thickness
         )
 
     img_anno = cv2.addWeighted(overlay, alpha, img, 1 - alpha, 0)
@@ -1000,7 +1000,7 @@ def _draw_polyline(img, polyline, annotation_config):
     # Draw title string
     #
 
-    tcx, tcy = tuple(np.mean(points, axis=0))
+    tcx, tcy = tuple(np.mean(points, axis=(0, 1)))
     ttlx, ttly, tw, th = _get_panel_coords(
         [title_str], annotation_config, center_coords=(tcx, tcy)
     )
@@ -1097,7 +1097,7 @@ def _draw_keypoints(img, keypoints, annotation_config):
         if keypoints.label in labels_blacklist:
             return_now = True
 
-    if not keypoints.points:
+    if not keypoints.has_points:
         return_now = True
 
     if return_now:

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -1019,9 +1019,6 @@ def convert_object_to_polygon(dobj, tolerance=2, filled=True):
     If the object an instance mask, the polyline will trace the boundary of the
     mask; otherwise, the polyline will trace the bounding box itself.
 
-    If the object's mask contains multiple connected components, the polyline
-    will only describe the first component.
-
     Args:
         dobj: a DetectedObject
         tolerance (2): a tolerance, in pixels, when generating an approximate
@@ -1034,34 +1031,26 @@ def convert_object_to_polygon(dobj, tolerance=2, filled=True):
     if dobj.has_mask:
         mask_polygons = _mask_to_polygons(dobj.mask, tolerance=tolerance)
 
-        num_polygons = len(mask_polygons)
+        x0 = dobj.bounding_box.top_left.x
+        y0 = dobj.bounding_box.top_left.y
+        w_box = dobj.bounding_box.width()
+        h_box = dobj.bounding_box.height()
 
-        if num_polygons == 0:
-            points = _get_bounding_box_points(dobj.bounding_box)
-        else:
-            if num_polygons > 1:
-                msg = (
-                    "Found object whose mask has more than one connected "
-                    "component; only returning first component"
-                )
-                warnings.warn(msg)
+        h_mask, w_mask = dobj.mask.shape[:2]
 
-            x0 = dobj.bounding_box.top_left.x
-            y0 = dobj.bounding_box.top_left.y
-            w_box = dobj.bounding_box.width()
-            h_box = dobj.bounding_box.height()
-
-            h_mask, w_mask = dobj.mask.shape[:2]
-
-            points = []
-            for x, y in mask_polygons[0]:
+        points = []
+        for mask_polygon in mask_polygons:
+            ppoints = []
+            for x, y in mask_polygon:
                 xp = x0 + (x / w_mask) * w_box
                 yp = y0 + (y / h_mask) * h_box
 
-                points.append((xp, yp))
+                ppoints.append((xp, yp))
 
+            points.append(ppoints)
     else:
-        points = _get_bounding_box_points(dobj.bounding_box)
+        tlx, tly, brx, bry = dobj.bounding_box.to_coords()
+        points = [[(tlx, tly), (brx, tly), (brx, bry), (tlx, bry)]]
 
     return etap.Polyline(
         name=dobj.name,
@@ -1072,11 +1061,6 @@ def convert_object_to_polygon(dobj, tolerance=2, filled=True):
         filled=filled,
         attrs=dobj.attrs,
     )
-
-
-def _get_bounding_box_points(bounding_box):
-    tlx, tly, brx, bry = bounding_box.to_coords()
-    return [(tlx, tly), (brx, tly), (brx, bry), (tlx, bry)]
 
 
 def _mask_to_polygons(mask, tolerance=2):


### PR DESCRIPTION
Data formats like COCO and BDD allow for the possibility of a single "object" being composed of multiple disjoint polylines/polygons. This PR updates the data model to allow for this. IE `Polyline.points` is now a list of lists of `(x, y)` points, where each outer list defines a separate shape.