### PR TITLE
Add support for S3 credential process config for S3 and MinIO storage

### DIFF
--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1412,6 +1412,8 @@ class S3StorageClient(_BotoStorageClient, NeedsAWSCredentials):
         if credentials is not None:
             credentials["region_name"] = credentials.pop("region", None)
 
+        credentials.pop("credential_process", None)
+
         try:
             super(S3StorageClient, self).__init__(
                 credentials,
@@ -1684,10 +1686,12 @@ class MinIOStorageClient(_BotoStorageClient, NeedsMinIOCredentials):
             raise MinIOCredentialsError("No MinIO credentials found")
 
         _credentials = {
-            "aws_access_key_id": credentials["access_key"],
-            "aws_secret_access_key": credentials["secret_access_key"],
             "region_name": credentials.get("region", "us-east-1"),
         }
+        if "access_key" in credentials:
+            _credentials["aws_access_key_id"] = credentials["access_key"]
+        if "secret_access_key" in credentials:
+            _credentials["aws_secret_access_key"] = credentials["secret_access_key"]
 
         alias = credentials.pop("alias", None)
         endpoint_url = credentials.pop("endpoint_url")


### PR DESCRIPTION
In some cases, users have mechanisms to provide s3 access key and secret access key credentials programatically which boto3 supports through a [credential_process](https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html)

What this means is instead of hard coding the credentials for each user into an ini file like this:
```
[default]
aws_access_key_id = XXXXXXXXXXXXXXXXXXX
aws_secret_access_key = YYYYYYYYYYYYYYYYY
region = us-east-2
```

It would look like this
```
[default]
credential_process = python /path/to/get_temp_credentials.py
region = us-east-2
```

Where `get_temp_credentials.py` might look something like:
```python
import datetime
import pytz

def get_credentials():
    access_key_id = "XXXXXXXXXXXXXXXXXXXXXX"
    secret_access_key = "YYYYYYYYYYYYYYYYYYYY"
    expiration_time = datetime.datetime.now(pytz.utc) + datetime.timedelta(minutes=15) 

    credentials = {
        "Version": 1,
        "AccessKeyId": access_key_id,
        "SecretAccessKey": secret_access_key,
        "Expiration": expiration_time.isoformat(),
    }
    return credentials
```

This allows multiple users to use the exact same `ini` file (in practice the credentials process will likely hit some API endpoint rather than a python script).

The changes in this PR make it so that:
* For MinIO-like storage, the access key and secret access key are no long required to be in the ini
* For AWS storage, the `credential_process` kwarg is removed when instantiating the `boto3.Session()` and it is picked up from the locally configured ini instead


To test this, you can configure the above credential process ini file and python script and attempt to call this using FiftyOne Enterprise:
```python
import fiftyone.core.storage as fos
fos.list_files("s3://some-bucket")
```
