### PR TITLE
Remote storage client path tweaks

### DIFF
--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1017,7 +1017,7 @@ class _BotoStorageClient(StorageClient, CanSyncDirectories):
             kwargs["Delimiter"] = "/"
 
         paths_or_metadata = []
-        prefix = self._prefixes[0] + bucket
+        prefix = self._get_prefix(cloud_folder) + bucket
         while True:
             resp = self._client.list_objects_v2(**kwargs)
 
@@ -1180,6 +1180,9 @@ class _BotoStorageClient(StorageClient, CanSyncDirectories):
             "etag": obj["ETag"][1:-1],
             "metadata": obj.get("Metadata", {}),
         }
+
+    def _get_prefix(self, cloud_path):
+        return _get_prefix(cloud_path, self._prefixes)
 
     def _strip_prefix(self, cloud_path):
         _cloud_path = _strip_prefix(cloud_path, self._prefixes)
@@ -3881,12 +3884,21 @@ def _to_bytes(val, encoding="utf-8"):
     return bytes_str
 
 
-def _strip_prefix(path, prefixes):
+def _get_prefix(path, prefixes):
     if not path:
         return None
 
     for prefix in prefixes:
         if path.startswith(prefix):
-            return path[len(prefix) :]
+            return prefix
+
+    return None
+
+
+def _strip_prefix(path, prefixes):
+    prefix = _get_prefix(path, prefixes)
+
+    if prefix:
+        return path[len(prefix): ]
 
     return None


### PR DESCRIPTION
Changelog
- Always use `/` rather than `os.path.sep` when dealing with remote paths, since these are URLs or S3/GCS/MinIO paths, which always use `/`
- Retain the user's prefix in `_BotoStorageClient.list_files_in_folder()`. Previously listing a MinIO folder using the `http://` syntax would return `alias://` paths if the user configured an alias; however, it is more natural to use the same prefix that the user actually provided
