### PR TITLE
chore(deps): Pin paramiko

### DIFF
--- a/requirements/storage.txt
+++ b/requirements/storage.txt
@@ -6,3 +6,4 @@ google-auth-httplib2==0.0.3
 google-cloud-storage==1.7.0
 httplib2==0.15.0
 pysftp==0.2.9
+paramiko<4.0

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,9 @@ setup(
             "google-api-python-client",
             "google-cloud-storage>=1.36",
             "httplib2<=0.15",
-            "pysftp",
+            "pysftp==0.2.9",
+            # paramiko 4.0 no longer supports DSA Encryption (DSSKey)
+            "paramiko<4.0",
         ],
     },
     classifiers=[


### PR DESCRIPTION
Paramiko has removed support for DSA in versions 4+. We should pin to lower than 4+ until we decide the best way to handle this moving forward.

This PR pins `paramiko<4.0`