### PR TITLE
Removing Sphinx dependency from main package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,13 +71,16 @@ COPY . eta/
 
 ARG TENSORFLOW_VERSION
 RUN pip --no-cache-dir  install --upgrade pip setuptools \
-    && pip --no-cache-dir install -r eta/requirements.txt \
+    && pip --no-cache-dir install -r eta/requirements/common.txt \
+    && pip --no-cache-dir install -r eta/requirements/pipeline.txt \
+    && pip --no-cache-dir install -r eta/requirements/storage.txt \
     && pip --no-cache-dir install --upgrade setuptools \
     && pip --no-cache-dir install -e eta/. \
     && pip --no-cache-dir install -I $TENSORFLOW_VERSION \
     && pip --no-cache-dir install --upgrade numpy==1.16.0 \
     && pip --no-cache-dir install -e eta/eta/tensorflow/darkflow/. \
     && pip --no-cache-dir install pycocotools \
+    && pip --no-cache-dir install protobuf \
     && curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip \
     && unzip protoc-3.6.1-linux-x86_64.zip -d protoc3 \
     && rm -rf protoc-3.6.1-linux-x86_64.zip \

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -35,7 +35,6 @@ import eta
 import eta.core.builder as etab
 import eta.constants as etac
 import eta.core.logging as etal
-import eta.core.metadata as etame
 import eta.core.models as etamode
 import eta.core.module as etamodu
 import eta.core.pipeline as etap
@@ -43,6 +42,7 @@ import eta.core.serial as etase
 import eta.core.utils as etau
 import eta.core.web as etaw
 
+etame = etau.lazy_import("eta.core.metadata")
 etast = etau.lazy_import("eta.core.storage")
 etat = etau.lazy_import("eta.core.tfutils")
 

--- a/eta/core/diagram.py
+++ b/eta/core/diagram.py
@@ -75,6 +75,11 @@ class HasBlockDiagram(object):
             logger.info("Generating block diagram '%s'", svg_path)
             args = ["blockdiag", "-Tsvg", "-o", svg_path, blockdiag_path]
             etau.communicate_or_die(args)
+        except etau.ExecutableNotFoundError:
+            raise etau.PackageError(
+                "You must run pip install voxel51-eta[pipeline] in order to "
+                "use this feature"
+            )
         finally:
             if not keep_diag_file:
                 etau.delete_file(blockdiag_path)

--- a/eta/core/metadata.py
+++ b/eta/core/metadata.py
@@ -25,13 +25,20 @@ import os
 import re
 import sys
 
-from docutils.core import publish_doctree
-from docutils.nodes import paragraph, field_list, field_name, field_body
-
-from sphinx.ext.napoleon.docstring import GoogleDocstring
-from sphinx.util.docstrings import prepare_docstring
-
 import eta.core.module as etam
+import eta.core.utils as etau
+
+try:
+    from docutils.core import publish_doctree
+    from docutils.nodes import paragraph, field_list, field_name, field_body
+
+    from sphinx.ext.napoleon.docstring import GoogleDocstring
+    from sphinx.util.docstrings import prepare_docstring
+except ImportError:
+    raise etau.PackageError(
+        "You must run pip install voxel51-eta[pipeline] in order to "
+        "use this feature"
+    )
 
 
 logger = logging.getLogger(__name__)

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -27,12 +27,10 @@ import logging
 import os
 import sys
 
-import numpy as np
-
 import eta
 import eta.constants as etac
 from eta.core.config import Config, Configurable
-from eta.core.serial import read_pickle, Serializable
+from eta.core.serial import Serializable
 import eta.core.utils as etau
 import eta.core.web as etaw
 
@@ -776,7 +774,7 @@ class ModelRequirements(Serializable):
                 1: log warning if a package install fails
                 2: ignore package install fails
             error_suffix: an optional message to append to the error if the
