### PR TITLE
dcos(RELEASING): AS-1103 add eta release docs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,43 @@
+# Releasing the ETA package
+
+> [!NOTE]
+> These steps are to be performed by authorized Voxel51 engineers.
+
+The `voxel51-eta` repository follows `Gitflow`.
+Releases will be initiated when a teammate submits a 
+pull request from their respective `release/v*` branch to `main`.
+We can see an example PR for
+[version 0.15.1](https://github.com/voxel51/eta/pull/670). 
+Reviewers should always check that the version in the `setup.py`
+matches the branch version.
+
+The release engineer will merge the pull request once it is approved.
+
+The PyPI uploads will be triggered when a release tag is pushed to the
+repository:
+
+1. Navigate to the
+   [releases page](https://github.com/voxel51/eta/releases).
+
+1. Select `Draft a new release`.
+
+1. Select `Create new tag` with the appropriate version and set the target to
+   `main`.
+
+    1. The tag format is `v<semantic-version>`.
+       For example, `v0.15.1`. 
+       This should match the `setup.py` and release branch.
+
+1. Select `Generate release notes`.
+
+1. Select `Set as the latest release`.
+
+1. Select `Publish release`.
+
+This will create a new tag in the repository and will trigger the
+[build/publish workflow](https://github.com/voxel51/eta/blob/develop/.github/workflows/publish.yml).
+This workflow will build the `.whl` artifacts and publish them to
+[PyPI](https://pypi.org/project/voxel51-eta/).
+
+Once the build are finished, submit a PR from `main` to `develop` to complete
+the `Gitflow` process.


### PR DESCRIPTION
The other day, we did a fiftyone-brain release. It makes sense to write down the steps that we took so other, newer, engineers can also understand the process.

This PR adds a new RELEASING.md. It made sense to me to put them in a separate file because CONTRIBUTING.md is used by (potentially) external collaborators and the release process doesn't apply to them.