### PR TITLE
Handle multiple requirement options

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -611,6 +611,16 @@ def install_package(requirement_str, error_level=0):
             1: log warning if the install fails
             2: ignore install fails
     """
+    if "|" in requirement_str:
+        full_requirement_str = requirement_str
+        requirement_str = full_requirement_str.split("|", 1)[0]
+        logger.warning(
+            "***** Requirement '%s' has multiple options. We're going to "
+            "install the first one: '%s' *****",
+            full_requirement_str,
+            requirement_str,
+        )
+
     args = [sys.executable, "-m", "pip", "install", requirement_str]
     p = subprocess.Popen(args, stderr=subprocess.PIPE)
     _, err = p.communicate()


### PR DESCRIPTION
The `eta.core.utils.ensure_package()` method allows for multiple choice requirement strings like `tensorflow-gpu|tensorflow>2`, which means "either `tensorflow-gpu` or `tensorflow>2` must be installed".

This PR supports the same syntax for `eta.core.utils.install_package()`, which fixes https://github.com/voxel51/fiftyone/issues/919.

```py
import eta.core.utils as etau                                                                                                                                                

# previously failed; now works
etau.install_package("tensorflow|torch")
```

```
***** Requirement 'tensorflow|torch' has multiple options. We're going to install the first one: 'tensorflow' *****
...
Requirement already satisfied: tensorflow in /Users/Brian/dev/env/eta3/lib/python3.6/site-packages (2.4.0)
```
