### PR TITLE
Hotfixes for FiftyOne v0.10.0

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -849,11 +849,9 @@ def _ensure_all_requirements(
     successes = []
     fails = []
     for req, version, error in results:
-        if (
-            error is not None
-            or version is None
-            and req.specifier
-            or not req.specifier.contains(version)
+        if error is not None or (
+            req.specifier
+            and (version is None or not req.specifier.contains(version))
         ):
             fails.append((req, version, error))
         else:
@@ -924,11 +922,9 @@ def _ensure_any_requirement(
     successes = []
     fails = []
     for req, version, error in results:
-        if (
-            error is not None
-            or version is None
-            and req.specifier
-            or not req.specifier.contains(version)
+        if error is not None or (
+            req.specifier
+            and (version is None or not req.specifier.contains(version))
         ):
             fails.append((req, version, error))
         else:

--- a/requirements/pipeline.txt
+++ b/requirements/pipeline.txt
@@ -1,0 +1,3 @@
+blockdiag==1.5.3
+Sphinx==2.4.4
+sphinxcontrib-napoleon==0.7

--- a/requirements/storage.txt
+++ b/requirements/storage.txt
@@ -1,0 +1,6 @@
+boto3==1.10.9
+google-api-python-client==1.6.5
+google-auth-httplib2==0.0.3
+google-cloud-storage==1.7.0
+httplib2==0.15.0
+pysftp==0.2.9

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 from wheel.bdist_wheel import bdist_wheel
 
 
-VERSION = "0.5.0"
+VERSION = "0.5.1"
 
 
 class BdistWheelCustom(bdist_wheel):


### PR DESCRIPTION
Fixes a bug that was causing calls like `fiftyone.core.utils.ensure_import("pycocotools")` to raise uncaught exceptions.

Also adds missing requirements files used by `install.bash` for source installs that were intended to be included in #515.