### PR TITLE
Treat empty string as cwd when ensuring directories exist

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -2784,7 +2784,8 @@ def ensure_dir(dirname):
     Args:
         dirname: the directory path
     """
-    os.makedirs(dirname, exist_ok=True)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
 
 
 def has_extension(filename, *args):


### PR DESCRIPTION
Previously `ensure_basedir("hi.txt")` would fail, since `os.path.dirname("hi.txt") == ""` and it wasn't clear what that meant. This PR makes it so that `dirname == ""` is treated as the current working directory, which is assumed to exist.

This choice allows downstream operations to work with paths like `"hi.txt"` without having to explicitly write `"./hi.txt"`.