### PR TITLE
Editable install for development installs only

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -230,7 +230,11 @@ fi
 
 
 MSG "Installing ETA"
-CRITICAL pip install -e .
+if [ ${DEV_INSTALL} = true ]; then
+    CRITICAL pip install -e .
+else
+    CRITICAL pip install .
+fi
 
 
 # Install ffmpeg


### PR DESCRIPTION
The motivation here is allow installs from source using the install script in Google's Colab. Installing in Colab with an `-e` flag does not work.

So, in short, this change allows one to install ETA in a Colab notebook with `bash install.bash` but not `bash install.bash -d`. 