### PR TITLE
Release v0.12.2

### DIFF
--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -1663,7 +1663,7 @@ def _draw_bounding_box(
 
     # Title background
     if title_str:
-        textw, texth = font.getsize(title_str)
+        textw, texth = _get_text_size(font, title_str)
         bgtlx = boxtlx - linewidth + 1
         bgbry = boxtly - linewidth + 1
         bgbrx = bgtlx + textw + 2 * (label_text_pad_pixels + _DX)
@@ -1912,8 +1912,17 @@ def _parse_hex_color(h):
     return rgb
 
 
+def _get_text_size(font, string):
+    try:
+        _, _, w, h = font.getbbox(string)
+    except AttributeError:
+        w, h = font.getsize(string)  # Pillow<8
+
+    return w, h
+
+
 def _compute_max_text_size(font, text_strs):
-    sizes = [font.getsize(s) for s in text_strs]
+    sizes = [_get_text_size(font, s) for s in text_strs]
     width, height = np.max(sizes, axis=0)
     return width, height
 

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -1912,11 +1912,11 @@ def _parse_hex_color(h):
     return rgb
 
 
-def _get_text_size(font, string):
+def _get_text_size(font, text_str):
     try:
-        _, _, w, h = font.getbbox(string)
+        _, _, w, h = font.getbbox(text_str)
     except AttributeError:
-        w, h = font.getsize(string)  # Pillow<8
+        w, h = font.getsize(text_str)  # Pillow<8
 
     return w, h
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 from wheel.bdist_wheel import bdist_wheel
 
 
-VERSION = "0.12.1"
+VERSION = "0.12.2"
 
 
 class BdistWheelCustom(bdist_wheel):


### PR DESCRIPTION
`Pillow==10` removed a `Font.getsize()` method that we used in one module. This PR ensures that we remain compatible with all Pillow versions.

Credit to https://github.com/tensorflow/models/issues/11040 for showing an easy solution.

```py
import fiftyone as fo
import fiftyone.zoo as foz

dataset = foz.load_zoo_dataset("quickstart-video", max_samples=2)

# previously failed with `Pillow==10` installed; now succeeds
dataset.draw_labels("/tmp/draw-labels", overwrite=True)
```
