### PR TITLE
Adding support for models with no managers and requirements.txt files on disk

### DIFF
--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -1807,15 +1807,12 @@ class ETAModelManager(ModelManager):
                 client = etas.GoogleDriveStorageClient()
                 client.download(gid, model_path)
                 logger.warning("Bandage applied")
-
         elif self.config.url:
             url = self.config.url
             logger.info("Downloading model from '%s' to '%s'", url, model_path)
             etaw.download_file(url, path=model_path)
         else:
-            raise ModelError(
-                "Invalid ETAModelManagerConfig '%s'" % str(self.config)
-            )
+            logger.info("Model downloading is not managed by ETA")
 
     def delete_model(self):
         raise NotImplementedError(

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -1428,7 +1428,9 @@ class ModelsManifest(Serializable):
                 "Manifest already contains model called '%s'" % model.name
             )
 
-        if self.has_model_with_filename(model.filename):
+        if model.filename is not None and self.has_model_with_filename(
+            model.filename
+        ):
             raise ModelError(
                 "Manifest already contains model with filename '%s'"
                 % (model.filename)


### PR DESCRIPTION
Changelog
- makes the `manager` property of `eta.core.models.Model` instances optional.
- adds support for loading package requirements for models from a `requirements.txt` file on disk