### PR TITLE
Cloud storage client enhancements

### DIFF
--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -966,7 +966,7 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
         Returns:
             a dictionary containing metadata about the file, including its
                 `bucket`, `object_name`, `name`, `size`, `mime_type`,
-                `last_modified`, `checksum`, and `metadata`
+                `last_modified`, `etag`, and `metadata`
         """
         bucket, object_name = self._parse_s3_path(cloud_path)
         return self._get_file_metadata(bucket, object_name)
@@ -1020,7 +1020,7 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
                 default, this is True
             return_metadata: whether to return a metadata dictionary for each
                 file, including its `bucket`, `object_name`, `name`, `size`,
-                `mime_type`, `last_modified`, `checksum`, and `metadata`. By
+                `mime_type`, `last_modified`, `etag`, and `metadata`. By
                 default, only the paths to the files are returned
 
         Returns:
@@ -1181,7 +1181,7 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
             "size": response["ContentLength"],
             "mime_type": mime_type,
             "last_modified": response["LastModified"],
-            "checksum": response["ETag"][1:-1],
+            "etag": response["ETag"][1:-1],
             "metadata": response["Metadata"],
         }
 
@@ -1197,7 +1197,7 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
             "size": obj["Size"],
             "mime_type": etau.guess_mime_type(path),
             "last_modified": obj["LastModified"],
-            "checksum": obj["ETag"][1:-1],
+            "etag": obj["ETag"][1:-1],
             "metadata": obj["Metadata"],
         }
 
@@ -1605,7 +1605,7 @@ class GoogleCloudStorageClient(
         Returns:
             a dictionary containing metadata about the file, including its
                 `bucket`, `object_name`, `name`, `size`, `mime_type`,
-                `last_modified`, `checksum`, and `metadata`
+                `last_modified`, `etag`, and `metadata`
         """
         blob = self._get_blob(cloud_path, include_metadata=True)
         return self._get_file_metadata(blob)
@@ -1659,7 +1659,7 @@ class GoogleCloudStorageClient(
                 default, this is True
             return_metadata: whether to return a metadata dictionary for each
                 file, including its  `bucket`, `object_name`, `name`, `size`,
-                `mime_type`, `last_modified`, `checksum`, and `metadata`. By
+                `mime_type`, `last_modified`, `etag`, and `metadata`. By
                 default, only the paths to the files are returned
 
         Returns:
@@ -1763,7 +1763,7 @@ class GoogleCloudStorageClient(
             "size": blob.size,
             "mime_type": mime_type,
             "last_modified": blob.updated,
-            "checksum": blob.etag,
+            "etag": blob.etag,
             "metadata": blob.metadata or {},
         }
 

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1124,6 +1124,7 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
             "object_name": object_name,
             "name": os.path.basename(object_name),
             "size": metadata["ContentLength"],
+            "checksum": metadata["ETag"][1:-1],
             "mime_type": mime_type,
             "last_modified": metadata["LastModified"],
         }
@@ -1138,6 +1139,7 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
             "object_name": path,
             "name": os.path.basename(path),
             "size": obj["Size"],
+            "checksum": obj["ETag"][1:-1],
             "mime_type": etau.guess_mime_type(path),
             "last_modified": obj["LastModified"],
         }
@@ -1639,6 +1641,7 @@ class GoogleCloudStorageClient(
             "object_name": blob.name,
             "name": os.path.basename(blob.name),
             "size": blob.size,
+            "checksum": blob.md5_hash,
             "mime_type": mime_type,
             "last_modified": blob.updated,
         }

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -811,10 +811,10 @@ class S3StorageClient(StorageClient, CanSyncDirectories, NeedsAWSCredentials):
         if credentials is None:
             credentials, _ = self.load_credentials()
 
