### PR TITLE
Adding support for nested progress bars

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -1457,8 +1457,7 @@ class CaptureStdout(object):
 
     def _get_stdout_loggers(self):
         all_loggers = it.chain(
-            [logging.getLogger()],
-            logging.Logger.manager.loggerDict.values()
+            [logging.getLogger()], logging.Logger.manager.loggerDict.values()
         )
 
         stdout_loggers = {}


### PR DESCRIPTION
Previously nesting progress bars would not work as expected. Specifically, the inner progress bar would not update in real-time. Now both progress bars are "live".

Current design decision is that only the outer progress bar's final progress string remains in stdout, while both progress bar's start messages do remain. My thinking here is that only the outer loop's total time is relevant after the fact, but it may still be interesting to see all info messages printed along the way.

```py
import time
import eta.core.logging as etal
import eta.core.utils as etau

etal.basic_setup()

with etau.ProgressBar(start_msg="foo") as pb1:
    for i in pb1(list(range(1000))):
        time.sleep(0.01)
        if i % 100 == 0:
            with etau.ProgressBar(start_msg="bar") as pb2:
                for _ in pb2(list(range(20))):
                    time.sleep(0.05)
```

Previous output:

```
foo
bar                                                                         
 100% |███████████████████████| 20/20 [1.0s elapsed, 0s remaining, 19.2 it/s]         
bar                                                                              
 100% |███████████████████████| 20/20 [1.0s elapsed, 0s remaining, 19.1 it/s]         
bar                                                                              
 100% |███████████████████████| 20/20 [1.1s elapsed, 0s remaining, 19.0 it/s]         
bar                                                                              
 100% |███████████████████████| 20/20 [1.1s elapsed, 0s remaining, 18.8 it/s]         
bar                                                                              
 100% |███████████████████████| 20/20 [1.1s elapsed, 0s remaining, 19.1 it/s]         
bar                                                                               
 100% |███████████████████████| 20/20 [1.1s elapsed, 0s remaining, 18.9 it/s]         
bar                                                                               
 100% |███████████████████████| 20/20 [1.1s elapsed, 0s remaining, 18.7 it/s]         
bar                                                                               
 100% |███████████████████████| 20/20 [1.0s elapsed, 0s remaining, 19.1 it/s]         
bar                                                                               
 100% |███████████████████████| 20/20 [1.0s elapsed, 0s remaining, 19.2 it/s]         
bar                                                                               
 100% |███████████████████████| 20/20 [1.1s elapsed, 0s remaining, 19.0 it/s]         
 100% |███████████████████| 1000/1000 [21.7s elapsed, 0s remaining, 89.5 it/s]
```

New output:

```
foo
bar                                                                         
bar                                                                                   
bar                                                                                   
bar                                                                                   
bar                                                                                   
bar                                                                                   
bar                                                                                   
bar                                                                                   
bar                                                                                   
bar                                                                                   
 100% |███████████████████| 1000/1000 [21.7s elapsed, 0s remaining, 91.5 it/s]        
```
