### PR TITLE
Bump to v0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 from wheel.bdist_wheel import bdist_wheel
 
 
-VERSION = "0.2.1"
+VERSION = "0.3.0"
 
 
 class BdistWheelCustom(bdist_wheel):


### PR DESCRIPTION
I'd like to start following the practice of bumping the minor (to `3` in this case) for better semantic versioning and requirement handling in FiftyOne.