### PR TITLE
don't raise on EOPNOTSUPP

### DIFF
--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -4513,6 +4513,7 @@ def get_terminal_size():
             getattr(errno, "ENOTTY", None),
             getattr(errno, "ENXIO", None),
             getattr(errno, "EBADF", None),
+            getattr(errno, "EOPNOTSUPP", None)
         ):
             return (80, 24)
 


### PR DESCRIPTION
`get_terminal_size()` was failing because `os.get_terminal_size()` was raising `EOPNOTSUPP` when code was being executed in a different process spawned by node and stdout was piped through sockets. This PR adds this error code to the list of acceptable errors for which (80, 24) is returned.