### PR TITLE
Allow directory to exist when running ensure_dir()

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -2767,9 +2767,7 @@ def ensure_dir(dirname):
     Args:
         dirname: the directory path
     """
-    if dirname and not os.path.isdir(dirname):
-        logger.debug("Making directory '%s'", dirname)
-        os.makedirs(dirname)
+    os.makedirs(dirname, exist_ok=True)
 
 
 def has_extension(filename, *args):


### PR DESCRIPTION
Tweaks the implementation of `ensure_dir()` so that it is **always** okay if a directory already exists. Previously I had errors in multiprocess workflows where one worker managed to create the directory between the execution of the `if` and `os.makedirs()` statements of another worker.