### PR TITLE
Added support for handling 206 response in `eta.core.web.download_file()` - Fix for Issue #620

### DIFF
--- a/eta/core/web.py
+++ b/eta/core/web.py
@@ -152,7 +152,6 @@ class WebSession(object):
             self._do_download(r, f)
 
     def _get_streaming_response(self, url, headers=None, params=None):
-        headers = headers or {}
 
         r = self.sess.get(
             url,
@@ -180,7 +179,10 @@ class WebSession(object):
                 total_downloaded_bytes += len(chunk)
                 pb.update(8 * len(chunk))
 
-            while True:
+            while size_bytes is not None and (
+                "Accept-Ranges" in r.headers
+                and r.headers["Accept-Ranges"] is not None
+            ):
                 remaining_bytes = size_bytes - total_downloaded_bytes
                 if remaining_bytes > 0:
                     logger.debug(


### PR DESCRIPTION
This pull request addresses the issue outlined in [https://github.com/voxel51/eta/issues/620](https://github.com/voxel51/eta/issues/620).

With these changes, `eta.core.web.download_file()` now enables the complete download of any file from the internet, even when obtained as a 206 partial content response.

The implementation has undergone thorough testing with the provided script. The script attempts to download the same tar file that initially caused the issue reported in [https://github.com/voxel51/eta/issues/620](https://github.com/voxel51/eta/issues/620). Additionally, have validated scenarios where the download is not a 206 response, all of which function correctly.

```python
#!/usr/bin/env python
# pragma pylint: disable=redefined-builtin
# pragma pylint: disable=unused-wildcard-import
# pragma pylint: disable=wildcard-import
from __future__ import absolute_import
from __future__ import division
from __future__ import print_function
from __future__ import unicode_literals
from builtins import *

# pragma pylint: enable=redefined-builtin
# pragma pylint: enable=unused-wildcard-import
# pragma pylint: enable=wildcard-import

import logging
import os

import eta.core.web as etaw
import eta.core.utils as etau


logger = logging.getLogger(__name__)


FILE_ID = "http://data.csail.mit.edu/places/places365/test_256.tar"

path = os.path.join(os.path.dirname(__file__), "test.tar")
etaw.download_file(FILE_ID, path=path)
```

Upon completion of the download, the md5sum of the downloaded file was verified and matched the expected value.