### PR TITLE
adding explicit start_number to ffmpeg

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -1957,14 +1957,12 @@ class VideoSetLabels(etal.LabelsSet):
         self.sort_by("filename", reverse=reverse)
 
     def clear_video_attributes(self):
-        """Removes all video-level attributes from all VideoLabels in the set.
-        """
+        """Removes all video-level attributes from all VideoLabels in the set."""
         for video_labels in self:
             video_labels.clear_video_attributes()
 
     def clear_frame_attributes(self):
-        """Removes all frame-level attributes from all VideoLabels in the set.
-        """
+        """Removes all frame-level attributes from all VideoLabels in the set."""
         for video_labels in self:
             video_labels.clear_frame_attributes()
 
@@ -4138,6 +4136,13 @@ class FFmpeg(object):
             in_opts = self.DEFAULT_IN_OPTS
         else:
             in_opts = self._in_opts
+
+        # Automatically determine the starting number of the inpath for cases
+        # where it's a sequence pattern (e.g. %06d.jpg).  The default behavior
+        # from ffmpeg is to start at 0 and look in the range [0,4].  If the first
+        # matched pattern begins above 4 we want to explicitly set that.
+        start_number = next(iter(etau.parse_pattern(inpath)), None) or 0
+        in_opts.extend(("-start_number", str(start_number)))
 
         # Output options
         if self._out_opts is None:


### PR DESCRIPTION
When ffmpeg is searching for files it looks for a sequence pattern containing `"%d"` or `"%0Nd"`, where the first filename of the file list specified by the pattern must contain a number inclusively contained between `start_number` and `start_number+start_number_range-1`.  By [default](http://ffmpeg.org/ffmpeg-all.html#image2-1) `start_number=0` and `start_number_range=5`.  If a file sequence begins at or after `start_number_range=5` an exception is thrown:
```
Could find no file with path '/fake/path/%06d.jpg' and index in the range 0-4
```

This change automatically determines the `start_number` to use based on the ffmpeg `inpath` parameter.  If no sequence is found then it will default to `0`, otherwise it will use the result of sequence pattern parsing.