### PR TITLE
Handling zero height/width when resizing images

### DIFF
--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -711,7 +711,7 @@ def resize(img, width=None, height=None, *args, **kwargs):
     if width is None or width < 0:
         width = int(round(iw * (height * 1.0 / ih)))
 
-    if ih == 0 | iw == 0 | width == 0 | height == 0:
+    if (ih == 0) | (iw == 0) | (width == 0) | (height == 0):
         shape = list(img.shape)
         shape[:2] = (height, width)
 

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -712,7 +712,10 @@ def resize(img, width=None, height=None, *args, **kwargs):
         width = int(round(iw * (height * 1.0 / ih)))
 
     if ih == 0 | iw == 0 | width == 0 | height == 0:
-        return np.zeros((height, width), dtype=img.dtype)
+        shape = list(img.shape)
+        shape[:2] = (height, width)
+
+        return np.zeros(shape, dtype=img.dtype)
 
     return cv2.resize(img, (width, height), *args, **kwargs)
 

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -711,6 +711,9 @@ def resize(img, width=None, height=None, *args, **kwargs):
     if width is None or width < 0:
         width = int(round(iw * (height * 1.0 / ih)))
 
+    if ih == 0 | iw == 0 | width == 0 | height == 0:
+        return np.zeros((height, width), dtype=img.dtype)
+
     return cv2.resize(img, (width, height), *args, **kwargs)
 
 
@@ -1200,7 +1203,10 @@ class Convert(object):
     """Interface for the ImageMagick convert binary."""
 
     def __init__(
-        self, executable="convert", in_opts=None, out_opts=None,
+        self,
+        executable="convert",
+        in_opts=None,
+        out_opts=None,
     ):
         """Constructs a convert command, minus the input/output paths.
 


### PR DESCRIPTION
`eta.core.image.resize()` was not previously robust to degenerate cases where an input/output width/height was zero. This PR resolves that.

```py
import fiftyone as fo
import numpy as np

detection = fo.Detection(
    label="empty",
    bounding_box=[0, 0, 0, 0],
    mask=np.zeros((0, 0)),
)

# Previously would raise an error; now succeeds
segmentation = detection.to_segmentation(frame_size=(32, 32))
```
