### PR TITLE
chore: pin paramiko to less than 4 to avoid DSSKey errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup, find_packages
 from wheel.bdist_wheel import bdist_wheel
 
 
-VERSION = "0.13.1"
+VERSION = "0.13.2"
 
 
 class BdistWheelCustom(bdist_wheel):
@@ -31,6 +31,7 @@ INSTALL_REQUIRES = [
     "jsonlines",
     "numpy",
     "packaging",
+    "paramiko>=3,<4",
     "Pillow>=6.2",
     "py7zr",
     "python-dateutil",


### PR DESCRIPTION
I guess this branch just gets to live forever since we have nowhere to merge it to.

This will fix previous versions of fiftyone to avoid today's `paramiko>4` DSSKey errors.