### PR TITLE
Adding retry policy to HTTPStorageClient

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -26,3 +26,4 @@ six==1.11.0
 sortedcontainers==2.1.0
 tabulate==0.8.5
 tzlocal==2.0.0
+urllib3==1.25.11

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ INSTALL_REQUIRES = [
     "sortedcontainers",
     "tabulate",
     "tzlocal",
+    "urllib3",
 ]
 
 


### PR DESCRIPTION
Adds a retry policy to `HTTPStorageClient` that behaves similarly to the default retry policies of `S3StorageClient` and `GCSStorageClient`.