### PR TITLE
Confirm large Google Drive downloads

### DIFF
--- a/eta/core/web.py
+++ b/eta/core/web.py
@@ -187,12 +187,12 @@ class GoogleDriveSession(WebSession):
 
     def get(self, fid):
         return super(GoogleDriveSession, self).get(
-            self.BASE_URL, params={"id": fid}
+            self.BASE_URL, params={"id": fid, "confirm": "t"}
         )
 
     def write(self, path, fid):
         return super(GoogleDriveSession, self).write(
-            path, self.BASE_URL, params={"id": fid}
+            path, self.BASE_URL, params={"id": fid, "confirm": "t"}
         )
 
     def _get_streaming_response(self, url, params=None):


### PR DESCRIPTION
The [previous method for confirming](https://github.com/voxel51/eta/blob/166a5fe6b652b4bfa92b38c23ada5716e9190ba1/eta/core/web.py#L206-L215) large file downloads from Google Drive seems to no longer work, this PR resolves that. 

## Example

```python
import eta.core.web as etaw

fid_large = "1O-WMjtiBBMXGEHnnus6y2nSlJu8pY5vo"
fid_small = "1UWTlFmdq8H-wdJHxVsAKpXBilY1CWwm_"

_ = etaw.download_google_drive_file(fid_large)
# Previous download size: 17.3Kb
# Now: 281.7Mb

_ = etaw.download_google_drive_file(fid_small)
# Previous download size: 188.0Mb
# Now: 188.0Mb
```

Adding `"confirm": "t"` to the params also works for smaller files that do not raise a prompt, however, I was unable to find much information about this. There may be some cases in which the old method of confirming the prompt through cookies is still required so I didn't remove that.