### PR TITLE
Add support for "natively installed" cloud credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__
 !/eta/models/manifest.json
 /eta/out
 
+/build
 /docs/*.tex
 /docs/*.html
 /docs/*.pdf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,18 @@
 repos:
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.6.0
+    rev: v1.12.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==19.10b0]
+        additional_dependencies: [black==21.12b0]
         args: ["-l 79"]
+        exclude: ^docs/theme/|\.rst$
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3
         args: ["-l 79"]
+        exclude: ^docs/theme/
   - repo: local
     hooks:
       - id: pylint
@@ -18,8 +20,20 @@ repos:
         language: system
         files: \.py$
         entry: pylint
-        args: ["--extension-pkg-whitelist=cv2", "--errors-only"]
+        args: ["--errors-only"]
+        exclude: ^(docs/theme/|app/)
+  - repo: local
+    hooks:
+      - id: ipynb-strip
+        name: ipynb-strip
+        language: system
+        files: \.ipynb$
+        exclude: ^docs/ # *do* commit ipynb outputs in `docs/`
+        entry: jupyter nbconvert --clear-output --ClearOutputPreprocessor.enabled=True
+        args: ["--log-level=ERROR"]
   - repo: https://github.com/prettier/prettier
     rev: 2.0.5
     hooks:
       - id: prettier
+        exclude: ^docs/theme/
+        language_version: system

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from builtins import *  # noqa
+from builtins import *
 from future.utils import iteritems
 import six
 
@@ -1237,8 +1237,8 @@ class NeedsAWSCredentials(object):
 
         Returns:
             a (credentials, path) tuple containing the credentials and the path
-                from which they were loaded. If the credentials were loaded
-                from environment variables, `path` will be None
+                from which they were loaded. If no credentials can be loaded,
+                `credentials` and `path` will be both be None.
         """
         if credentials_path:
             logger.debug(
@@ -1466,7 +1466,9 @@ class NeedsMinIOCredentials(object):
         Returns:
             a (credentials, path) tuple containing the credentials and the path
                 from which they were loaded. If the credentials were loaded
-                from environment variables, `path` will be None
+                from environment variables, `path` will be None. If no
+                credentials can be loaded, `credentials` and `path` will be
+                both be None.
         """
         if profile is None and "MINIO_PROFILE" in os.environ:
             logger.debug(
@@ -1741,7 +1743,8 @@ class NeedsGoogleCredentials(object):
         Returns:
             a (credentials, path) tuple containing the
                 `google.auth.credentials.Credentials` instance and the path
-                from which it was loaded
+                from which it was loaded. If no credentials can be loaded,
+                `credentials` and `path` will be both be None.
         """
 
         if credentials_path is not None:

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -50,10 +50,6 @@ try:
     import boto3
     import botocore
     import botocore.config as bcc
-
-    # TODO: remove the following
-    # import botocore.credentials as bcr
-    # import botocore.session as bcs
     import botocore.exceptions as bce
     import google.api_core.exceptions as gae
     import google.api_core.retry as gar

--- a/install.bash
+++ b/install.bash
@@ -243,12 +243,12 @@ if [ "${GCARD}" == "ON" ]; then
         CRITICAL pip install --upgrade tensorflow-gpu~=1.15
     else
         # Couldn't find CUDA
-        MSG "Installing tensorflow-gpu 1.15"
-        CRITICAL pip install --upgrade tensorflow-gpu~=1.15
+        MSG "Installing tensorflow-gpu"
+        CRITICAL pip install --upgrade tensorflow-gpu
     fi
 else
-    MSG "Installing tensorflow 1.15"
-    CRITICAL pip install --upgrade tensorflow~=1.15
+    MSG "Installing tensorflow"
+    CRITICAL pip install --upgrade tensorflow
 fi
 
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,24 +1,24 @@
 argcomplete==1.11.0
 contextlib2==0.5.5
-Cython==0.28.5
+Cython>=0.28.5 # 0.29.28
 dill==0.2.7.1
 future==0.16.0
 glob2==0.6
 importlib-metadata==1.3.0; python_version<"3.8"
 lxml==4.6.3
 ndjson==0.3.1
-numpy==1.16.3
-opencv-python-headless==4.1.0.25
+numpy>=1.16.3
+opencv-python-headless<5,>=4.1.0.25
 packaging==19.2
 patool==1.12
 Pillow==9.0.1
 python-dateutil==2.7.0
 pytz==2019.3
 requests-toolbelt==0.8.0
-requests==2.21.0
+requests>=2.21.0
 retrying==1.3.3
-scikit-image==0.16.2
-scipy==0.19.1
+scikit-image>=0.16.2
+scipy>=0.19.1
 setuptools==44.0.0;python_version<"3"
 setuptools==45.2.0;python_version>="3"
 simplejson==3.8.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 ipython==5.8.0;python_version<"3"
 ipython==7.16.3;python_version>="3"
 m2r==0.2.1
-pre-commit==2.0.1
+pre-commit==2.17.0
 pylint==1.9.4;python_version<"3"
 pylint==2.3.1;python_version>="3"
 Sphinx==2.4.4


### PR DESCRIPTION
Add support for using Application Default Credentials (GCP) and native IAM role (AWS) in lieu of requiring cloud storage 
credentials to be explicitly configured.

- https://cloud.google.com/docs/authentication/production#automatically
- https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials


## Testing (Local/Regression)
- Revoke any local permissions the AWS, Google Cloud SDK, MinIO might have.
- [Optional] Set up a [standalone version of MinIO](https://docs.min.io/minio/baremetal/) (if no server available).

- ### Requirements

    - #### AWS
        - Credentials that have access to the `voxel51-test` bucket.
        - `.ini` file  using those credentials with similar syntax to the following: 
        ```ini
        [default]
        aws_access_key_id = ...
        aws_secret_access_key = ...
        aws_session_token = ...  ; if applicable
        region = ...
        ```

    - #### GCP
        - Credentials that have access to the `voxel51-test` bucket.
        - JSON file with similar syntax to the following:
        ```json
        {
            "type": "service_account",
                "project_id": "<project-id>",
                "private_key_id": "<private-key-id>",
                "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
                "client_email": "<account-name>@<project-id>.iam.gserviceaccount.com",
                "client_id": "<client-id>",
                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                "token_uri": "https://oauth2.googleapis.com/token",
                "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
                "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/..."
        }
        ```
    - #### MinIO
        - Credentials to an instance of MinIO
        - A bucket in that instance, called `voxel51-test`, that has at least one file.
        - `.ini` file  using those credentials with similar syntax to the following: 
        ```ini
        [default]
        access_key = ...
        secret_access_key = ...
        endpoint_url = ...
        alias = ...  ; optional
        region = ...  ; if applicable    
        ```

- Run the following script:
    ```py
    # test.py

    import os

    import eta.core.storage as ecs

    AWS_ACCESS_KEY_ID = ""
    AWS_SECRET_ACCESS_KEY = ""
    AWS_DEFAULT_REGION = ""
    MINIO_ACCESS_KEY = ""
    MINIO_SECRET_ACCESS_KEY = ""
    MINIO_ENDPOINT_URL = ""

    LOCAL_CREDS_PATH_AWS = ""  # /some/path/to/aws.ini
    LOCAL_CREDS_PATH_GCP = ""  # /some/path/to/gcp.json
    LOCAL_CREDS_PATH_MINIO = "" # /some/path/to/minio.ini

    # Ensure any credential enivornment variables are unset
    os.environ.pop("AWS_ACCESS_KEY_ID", None)
    os.environ.pop("AWS_CONFIG_FILE", None)
    os.environ.pop("AWS_DEFAULT_REGION", None)
    os.environ.pop("AWS_SECRET_ACCESS_KEY", None)
    os.environ.pop("AWS_SHARED_CREDENTIALS_FILE", None)
    os.environ.pop("AWS_PROFILE", None)
    os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
    os.environ.pop("MINIO_ACCESS_KEY", None)
    os.environ.pop("MINIO_ALIAS", None)
    os.environ.pop("MINIO_CONFIG_FILE", None)
    os.environ.pop("MINIO_ENDPOINT_URL", None)
    os.environ.pop("MINIO_REGION", None)
    os.environ.pop("MINIO_SECRET_ACCESS_KEY", None)
    os.environ.pop("MINIO_SHARED_CREDENTIALS_FILE", None)

    # Ensure any active credentials are deactivated
    if ecs.S3StorageClient.has_active_credentials():
        ecs.S3StorageClient.deactivate_credentials()

    if ecs.GoogleCloudStorageClient.has_active_credentials():
        ecs.GoogleCloudStorageClient.deactivate_credentials()

    if ecs.MinIOStorageClient.has_active_credentials():
        ecs.MinIOStorageClient.deactivate_credentials()


    def get_aws_clients():
        clients = {}

        # === none ===
        try:
            ecs.S3StorageClient()
        except ecs.AWSCredentialsError:
            pass
        else:
            raise Exception(
                "Found S3 credentials. Please check the all defaults are disabled or removed."
            )

        # === explicit ===
        credentials, _ = ecs.S3StorageClient.load_credentials(
            credentials_path=LOCAL_CREDS_PATH_AWS
        )
        clients["explicit"] = ecs.S3StorageClient(credentials=credentials)
        assert isinstance(clients["explicit"], ecs.S3StorageClient)

        # === eta ===
        ecs.S3StorageClient.activate_credentials(LOCAL_CREDS_PATH_AWS)
        clients["eta"] = ecs.S3StorageClient()
        assert isinstance(clients["eta"], ecs.S3StorageClient)
        ecs.S3StorageClient.deactivate_credentials()

        # === boto3: individual env variables ===
        # Setting the following environment variables directly:
        # - AWS_ACCESS_KEY_ID
        # - AWS_SECRET_ACCESS_KEY
        # - AWS_DEFAULT_REGION
        os.environ["AWS_ACCESS_KEY_ID"] = AWS_ACCESS_KEY_ID
        os.environ["AWS_SECRET_ACCESS_KEY"] = AWS_SECRET_ACCESS_KEY
        os.environ["AWS_DEFAULT_REGION"] = AWS_DEFAULT_REGION

        clients["boto3:env"] = ecs.S3StorageClient()
        assert isinstance(clients["boto3:env"], ecs.S3StorageClient)

        del os.environ["AWS_ACCESS_KEY_ID"]
        del os.environ["AWS_SECRET_ACCESS_KEY"]
        del os.environ["AWS_DEFAULT_REGION"]

        # === boto3: shared credentials file ===
        # Setting the `AWS_SHARED_CREDENTIALS_FILE` environment variable to
        # point to a valid credentials `.ini` file
        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = LOCAL_CREDS_PATH_AWS

        clients["boto3:creds-file"] = ecs.S3StorageClient()
        assert isinstance(clients["boto3:creds-file"], ecs.S3StorageClient)

        del os.environ["AWS_SHARED_CREDENTIALS_FILE"]

        # === boto3: aws config file ===
        # Setting the `AWS_CONFIG_FILE` environment variable to point to a
        # valid credentials `.ini` file

        os.environ["AWS_CONFIG_FILE"] = LOCAL_CREDS_PATH_AWS

        clients["boto3:config-file"] = ecs.S3StorageClient()
        assert isinstance(clients["boto3:config-file"], ecs.S3StorageClient)

        del os.environ["AWS_CONFIG_FILE"]
        return clients


    def get_gcp_clients():
        clients = {}

        # === none ===
        try:
            ecs.GoogleCloudStorageClient()
        except ecs.GoogleCredentialsError:
            pass
        else:
            raise Exception(
                "Found GCP credentials. Please check the all defaults are disabled or removed."
            )

        # === explicit ===
        credentials, _ = ecs.GoogleCloudStorageClient.load_credentials(
            credentials_path=LOCAL_CREDS_PATH_GCP
        )
        clients["explicit"] = ecs.GoogleCloudStorageClient(credentials=credentials)
        assert isinstance(clients["explicit"], ecs.GoogleCloudStorageClient)

        # === eta ===
        ecs.GoogleCloudStorageClient.activate_credentials(LOCAL_CREDS_PATH_GCP)

        clients["eta"] = ecs.GoogleCloudStorageClient()
        assert isinstance(clients["eta"], ecs.GoogleCloudStorageClient)

        ecs.GoogleCloudStorageClient.deactivate_credentials()

        # === Application Default Credentials ===
        # https://google-auth.readthedocs.io/en/master/reference/google.auth.html

        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = LOCAL_CREDS_PATH_GCP

        clients["ADC:env"] = ecs.GoogleCloudStorageClient()
        assert isinstance(clients["ADC:env"], ecs.GoogleCloudStorageClient)

        del os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
        return clients


    def get_minio_clients():
        clients = {}

        # === none ===
        try:
            ecs.MinIOStorageClient()
        except ecs.MinIOCredentialsError:
            pass
        else:
            raise Exception(
                "Found MinIO credentials. Please check the all defaults are disabled or removed."
            )

        # === explicit ===
        credentials, _ = ecs.MinIOStorageClient.load_credentials(
            credentials_path=LOCAL_CREDS_PATH_MINIO
        )
        clients["explicit"] = ecs.MinIOStorageClient(credentials=credentials)
        assert isinstance(clients["explicit"], ecs.MinIOStorageClient)

        # === eta ===
        ecs.MinIOStorageClient.activate_credentials(LOCAL_CREDS_PATH_MINIO)
        clients["eta"] = ecs.MinIOStorageClient()
        assert isinstance(clients["eta"], ecs.MinIOStorageClient)
        ecs.MinIOStorageClient.deactivate_credentials()

        # === individual env variables ===
        # Setting the following environment variables directly:
        # - MINIO_ACCESS_KEY
        # - MINIO_SECRET_ACCESS_KEY
        # - MINIO_ENDPOINT_URL
        os.environ["MINIO_ACCESS_KEY"] = MINIO_ACCESS_KEY
        os.environ["MINIO_SECRET_ACCESS_KEY"] = MINIO_SECRET_ACCESS_KEY
        os.environ["MINIO_ENDPOINT_URL"] = MINIO_ENDPOINT_URL

        clients["env"] = ecs.MinIOStorageClient()
        assert isinstance(clients["env"], ecs.MinIOStorageClient)

        del os.environ["MINIO_ACCESS_KEY"]
        del os.environ["MINIO_SECRET_ACCESS_KEY"]
        del os.environ["MINIO_ENDPOINT_URL"]

        # === shared credentials file ===
        # Setting the `MINIO_SHARED_CREDENTIALS_FILE` environment variable to
        # point to a valid credentials `.ini` file
        os.environ["MINIO_SHARED_CREDENTIALS_FILE"] = LOCAL_CREDS_PATH_MINIO

        clients["creds-file"] = ecs.MinIOStorageClient()
        assert isinstance(clients["creds-file"], ecs.MinIOStorageClient)

        del os.environ["MINIO_SHARED_CREDENTIALS_FILE"]

        # === config file ===
        # Setting the `MINIO_CONFIG_FILE` environment variable to point to a
        # valid credentials `.ini` file

        os.environ["MINIO_CONFIG_FILE"] = LOCAL_CREDS_PATH_MINIO

        clients["config-file"] = ecs.MinIOStorageClient()
        assert isinstance(clients["config-file"], ecs.MinIOStorageClient)

        del os.environ["MINIO_CONFIG_FILE"]

        return clients


    providers = {
        "AWS": {
            "base_path": "s3://voxel51-test",
            "clients": get_aws_clients(),
        },
        "GCP": {
            "base_path": "gs://voxel51-test",
            "clients": get_gcp_clients(),
        },
        "MinIO": {
            "base_path": f"{MINIO_ENDPOINT_URL}/voxel51-test",
            "clients": get_minio_clients(),
        },
    }


    for provider_name, provider in providers.items():
        for client_key, client in provider["clients"].items():
            try:
                # ensure at one method call works and data is returned
                assert len(client.list_files_in_folder(provider["base_path"])) > 0
            except Exception as e:
                raise AssertionError(provider_name, client_key, e)
    ```





## Testing (Cloud VM)

Following are the steps I performed for each cloud provider to test the code changes:


### AWS
- Create an EC2 instance (or use "IAM Test" ). Make sure it has an attached IAM role account that can access S3.
- `ssh` onto the instance and ensure `python`, `pip`, `git` are installed.
- Run the following in the terminal:
    ```sh
    git clone https://github.com/voxel51/eta.git`
    cd eta
    git checkout develop
    pip install ".[storage]"
    ```
- Run the following script in `python`. It should print an error and exit.

    ```py     
    # aws_test.py

    import eta.core.storage as ecs

    try:
        client = ecs.S3StorageClient()
        client.list_files_in_folder("s3://voxel51-test")
    except ecs.AWSCredentialsError as e:
        print(e)
        exit()
    ```

- Run the following in the terminal:
    ```sh
    git checkout default-cloud-credentials
    pip install ".[storage]"
    ```
- Re-run `aws_test.py`. This time there should be no error and it should list the objects in the bucket.


### GCP
- Create an GCE instance (or use "default-service-account-test" ) in the "computer-vision-team" project. Make sure it has an attached service account that can access Storage.
- `ssh` onto the instance and ensure `python`, `pip`, `git` are installed.
- Run the following in the terminal:
    ```sh
    git clone https://github.com/voxel51/eta.git`
    cd eta
    git checkout develop
    pip install ".[storage]"
    ```
- Run the following script in `python`. It should print an error and exit.

    ```py     
    # gcp_test.py

    import eta.core.storage as ecs

    try:
        client = ecs.GoogleCloudStorageClient()
        client.list_files_in_folder("gs://voxel51-test")
    except ecs.GoogleCredentialsError as e:
        print(e)
        exit()
    ```

- Run the following in the terminal:
    ```sh
    git checkout default-cloud-credentials
    pip install ".[storage]"
    ```
- Re-run `gcp_test.py`. This time there should be no error and it should list the objects in the bucket. 

## TODO
- suppress logging from internal libraries