### PR TITLE
build(actions): AS-898 utilizing trusted publisher workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    environment: release # For trusted publishing. See below.
     steps:
       - name: Clone ETA
         uses: actions/checkout@v2
@@ -31,19 +32,10 @@ jobs:
       - name: Build wheel
         run: |
           RELEASE_VERSION=$(echo "${{ github.ref }}" | sed 's/^refs\/tags\/v//') python setup.py sdist bdist_wheel
-      - name: Upload wheel
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheel
-          path: dist/
-      - name: Set environment
-        env:
-          RELEASE_TAG: ${{ github.ref }}
-        run: |
-          echo "TWINE_PASSWORD=${{ secrets.FIFTYONE_PYPI_TOKEN }}" >> $GITHUB_ENV
-          echo "TWINE_REPOSITORY=pypi" >> $GITHUB_ENV
-      - name: Publish wheel
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_NON_INTERACTIVE: 1
-        run: twine upload dist/*
+      # Utilize
+      # [trusted publishers](https://docs.pypi.org/trusted-publishers/)
+      # This will use OIDC to publish the dists/ package to pypi.
+      # See
+      # [fiftyone-brain](https://pypi.org/manage/project/fiftyone-brain/settings/publishing/)
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: release # For trusted publishing. See below.
+    permissions:
+      id-token: write
     steps:
       - name: Clone ETA
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release # For trusted publishing. See below.
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Clone ETA

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,6 @@ jobs:
       # [trusted publishers](https://docs.pypi.org/trusted-publishers/)
       # This will use OIDC to publish the dists/ package to pypi.
       # See
-      # [fiftyone-brain](https://pypi.org/manage/project/fiftyone-brain/settings/publishing/)
+      # [voxel51-eta](https://pypi.org/manage/project/voxel51-eta/settings/publishing)
       - name: Publish
         uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -2259,7 +2259,9 @@ class GoogleCloudStorageClient(
             self._client._credentials, impersonated_credentials.Credentials
         ):
             self._signing_credentials = self._client._credentials
-        elif self._is_default_credentials and self._signing_credentials is None:
+        elif (
+            self._is_default_credentials and self._signing_credentials is None
+        ):
             # May need to ensure the client has been used at least once
             # https://gist.github.com/jezhumble/91051485db4462add82045ef9ac2a0ec?permalink_comment_id=3585157#gistcomment-3585157
             _ = self._get_blob(cloud_path)


### PR DESCRIPTION
Recently, I came across [trusted pypi publishers](https://docs.pypi.org/trusted-publishers/). They utilize OIDC to authenticate with PyPi so that we don't need to keep tokens around for individual users. 

Using short-lived credentials reduces things like attach surface areas and makes maintaining user credentials much easier!

This was tested with a private repository that published to [the PyPi test site](https://test.pypi.org/project/v51-trusted-workflow-package/).

A trusted publisher has also been added to the `voxel51-eta` project.

Some other changes in this PR came from `black` and `prettier` pre-commit hooks. Nothing functional changed.