-                installation fails
+                installation fails and ``error_level == 0``
         """
         if self.packages is None:
             return
@@ -798,7 +796,7 @@ class ModelRequirements(Serializable):
                 1: log warning if a package install fails
                 2: ignore package install fails
             error_suffix: an optional message to append to the error if the
-                installation fails
+                installation fails and ``error_level == 0``
         """
         if self.cpu_packages is None:
             return
@@ -820,7 +818,7 @@ class ModelRequirements(Serializable):
                 1: log warning if a package install fails
                 2: ignore package install fails
             error_suffix: an optional message to append to the error if the
-                installation fails
+                installation fails and ``error_level == 0``
         """
         if self.gpu_packages is None:
             return
@@ -845,7 +843,7 @@ class ModelRequirements(Serializable):
                 1: log warning if a requirement is not satisifed
                 2: ignore unsatisifed requirements
             error_suffix: an optional message to append to the error if a
-                requirement is not satisifed
+                requirement is not satisifed and ``error_level == 0``
             log_success: whether to generate a log message when a requirement
                 is satisifed
         """
@@ -873,7 +871,7 @@ class ModelRequirements(Serializable):
                 1: log warning if a requirement is not satisifed
                 2: ignore unsatisifed requirements
             error_suffix: an optional message to append to the error if a
-                requirement is not satisifed
+                requirement is not satisifed and ``error_level == 0``
             log_success: whether to generate a log message when a requirement
                 is satisifed
         """
@@ -901,7 +899,7 @@ class ModelRequirements(Serializable):
                 1: log warning if a requirement is not satisifed
                 2: ignore unsatisifed requirements
             error_suffix: an optional message to append to the error if a
-                requirement is not satisifed
+                requirement is not satisifed and ``error_level == 0``
             log_success: whether to generate a log message when a requirement
                 is satisifed
         """

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -598,7 +598,9 @@ def get_function(function_name, module_name=None):
     return get_class(function_name, module_name=module_name)
 
 
-def install_package(requirement_str, error_level=0):
+def install_package(
+    requirement_str, error_level=0, error_msg=None, error_suffix=None,
+):
     """Installs the newest compliant version of the package.
 
     Args:
@@ -610,6 +612,10 @@ def install_package(requirement_str, error_level=0):
             0: raise error if the install fails
             1: log warning if the install fails
             2: ignore install fails
+
+        error_msg: an optional error message to use if the installation fails
+        error_suffix: an optional message to append to the error if the
+            installation fails and ``error_level == 0``
 
     Returns:
         True/False whether the requirement was successfully installed
@@ -631,13 +637,16 @@ def install_package(requirement_str, error_level=0):
     success = p.returncode == 0
 
     if not success:
-        handle_error(
-            OSError(
-                "Failed to install package '%s'\n\n%s"
-                % (requirement_str, err.decode())
-            ),
-            error_level,
-        )
+        if error_msg is None:
+            error_msg = "Failed to install package '%s'\n\n%s" % (
+                requirement_str,
+                err.decode(),
+            )
+
+        if error_suffix is not None and error_level <= 0:
+            error_msg += "\n" + error_suffix
+
+        handle_error(PackageError(error_msg), error_level)
 
     return success
 
@@ -674,7 +683,7 @@ def ensure_package(
         error_msg: an optional error message to use if the requirement is not
             satisifed
         error_suffix: an optional message to append to the error if the
-            requirement is not satisifed
+            requirement is not satisifed and ``error_level == 0``
         log_success: whether to generate a log message if the requirement is
             satisifed
 
@@ -744,7 +753,7 @@ def ensure_import(
         error_msg: an optional error message to use if the requirement is not
             satisifed
         error_suffix: an optional message to append to the error if the
-            requirement is not satisifed
+            requirement is not satisifed and ``error_level == 0``
         log_success: whether to generate a log message if the requirement is
             satisifed
 
@@ -1010,7 +1019,7 @@ def ensure_cuda_version(
         error_msg: an optional error message to use if the requirement is not
             satisifed
         error_suffix: an optional message to append to the error if the
-            requirement is not satisifed
+            requirement is not satisifed and ``error_level == 0``
         log_success: whether to generate a log message if the requirement is
             satisifed
 
@@ -1055,7 +1064,7 @@ def ensure_cudnn_version(
         error_msg: an optional error message to use if the requirement is not
             satisifed
         error_suffix: an optional message to append to the error if the
-            requirement is not satisifed
+            requirement is not satisifed and ``error_level == 0``
         log_success: whether to generate a log message if the requirement is
             satisifed
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -642,7 +642,13 @@ def install_package(requirement_str, error_level=0):
     return success
 
 
-def ensure_package(requirement_str, error_level=0, log_success=False):
+def ensure_package(
+    requirement_str,
+    error_level=0,
+    error_msg=None,
+    error_suffix=None,
+    log_success=False,
+):
     """Ensures that the given package is installed.
 
     This function uses `pkg_resources.get_distribution` to locate the package
