### PR TITLE
Handle empty polylines

### DIFF
--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -1122,7 +1122,11 @@ def render_bounding_box(polyline):
     Returns:
         a BoundingBox
     """
-    xx, yy = zip(*list(itertools.chain(*polyline.points)))
+    try:
+        xx, yy = zip(*list(itertools.chain(*polyline.points)))
+    except ValueError:
+        return etag.BoundingBox.empty()
+
     xtl = min(xx)
     ytl = min(yy)
     xbr = max(xx)


### PR DESCRIPTION
Resolves https://github.com/voxel51/eta/issues/641

```py
import numpy as np
import fiftyone as fo

polyline = fo.Polyline(points=[])

detection = polyline.to_detection()
assert np.allclose(detection.bounding_box, [0, 0, 0, 0])

detection = polyline.to_detection(mask_size=(2, 2))
assert np.allclose(detection.bounding_box, [0, 0, 0, 0])
assert np.allclose(detection.mask, [[False, False], [False, False]])
```
