### PR TITLE
Pin pip 23.3.2 to fix publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3
       - name: Install dependencies
         run: |
-          pip install --upgrade pip setuptools==v69.0.3 wheel twine
+          pip install --upgrade pip==23.3.2 setuptools==v69.0.3 wheel twine
       - name: Install ETA
         run: |
           pip install --no-deps -e .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3
       - name: Install dependencies
         run: |
-          pip install --upgrade pip setuptools wheel twine
+          pip install --upgrade pip<24.0 setuptools wheel twine
       - name: Install ETA
         run: |
           pip install --no-deps -e .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3
       - name: Install dependencies
         run: |
-          pip install --upgrade pip<24.0 setuptools wheel twine
+          pip install --upgrade 'pip<24.0' setuptools wheel twine
       - name: Install ETA
         run: |
           pip install --no-deps -e .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3
       - name: Install dependencies
         run: |
-          pip install --upgrade pip setuptools wheel twine
+          pip install --upgrade pip setuptools==v69.0.3 wheel twine
       - name: Install ETA
         run: |
           pip install --no-deps -e .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: 3
       - name: Install dependencies
         run: |
-          pip install --upgrade 'pip<24.0' setuptools wheel twine
+          pip install --upgrade pip setuptools wheel twine
       - name: Install ETA
         run: |
           pip install --no-deps -e .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone ETA
         uses: actions/checkout@v2
@@ -17,7 +17,7 @@ jobs:
           python-version: 3
       - name: Install dependencies
         run: |
-          pip install --upgrade pip==23.3.2 setuptools==v69.0.3 wheel twine
+          pip install --upgrade pip setuptools wheel twine
       - name: Install ETA
         run: |
           pip install --no-deps -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+[build-system]
+requires = ["setuptools", "wheel"]
 [tool.black]
 line-length = 79
 include = '\.pyi?$'


### PR DESCRIPTION
Seeing an issue with publish in recent github actions. Pinning to 23.3.2 appears to fix it.
Also update runner to ubuntu 22 while at it.