### PR TITLE
Fix start number bug from #562

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         language: system
         files: \.py$
         entry: pylint
-        args: ["--errors-only"]
+        args: ["--extension-pkg-whitelist=cv2", "--errors-only"]
         exclude: ^(docs/theme/|app/)
   - repo: local
     hooks:
@@ -31,8 +31,8 @@ repos:
         exclude: ^docs/ # *do* commit ipynb outputs in `docs/`
         entry: jupyter nbconvert --clear-output --ClearOutputPreprocessor.enabled=True
         args: ["--log-level=ERROR"]
-  - repo: https://github.com/prettier/prettier
-    rev: 2.0.5
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.6.2
     hooks:
       - id: prettier
         exclude: ^docs/theme/

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -4145,7 +4145,9 @@ class FFmpeg(object):
             "-start_number" not in in_opts
         ):
             start_number = next(iter(etau.parse_pattern(inpath)), 0)
-            in_opts = in_opts.copy() + ["-start_number", str(start_number)]
+
+            # Note that `in_opts` modification must be a per-call change
+            in_opts = in_opts + ["-start_number", str(start_number)]
 
         # Output options
         if self._out_opts is None:

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -4138,18 +4138,14 @@ class FFmpeg(object):
             in_opts = self._in_opts
 
         # Automatically determine the starting number of the inpath for cases
-        # where it's a sequence pattern (e.g. %06d.jpg).  The default behavior
-        # from ffmpeg is to start at 0 and look in the range [0,4].  If the first
-        # matched pattern begins above 4 we want to explicitly set that.
-        if "-start_number" not in in_opts and is_supported_image_sequence(
-            inpath
+        # where it's a sequence pattern (e.g. %06d.jpg). The default behavior
+        # from ffmpeg is to start at 0 and look in the range [0, 4]. If the
+        # first matched pattern begins above 4 we want to explicitly set that.
+        if is_supported_image_sequence(inpath) and (
+            "-start_number" not in in_opts
         ):
             start_number = next(iter(etau.parse_pattern(inpath)), 0)
-
-            # Ensure in_opts modification is a per-call change
-            in_opts = in_opts.copy().extend(
-                ["-start_number", str(start_number)]
-            )
+            in_opts = in_opts.copy() + ["-start_number", str(start_number)]
 
         # Output options
         if self._out_opts is None:


### PR DESCRIPTION
Looks like https://github.com/voxel51/eta/pull/562 wasn't tested before releasing, because there was a bug (`extend()` returns `None`, not the list).

Example usage:

```py
import eta.core.video as etav

inpath = "/path/to/video.mp4"
frames_patt = "/tmp/frames/%06d.jpg"
outpath = "tmp/video.mp4"

ffmpeg = etav.FFmpeg()
ffmpeg.run(inpath, frames_patt)
ffmpeg.run(frames_patt, outpath)  # fails on `develop`, works on this branch
```
