### PR TITLE
Fix bug when computing mask from polyline

### DIFF
--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -1140,7 +1140,7 @@ def render_bounding_box_and_mask(polyline, mask_size):
 
     # Render mask
 
-    mask = np.zeros(mask_size, dtype=np.uint8)
+    mask = np.zeros((h_mask, w_mask), dtype=np.uint8)
     abs_points = np.array(abs_points, dtype=np.int32)
 
     if polyline.filled:


### PR DESCRIPTION
Numpy arrays are `(height, width)` but the mask was being initialized with the `(width, height)` mask size.