@@ -655,22 +661,45 @@ def ensure_package(requirement_str, error_level=0, log_success=False):
     Args:
         requirement_str: a PEP 440 compliant package requirement, like
             "tensorflow", "tensorflow<2", "tensorflow==2.3.0", or
-            "tensorflow>=1.13,<1.15"
+            "tensorflow>=1.13,<1.15". This can also be an iterable of multiple
+            requirements, all of which must be installed, or this can be a
+            single "|"-delimited string specifying multiple requirements, at
+            least one of which must be installed
         error_level: the error level to use, defined as:
 
             0: raise error if requirement is not satisfied
             1: log warning if requirement is not satisifed
             2: ignore unsatisifed requirements
 
+        error_msg: an optional error message to use if the requirement is not
+            satisifed
+        error_suffix: an optional message to append to the error if the
+            requirement is not satisifed
         log_success: whether to generate a log message if the requirement is
             satisifed
 
     Returns:
         True/False whether the requirement is installed
     """
-    if "|" in requirement_str:
-        return _ensure_packages(requirement_str, error_level, log_success)
+    parse_requirement = lambda req_str: _get_package_version(req_str)
+    error_cls = PackageError
 
+    return _ensure_requirements(
+        requirement_str,
+        parse_requirement,
+        error_level,
+        error_cls,
+        error_msg,
+        error_suffix,
+        log_success,
+    )
+
+
+class PackageError(ImportError):
+    """Exception raised when a requested package is not installed."""
+
+
+def _get_package_version(requirement_str):
     req = Requirement(requirement_str)
 
     try:
@@ -680,29 +709,16 @@ def ensure_package(requirement_str, error_level=0, log_success=False):
         version = None
         error = e
 
-    return _ensure_requirement(
-        req, version, error_level, log_success, error=error
-    )
+    return req, version, error
 
 
-def _ensure_packages(requirement_str, error_level, log_success):
-    results = []
-    for req_str in requirement_str.split("|"):
-        req = Requirement(req_str)
-
-        try:
-            version = pkg_resources.get_distribution(req.name).version
-            error = None
-        except pkg_resources.DistributionNotFound as e:
-            version = None
-            error = e
-
-        results.append((req, version, error))
-
-    return _ensure_one_requirement(results, error_level, log_success)
-
-
-def ensure_import(requirement_str, error_level=0, log_success=False):
+def ensure_import(
+    requirement_str,
+    error_level=0,
+    error_msg=None,
+    error_suffix=None,
+    log_success=False,
+):
     """Ensures that the given package is installed and importable.
 
     This function imports the module the specified name and optionally enforces
@@ -714,85 +730,132 @@ def ensure_import(requirement_str, error_level=0, log_success=False):
 
     Args:
         requirement_str: a PEP 440-like module requirement, like "tensorflow",
