### PR TITLE
Explicitly show progress bar for large files

### DIFF
--- a/eta/core/web.py
+++ b/eta/core/web.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 URL_REGEX = re.compile(r"http://|https://|ftp://|file://|file:\\")
+LARGE_FILE_SIZE = 128*1024**2  # 128 MB
 
 
 def is_url(filename):
@@ -168,8 +169,13 @@ class WebSession(object):
         size_bits = 8 * size_bytes if size_bytes is not None else None
         total_downloaded_bytes = 0
 
+        quiet = self.quiet
+        # Show progress bar for large files since they take a while to download
+        if size_bytes >= LARGE_FILE_SIZE:
+            quiet = False
+
         with etau.ProgressBar(
-            size_bits, use_bits=True, quiet=self.quiet
+            size_bits, use_bits=True, quiet=quiet
         ) as pb:
             for chunk in r.iter_content(chunk_size=self.chunk_size):
                 f.write(chunk)


### PR DESCRIPTION
When following our documentation to download large datasets (such as Open Images), the default behavior is that all progress bars are hidden; hence, sometimes, the snippet appears stuck when downloading large files. This PR changes the behavior so that progress bars are shown explicitly when downloading files greater than a certain size.

Before:
```
In [20]: dataset = foz.load_zoo_dataset(
    ...:     "open-images-v7",
    ...:     split="train",
    ...:     max_samples=1000,
    ...:     seed=51,
    ...:     shuffle=True,
    ...: )
Downloading split 'train' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train' if necessary
Downloading 'https://storage.googleapis.com/openimages/2018_04/train/train-images-boxable-with-rotation.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/metadata/image_ids.csv'
 100% |█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|    4.8Gb/4.8Gb [58.0s elapsed, 0s remaining, 89.5Mb/s]
Downloading 'https://storage.googleapis.com/openimages/v5/class-descriptions-boxable.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/metadata/classes.csv'
Downloading 'https://storage.googleapis.com/openimages/v6/oidv6-attributes-description.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/metadata/attributes.csv'
Downloading 'https://storage.googleapis.com/openimages/v5/classes-segmentation.txt' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/metadata/segmentation_classes.csv'
Downloading 'https://storage.googleapis.com/openimages/v7/oidv7-class-descriptions.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/metadata/point_classes.csv'
Downloading 'https://storage.googleapis.com/openimages/2018_04/bbox_labels_600_hierarchy.json' to '/var/folders/bg/cq0lv35x74s_8tlvqfdmf90r0000gn/T/tmptqnku3ue/metadata/hierarchy.json'
Downloading 'https://storage.googleapis.com/openimages/v5/train-annotations-human-imagelabels-boxable.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/labels/classifications.csv'

Downloading 'https://storage.googleapis.com/openimages/v6/oidv6-train-annotations-bbox.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/labels/detections.csv'
Downloading 'https://storage.googleapis.com/openimages/v7/oidv7-train-annotations-point-labels.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/labels/points.csv'
```

After:
```
In [1]: import fiftyone as fo
   ...: import fiftyone.zoo as foz

In [2]: dataset = foz.load_zoo_dataset(
   ...:     "open-images-v7",
   ...:     split="train",
   ...:     max_samples=1500,
   ...:     seed=51,
   ...:     shuffle=True,
   ...: )
Downloading split 'train' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train' if necessary
Downloading 'https://storage.googleapis.com/openimages/2018_04/train/train-images-boxable-with-rotation.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/metadata/image_ids.csv'
 100% |█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|    4.8Gb/4.8Gb [57.3s elapsed, 0s remaining, 88.3Mb/s]
Downloading 'https://storage.googleapis.com/openimages/v5/class-descriptions-boxable.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/metadata/classes.csv'
Downloading 'https://storage.googleapis.com/openimages/v6/oidv6-attributes-description.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/metadata/attributes.csv'
Downloading 'https://storage.googleapis.com/openimages/v5/classes-segmentation.txt' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/metadata/segmentation_classes.csv'
Downloading 'https://storage.googleapis.com/openimages/v7/oidv7-class-descriptions.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/metadata/point_classes.csv'
Downloading 'https://storage.googleapis.com/openimages/2018_04/bbox_labels_600_hierarchy.json' to '/var/folders/bg/cq0lv35x74s_8tlvqfdmf90r0000gn/T/tmpklrabgfn/metadata/hierarchy.json'
Downloading 'https://storage.googleapis.com/openimages/v5/train-annotations-human-imagelabels-boxable.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/labels/classifications.csv'
 100% |█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|    2.8Gb/2.8Gb [33.2s elapsed, 0s remaining, 89.8Mb/s]
Downloading 'https://storage.googleapis.com/openimages/v6/oidv6-train-annotations-bbox.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/labels/detections.csv'
 100% |████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|   16.8Gb/16.8Gb [3.3m elapsed, 0s remaining, 89.6Mb/s]
Downloading 'https://storage.googleapis.com/openimages/v7/oidv7-train-annotations-point-labels.csv' to '/Users/minhtuevo/.fiftyone/datasets/open-images-v7/train/labels/points.csv'
  21% |████████████████████████\-------------------------------------------------------------------------------------------|    5.6Gb/26.3Gb [1.1m elapsed, 4.1m remaining, 88.9Mb/s]