### PR TITLE
Bugfix 

### DIFF
--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -1412,7 +1412,7 @@ class S3StorageClient(_BotoStorageClient, NeedsAWSCredentials):
         if credentials is not None:
             credentials["region_name"] = credentials.pop("region", None)
 
-        credentials.pop("credential_process", None)
+            credentials.pop("credential_process", None)
 
         try:
             super(S3StorageClient, self).__init__(


### PR DESCRIPTION
Fix error: 
```
│ /usr/local/lib/python3.11/site-packages/fiftyone/core/storage.py:2726 in _make_client            │
│                                                                                                  │
│ ❱ 2726 return _make_s3_client(credentials_path, profile, region, **kwargs)                       │
│                                                                                                  │
│                                                                                                  │
│ /usr/local/lib/python3.11/site-packages/fiftyone/core/storage.py:2863 in _make_s3_client         │
│                                                                                                  │
│ ❱ 2863 return S3StorageClient(credentials=credentials, **client_kwargs)                          │
│                                                                                                  │
│                                                                                                  │
│ /usr/local/lib/python3.11/site-packages/eta/core/storage.py:1415 in __init__                     │
│                                                                                                  │
│ ❱ 1415 credentials.pop("credential_process", None)                                               │
│                                                                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'NoneType' object has no attribute 'pop'
```