### PR TITLE
Disable default logging modifications

### DIFF
--- a/eta/__init__.py
+++ b/eta/__init__.py
@@ -24,7 +24,6 @@ import sys
 
 import eta.constants as etac
 from eta.core.config import Config, EnvConfig
-import eta.core.logging as etal
 import eta.core.utils as etau
 
 
@@ -202,9 +201,6 @@ def is_python3():
     """Returns True/False whether the Python version running is 3.X."""
     return sys.version_info[0] == 3
 
-
-# Default logging behavior
-etal.basic_setup()
 
 # Load global ETA config
 config = ETAConfig.from_json(etac.CONFIG_JSON_PATH)

--- a/eta/core/logging.py
+++ b/eta/core/logging.py
@@ -1,6 +1,8 @@
 """
 Core logging infrastructure.
 
+Note that calling this module's methods will modify your **root logger**.
+
 Copyright 2017-2022, Voxel51, Inc.
 voxel51.com
 """


### PR DESCRIPTION
Currently, `import eta` triggers `eta.core.logging.basic_setup()` to be called, which modifies the user's root logger. This is bad manners for anyone who is simply using ETA as a dependency and not for it's [module](https://github.com/voxel51/eta/blob/develop/docs/modules_dev_guide.md) or [pipeline](https://github.com/voxel51/eta/blob/develop/docs/pipelines_dev_guide.md) constructs.

This PR removes the default logging configuration so that `import eta` by itself not cause any modifications to the root logger (it is only configured when ETA modules/pipelines are actually run).