-            "tensorflow<2", "tensorflow==2.3.0", or "tensorflow>=1.13,<1.15"
+            "tensorflow<2", "tensorflow==2.3.0", or "tensorflow>=1.13,<1.15".
+            This can also be an iterable of multiple requirements, all of which
+            must be installed, or this can be a single "|"-delimited string
+            specifying multiple requirements, at least one of which must be
+            installed
         error_level: the error level to use, defined as:
 
             0: raise error if requirement is not satisfied
             1: log warning if requirement is not satisifed
             2: ignore unsatisifed requirements
 
+        error_msg: an optional error message to use if the requirement is not
+            satisifed
+        error_suffix: an optional message to append to the error if the
+            requirement is not satisifed
         log_success: whether to generate a log message if the requirement is
             satisifed
 
     Returns:
         True/False whether the package is installed and importable
     """
+    parse_requirement = lambda req_str: _get_module_version(
+        req_str, error_level
+    )
+    error_cls = ImportError
+
+    return _ensure_requirements(
+        requirement_str,
+        parse_requirement,
+        error_level,
+        error_cls,
+        error_msg,
+        error_suffix,
+        log_success,
+    )
+
+
+def _get_module_version(requirement_str, error_level):
     req = Requirement(requirement_str)
 
     try:
-        # @todo not all modules have `__version__`
         mod = importlib.import_module(req.name)
-        version = mod.__version__
+        version = getattr(mod, "__version__", None)
         error = None
     except ImportError as e:
         version = None
         error = e
 
-    return _ensure_requirement(
-        req, version, error_level, log_success, error=error
+    if error is None and version is None and req.specifier:
+        handle_error(
+            ImportError(
+                "Unable to determine the installed version of '%s'; required "
+                "'%s'" % (req.name, req)
+            ),
+            error_level + 1,
+        )
+
+    return req, version, error
+
+
+def _ensure_requirements(
+    requirement_str,
+    parse_requirement,
+    error_level,
+    error_cls,
+    error_msg,
+    error_suffix,
+    log_success,
+):
+    if is_str(requirement_str):
+        # Require any
+        if "|" in requirement_str:
+            results = [
+                parse_requirement(req_str)
+                for req_str in requirement_str.split("|")
+            ]
+            return _ensure_any_requirement(
+                results,
+                error_level,
+                log_success,
+                error_cls=error_cls,
+                error_msg=error_msg,
+                error_suffix=error_suffix,
+            )
+
+        requirement_str = [requirement_str]
+
+    # Require all
+    results = [parse_requirement(req_str) for req_str in requirement_str]
+    return _ensure_all_requirements(
+        results,
+        error_level,
+        log_success,
+        error_cls=error_cls,
+        error_msg=error_msg,
+        error_suffix=error_suffix,
     )
 
 
-def _ensure_requirement(
-    req, version, error_level, log_success, error_cls=ImportError, error=None
-):
-    if version is None:
-        handle_error(
-            error_cls(
-                "The requested operation requires that '%s' is installed on "
-                "your machine" % str(req)
-            ),
-            error_level,
-            base_error=error,
-        )
-        return False
-
-    if not req.specifier.contains(version):
-        handle_error(
-            error_cls(
-                "The requested operation requires that '%s' is installed "
-                "on your machine; found '%s==%s'"
-                % (str(req), req.name, version)
-            ),
-            error_level,
-        )
-        return False
-
-    if log_success:
-        logger.info(
-            "Requirement satisfied: %s (found %s)" % (str(req), version)
-        )
-
-    return True
-
-
-def _ensure_one_requirement(
-    results, error_level, log_success, error_cls=ImportError
+def _ensure_all_requirements(
+    results,
+    error_level,
+    log_success,
+    error_cls=ImportError,
+    error_msg=None,
+    error_suffix=None,
 ):
     successes = []
     fails = []
     for req, version, error in results:
-        if version is None or not req.specifier.contains(version):
+        if (
+            error is not None
+            or version is None
+            and req.specifier
+            or not req.specifier.contains(version)
+        ):
             fails.append((req, version, error))
         else:
             successes.append((req, version))
 
-    if successes:
+    if not fails:
         if log_success:
             for req, version in successes:
+                ver = version or "???"
                 logger.info(
-                    "Requirement satisfied: %s (found %s)"
-                    % (str(req), version)
+                    "Requirement satisfied: %s (found %s)", str(req), ver
                 )
 
         return True
@@ -802,22 +865,103 @@ def _ensure_one_requirement(
     last_error = None
     for req, version, error in fails:
         req_strs.append(str(req))
+
+        if error is None and version is None:
+            found_strs.append("%s==???" % req.name)
+
         if version is not None:
             found_strs.append("%s==%s" % (req.name, version))
 
         if error is not None:
             last_error = error
 
-    req_str = "\n".join("-   %s" % r for r in req_strs)
-    found_str = "\n".join("-   %s" % f for f in found_strs)
-    error = error_cls(
-        (
+    if error_msg is None:
+        num_req = len(req_strs)
+        num_found = len(found_strs)
+
+        if num_req == 1:
+            reqs = "'%s' is" % req_strs[0]
+        else:
+            reqs = "%s are" % (req_strs,)
+
+        if num_found == 1:
+            founds = ", but found '%s'." % found_strs[0]
+        elif num_found > 1:
+            founds = ", but found %s." % (found_strs,)
+        else:
+            founds = "."
+
+        error_msg = (
+            "The requested operation requires that %s installed on "
+            "your machine%s" % (reqs, founds)
+        )
+
+    if error_suffix is not None and error_level <= 0:
+        error_msg += "\n\n" + error_suffix
+
+    handle_error(error_cls(error_msg), error_level, base_error=last_error)
+
+    return False
+
+
+def _ensure_any_requirement(
+    results,
+    error_level,
+    log_success,
+    error_cls=ImportError,
+    error_msg=None,
+    error_suffix=None,
+):
+    successes = []
+    fails = []
+    for req, version, error in results:
+        if (
+            error is not None
+            or version is None
+            and req.specifier
+            or not req.specifier.contains(version)
+        ):
+            fails.append((req, version, error))
+        else:
+            successes.append((req, version))
+
+    if successes:
+        if log_success:
+            for req, version in successes:
+                ver = version or "???"
+                logger.info(
+                    "Requirement satisfied: %s (found %s)", str(req), ver
+                )
+
+        return True
+
+    req_strs = []
+    found_strs = []
+    last_error = None
+    for req, version, error in fails:
+        req_strs.append(str(req))
+
+        if error is None and version is None:
+            found_strs.append("%s==???" % req.name)
+
+        if version is not None:
+            found_strs.append("%s==%s" % (req.name, version))
+
+        if error is not None:
+            last_error = error
+
+    if error_msg is None:
+        req_str = "\n".join("-   %s" % r for r in req_strs)
+        found_str = "\n".join("-   %s" % f for f in found_strs)
+        error_msg = (
             "The requested operation requires that one of the following is "
             "installed on your machine:\n%s\n\nbut found:\n%s"
-        )
-        % (req_str, found_str)
-    )
-    handle_error(error, error_level, base_error=last_error)
+        ) % (req_str, found_str)
+
+    if error_suffix is not None and error_level <= 0:
+        error_msg += "\n\n" + error_suffix
+
+    handle_error(error_cls(error_msg), error_level, base_error=last_error)
 
     return False
 
@@ -845,7 +989,13 @@ def handle_error(error, error_level, base_error=None):
         logger.warning(error)
 
 
-def ensure_cuda_version(requirement_str, error_level=0, log_success=False):
+def ensure_cuda_version(
+    requirement_str,
+    error_level=0,
+    error_msg=None,
+    error_suffix=None,
+    log_success=False,
+):
     """Ensures that a compliant version of CUDA is installed.
 
     Args:
