### PR TITLE
Use raw string in regex

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -3889,7 +3889,7 @@ def _iter_pattern_matches(patt):
     # Create validation functions
     seq_patts = re.findall(seq_exp, patt)
     fcns = [parse_int_sprintf_pattern(sp) for sp in seq_patts]
-    full_exp, num_inds = re.subn(seq_exp, "(\\s*\\d+)", patt)
+    full_exp, num_inds = re.subn(seq_exp, r"(\\s*\\d+)", patt)
 
     # Iterate over exactly matching patterns and files
     for f in files:


### PR DESCRIPTION
In Python 3.7+, passing `"(\\s*\\d+)"` to the `re` module is not allowed; one must use `r"(\\s*\\d+)"`.