### PR TITLE
Indicate whether requirement installs were successful

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ complete information.
 ## Quickstart
 
 Get your feet wet with ETA by running some of examples in the
-[examples folder](https://github.com/voxel51/eta/tree/develop/examples).
+[examples folder](https://github.com/voxel51/eta/tree/develop/eta/examples).
 
 Also, see the [docs folder](https://github.com/voxel51/eta/tree/develop/docs)
 for more documentation about the various components of the ETA library.


### PR DESCRIPTION
In situations when `error_level > 0`, it can be useful to get a return flag indicating whether a particular requirement is installed.

For example, third-party code may want to set `error_level=1` and then issue an additional message suggesting a workaround if a package is not installed.

```py
import eta.core.utils as etau

print(etau.install_package("tensorflow"))  # True
print(etau.install_package("tensorflowz", error_level=1))  # False

print(etau.ensure_package("tensorflow"))  # True
print(etau.ensure_package("tensorflowz", error_level=1))  # False

print(etau.ensure_import("tensorflow"))  # True
print(etau.ensure_import("tensorflowz", error_level=1))  # False

print(etau.ensure_cuda_version(">51"), error_level=1)  # False
print(etau.ensure_cudnn_version(">51"), error_level=1)  # False
```