@@ -857,24 +1007,40 @@ def ensure_cuda_version(requirement_str, error_level=0, log_success=False):
             1: log warning if the requirement is not satisifed
             2: ignore unsatisifed requirements
 
+        error_msg: an optional error message to use if the requirement is not
+            satisifed
+        error_suffix: an optional message to append to the error if the
+            requirement is not satisifed
         log_success: whether to generate a log message if the requirement is
             satisifed
 
     Returns:
         True/False whether a compliant CUDA version was found
-
-    Raises:
-        CUDAError: if CUDA is not installed or does not meet the specified
-            requirements and `error_level == 0`
     """
     req = Requirement("CUDA" + requirement_str)
     version = get_cuda_version()
-    return _ensure_requirement(
-        req, version, error_level, log_success, error_cls=CUDAError
+    if version is None:
+        error = CUDAError("CUDA not found")
+    else:
+        error = None
+
+    return _ensure_all_requirements(
+        [(req, version, error)],
+        error_level,
+        log_success,
+        error_cls=CUDAError,
+        error_msg=error_msg,
+        error_suffix=error_suffix,
     )
 
 
-def ensure_cudnn_version(requirement_str, error_level=0, log_success=False):
+def ensure_cudnn_version(
+    requirement_str,
+    error_level=0,
+    error_msg=None,
+    error_suffix=None,
+    log_success=False,
+):
     """Ensures that a compliant version of cuDNN is installed.
 
     Args:
@@ -886,20 +1052,30 @@ def ensure_cudnn_version(requirement_str, error_level=0, log_success=False):
             1: log warning if the requirement is not satisifed
             2: ignore unsatisifed requirements
 
+        error_msg: an optional error message to use if the requirement is not
+            satisifed
+        error_suffix: an optional message to append to the error if the
+            requirement is not satisifed
         log_success: whether to generate a log message if the requirement is
             satisifed
 
     Returns:
         True/False whether a compliant CUDA version was found
-
-    Raises:
-        CUDAError: if cuDNN is not installed or does not meet the specified
-            requirements and `error_level == 0`
     """
     req = Requirement("cuDNN" + requirement_str)
     version = get_cudnn_version()
-    return _ensure_requirement(
-        req, version, error_level, log_success, error_cls=CUDAError
+    if version is None:
+        error = CUDAError("cuDNN not found")
+    else:
+        error = None
+
+    return _ensure_all_requirements(
+        [(req, version, error)],
+        error_level,
+        log_success,
+        error_cls=CUDAError,
+        error_msg=error_msg,
+        error_suffix=error_suffix,
     )
 
 

--- a/eta/tensorflow/install_models.bash
+++ b/eta/tensorflow/install_models.bash
@@ -32,6 +32,9 @@ fi
 
 cd "${MODELS_DIR}"
 
+echo "Installing protobuf"
+pip install protobuf
+
 if command -v protoc &> /dev/null; then
     echo "Found protoc"
 else

--- a/install.bash
+++ b/install.bash
@@ -190,12 +190,35 @@ fi
 
 
 MSG "Installing Python packages"
+CRITICAL pip install -r requirements.txt
+
+
+MSG "Installing ETA"
+if [ ${DEV_INSTALL} = true ]; then
+    CRITICAL pip install -e .
+else
+    CRITICAL pip install .
+fi
+
+
+# @note(lite) handle lite installation
+if [[ ${LITE_INSTALL} = true ]]; then
+    EXIT "LITE INSTALLATION COMPLETE"
+fi
+
+
+MSG "Installing storage extras"
+CRITICAL pip install -r requirements/storage.txt
+
+
+MSG "Installing pipeline extras"
+CRITICAL pip install -r requirements/pipeline.txt
+
+
 if [ ${DEV_INSTALL} = true ]; then
     MSG "Performing dev install"
     CRITICAL pip install -r requirements/dev.txt
     CRITICAL pre-commit install
-else
-    CRITICAL pip install -r requirements.txt
 fi
 
 
@@ -226,14 +249,6 @@ if [ "${GCARD}" == "ON" ]; then
 else
     MSG "Installing tensorflow 1.15"
     CRITICAL pip install --upgrade tensorflow~=1.15
-fi
-
-
-MSG "Installing ETA"
-if [ ${DEV_INSTALL} = true ]; then
-    CRITICAL pip install -e .
-else
-    CRITICAL pip install .
 fi
 
 
@@ -270,12 +285,6 @@ else
             CRITICAL brew install imagemagick
         fi
     fi
-fi
-
-
-# @note(lite) handle lite installation
-if [[ ${LITE_INSTALL} = true ]]; then
-    EXIT "LITE INSTALLATION COMPLETE"
 fi
 
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,17 +1,10 @@
 argcomplete==1.11.0
-blockdiag==1.5.3
-boto3==1.10.9
 contextlib2==0.5.5
 Cython==0.28.5
 dill==0.2.7.1
 future==0.16.0
 glob2==0.6
-google-api-python-client==1.6.5
-google-auth-httplib2==0.0.3
-google-cloud-storage==1.7.0
-httplib2==0.15.0
 importlib-metadata==1.3.0; python_version<"3.8"
-Jinja2==2.11.3
 lxml==4.6.3
 ndjson==0.3.1
 numpy==1.16.3
@@ -19,8 +12,6 @@ opencv-python-headless==4.1.0.25
 packaging==19.2
 patool==1.12
 Pillow==8.1.1
-protobuf==3.6.1
-pysftp==0.2.9
 python-dateutil==2.7.0
 pytz==2019.3
 requests-toolbelt==0.8.0
@@ -33,6 +24,5 @@ setuptools==45.2.0;python_version>="3"
 simplejson==3.8.1
 six==1.11.0
 sortedcontainers==2.1.0
-Sphinx==2.4.4
 tabulate==0.8.5
 tzlocal==2.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,9 @@
--r common.txt
-
 ipython==5.8.0;python_version<"3"
 ipython==7.8.0;python_version>="3"
 m2r==0.2.1
 pre-commit==2.0.1
 pylint==1.9.4;python_version<"3"
 pylint==2.3.1;python_version>="3"
+Sphinx==2.4.4
 sphinxcontrib-napoleon==0.7
 sphinx-rtd-theme==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -68,11 +68,11 @@ setup(
         "six",
         "scikit-image",
         "sortedcontainers",
-        "Sphinx",
         "tabulate",
         "tzlocal",
     ],
     extras_require={
+        "pipeline": ["blockdiag", "Sphinx", "sphinxcontrib-napoleon"],
         "storage": [
             "boto3",
             "google-api-python-client",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 from wheel.bdist_wheel import bdist_wheel
 
 
-VERSION = "0.4.1"
+VERSION = "0.5.0"
 
 
 class BdistWheelCustom(bdist_wheel):


### PR DESCRIPTION
Resolves https://github.com/voxel51/eta/issues/513.

Refactors heavier dependencies like Sphinx that are only required when using ETA's pipeline features into a new `[pipeline]` extras package.

Also adds some additional features to `install_package()`, `ensure_package()`, and `ensure_import()` that are used by https://github.com/voxel51/fiftyone/pull/1059.

```shell
git clone https://github.com/voxel51/eta
cd eta

# lite installation
pip install -e .
```

```py
import eta.core.utils as etau

etau.ensure_package(["numpy", "scipy"])  # success
etau.ensure_import(["numpy", "scipy"])  # success

etau.ensure_package(["numpyyy", "scipy>1000"])  # helpful error
etau.ensure_import(["numpyyy", "scipy>1000"])  # helpful error
```

```shell
# do something that requires [pipeline] extras
eta modules --metadata eta/modules/sample_videos.py  # helpful error

pip install -e .[pipeline]

eta modules --metadata eta/modules/sample_videos.py  # works
```
