### PR TITLE
adding retry to gcs client upload and download methods

### DIFF
--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1882,7 +1882,9 @@ class GoogleCloudStorageClient(
         if metadata:
             blob.metadata = metadata
 
-        blob.upload_from_filename(local_path, content_type=content_type)
+        blob.upload_from_filename(
+            local_path, content_type=content_type, retry=self._retry
+        )
 
     def upload_bytes(
         self, bytes_str, cloud_path, content_type=None, metadata=None
@@ -1902,7 +1904,9 @@ class GoogleCloudStorageClient(
         if metadata:
             blob.metadata = metadata
 
-        blob.upload_from_string(bytes_str, content_type=content_type)
+        blob.upload_from_string(
+            bytes_str, content_type=content_type, retry=self._retry
+        )
 
     def upload_stream(
         self, file_obj, cloud_path, content_type=None, metadata=None
@@ -1923,7 +1927,9 @@ class GoogleCloudStorageClient(
         if metadata:
             blob.metadata = metadata
 
-        blob.upload_from_file(file_obj, content_type=content_type)
+        blob.upload_from_file(
+            file_obj, content_type=content_type, retry=self._retry
+        )
 
     def download(self, cloud_path, local_path):
         """Downloads the file from GCS to the given location.
@@ -1934,7 +1940,7 @@ class GoogleCloudStorageClient(
         """
         blob = self._get_blob(cloud_path)
         etau.ensure_basedir(local_path)
-        blob.download_to_filename(local_path, checksum=None)
+        blob.download_to_filename(local_path, checksum=None, retry=self._retry)
 
     def download_bytes(self, cloud_path, start=None, end=None):
         """Downloads the file from GCS and returns the bytes string.
@@ -1948,7 +1954,9 @@ class GoogleCloudStorageClient(
             the downloaded bytes string
         """
         blob = self._get_blob(cloud_path)
-        return blob.download_as_bytes(start=start, end=end, checksum=None)
+        return blob.download_as_bytes(
+            start=start, end=end, checksum=None, retry=self._retry
+        )
 
     def download_stream(self, cloud_path, file_obj):
         """Downloads the file from GCS to the given file-like object.
@@ -1959,7 +1967,7 @@ class GoogleCloudStorageClient(
                 which must be open for writing
         """
         blob = self._get_blob(cloud_path)
-        blob.download_to_file(file_obj, checksum=None)
+        blob.download_to_file(file_obj, checksum=None, retry=self._retry)
 
     def delete(self, cloud_path):
         """Deletes the given file from GCS.

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1976,7 +1976,7 @@ class GoogleCloudStorageClient(
             cloud_path: the path to the GCS object to delete
         """
         blob = self._get_blob(cloud_path)
-        blob.delete()
+        blob.delete(retry=self._retry)
 
     def delete_folder(self, cloud_folder):
         """Deletes all files in the given GCS "folder".
@@ -1993,7 +1993,7 @@ class GoogleCloudStorageClient(
         )
 
         for blob in blobs:
-            blob.delete()
+            blob.delete(retry=self._retry)
 
     def get_file_metadata(self, cloud_path):
         """Returns metadata about the given file in GCS.
@@ -2057,7 +2057,7 @@ class GoogleCloudStorageClient(
             True/False
         """
         blob = self._get_blob(cloud_path)
-        return blob.exists()
+        return blob.exists(retry=self._retry)
 
     def is_folder(self, cloud_folder):
         """Determines whether the given GCS "folder" contains at least one
@@ -2171,7 +2171,7 @@ class GoogleCloudStorageClient(
         else:
             blob.metadata = metadata
 
-        blob.patch()
+        blob.patch(retry=self._retry)
 
     def _get_blob(self, cloud_path, include_metadata=False):
         bucket_name, object_name = self._parse_path(cloud_path)
@@ -2179,7 +2179,7 @@ class GoogleCloudStorageClient(
         blob = bucket.blob(object_name, chunk_size=self.chunk_size)
 
         if include_metadata:
-            blob.reload()
+            blob.reload(retry=self._retry)
 
         return blob
 


### PR DESCRIPTION
Small update to make sure that the GCS storage client upload and download methods are using the Retry object defined on the class.