### PR TITLE
read json file with utf-8

### DIFF
--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -103,7 +103,7 @@ def read_json(path):
         ValueError: if the JSON file was invalid
     """
     try:
-        with open(path, "rt") as f:
+        with open(path, "rt", encoding='utf-8') as f:
             return json.load(f)
     except ValueError:
         raise ValueError("Unable to parse JSON file '%s'" % path)


### PR DESCRIPTION
Different language platform especially in windows may cause error here, read json file with utf-8 decoder might work better.