-            # The .ini files use `region` but `boto3.client` uses `region_name`
-            region = credentials.pop("region", None)
-            if region:
-                credentials["region_name"] = region
+        # The .ini files use `region` but `boto3.client` uses `region_name`
+        region = credentials.pop("region", None)
+        if region:
+            credentials["region_name"] = region
 
         if "retries" not in kwargs:
             kwargs["retries"] = {"max_attempts": 10, "mode": "standard"}

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1763,7 +1763,7 @@ class GoogleCloudStorageClient(
             "size": blob.size,
             "mime_type": mime_type,
             "last_modified": blob.updated,
-            "checksum": blob.md5_hash,
+            "checksum": blob.etag,
             "metadata": blob.metadata or {},
         }
 

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -672,6 +672,12 @@ class NeedsAWSCredentials(object):
                 from which they were loaded. If the credentials were loaded
                 from environment variables, `path` will be None
         """
+        if profile is None and "AWS_PROFILE" in os.environ:
+            logger.debug(
+                "Loading profile from 'AWS_PROFILE' environment variable"
+            )
+            profile = os.environ["AWS_PROFILE"]
+
         if credentials_path:
             logger.debug(
                 "Loading AWS credentials from manually provided path " "'%s'",

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -43,8 +43,6 @@ except ImportError:
     import urlparse  # Python 2
 
 import dateutil.parser
-
-from retrying import retry
 import requests
 
 try:
@@ -2056,7 +2054,7 @@ class GoogleDriveStorageClient(StorageClient, NeedsGoogleCredentials):
             return response["name"]
         except:
             raise GoogleDriveStorageClientError(
-                "Team Drive with ID '%s' not found", drive_id
+                "Team Drive with ID '%s' not found" % drive_id
             )
 
     def get_root_team_drive_id(self, file_id):

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -37,6 +37,11 @@ try:
 except ImportError:
     from io import StringIO as _StringIO  # Python 3
 
+try:
+    import urllib.parse as urlparse  # Python 3
+except ImportError:
+    import urlparse  # Python 2
+
 import itertools as it
 import logging
 import math
@@ -2301,8 +2306,10 @@ def get_dir_size(dirpath):
 
 
 def guess_mime_type(filepath):
-    """Guess the MIME type for the given file path. If no reasonable guess can
-    be determined, `application/octet-stream` is returned.
+    """Guess the MIME type for the given file path.
+
+    If no reasonable guess can be determined, `application/octet-stream` is
+    returned.
 
     Args:
         filepath: path to the file
@@ -2310,7 +2317,15 @@ def guess_mime_type(filepath):
     Returns:
         the MIME type string
     """
-    return mimetypes.guess_type(filepath)[0] or "application/octet-stream"
+    if filepath.startswith("http"):
+        filepath = urlparse.urlparse(filepath).path
+
+    mime_type, _ = mimetypes.guess_type(filepath)
+
+    if not mime_type:
+        return "application/octet-stream"
+
+    return mime_type
 
 
 def read_file(inpath, binary=False):

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -2298,11 +2298,12 @@ class VideoStreamInfo(etas.Serializable):
         return self.custom_attributes(dynamic=True)
 
     @classmethod
-    def build_for(cls, video_path, verbose=False):
+    def build_for(cls, video_path, mime_type=None, verbose=False):
         """Builds a VideoStreamInfo instance for the given video.
 
         Args:
             video_path: the path to the video
+            mime_type: the MIME type of the video, if already known
             verbose: whether to generously log the process of extracting the
                 stream info. By default, this is False
 
@@ -2322,7 +2323,9 @@ class VideoStreamInfo(etas.Serializable):
                 "Found video stream: %s", etas.json_to_str(stream_info)
             )
 
-        mime_type = etau.guess_mime_type(video_path)
+        if mime_type is None:
+            mime_type = etau.guess_mime_type(video_path)
+
         return cls(stream_info, format_info, mime_type=mime_type)
 
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -74,9 +74,9 @@ setup(
     extras_require={
         "pipeline": ["blockdiag", "Sphinx", "sphinxcontrib-napoleon"],
         "storage": [
-            "boto3",
+            "boto3>=1.15",
             "google-api-python-client",
-            "google-cloud-storage",
+            "google-cloud-storage>=1.36",
             "httplib2<=0.15",
             "pysftp",
         ],


### PR DESCRIPTION
Change log:
- Including checksums of cloud objects in `StorageClient.get_file_metadata()`
- Allows for configuration of the max connection pool size of GCP/S3 storage clients
- Adds support for the `AWS_PROFILE` environment variable
- Adds support for downloading byte ranges for HTTP/S3/GCS clients
- Upgrades failed request retrying for GCP/S3 to 2021 best practices