### PR TITLE
Render polylines of different sizes

### DIFF
--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -1141,7 +1141,7 @@ def render_bounding_box_and_mask(polyline, mask_size):
     # Render mask
 
     mask = np.zeros((h_mask, w_mask), dtype=np.uint8)
-    abs_points = np.array(abs_points, dtype=np.int32)
+    abs_points = [np.array(shape, dtype=np.int32) for shape in abs_points]
 
     if polyline.filled:
         # Note: this function handles closed vs not closed automatically


### PR DESCRIPTION
This PR fixes a bug where `eta.core.image.render_bounding_box_and_mask()` only allows for polylines where every shape that it contains has the same number of points. It now mimics what is done in `fiftyone.core.labels._render_polyline()`.