### PR TITLE
Fix TF2 SavedModel loading for signature-based models

### DIFF
--- a/eta/detectors/tfmodels_detectors.py
+++ b/eta/detectors/tfmodels_detectors.py
@@ -1007,7 +1007,10 @@ def _load_tf2_detection_model(model_dir):
                 detections["detection_classes"],
             )
         else:
-            # inferred from tensor shapes
+            # centernet-mobilenet-v2-fpn was exported for TFLite and uses
+            # generic output names: output_1=scores, output_2=classes,
+            # output_3=boxes; see CenterNetModule in
+            # https://github.com/tensorflow/models/blob/master/research/object_detection/export_tflite_graph_lib_tf2.py
             boxes = detections["output_3"]
             scores = detections["output_1"]
             classes = detections["output_2"]


### PR DESCRIPTION
centernet-mobilenet-v2-fpn-512-coco-tf2 is exported with signatures rather than as a directly callable object, causing `TypeError: '_UserObject' object is not callable` when attempting inference.

This fix:
- Checks `callable(loaded)` and falls back to `signatures['serving_default']`
- Handles both standard output keys (detection_boxes, etc.) and generic output keys (output_0, output_1, etc.)

## Error

```python
import fiftyone.zoo as foz
import numpy as np

model = foz.load_zoo_model('centernet-mobilenet-v2-fpn-512-coco-tf2')
with model:
    model.predict(np.random.randint(0, 255, (512, 512, 3), dtype=np.uint8))
```

```
Traceback (most recent call last):
  File "<string>", line 7, in <module>
  File "fiftyone/utils/eta.py", line 205, in predict
    eta_labels = self._model.detect(arg)
  File "eta/detectors/tfmodels_detectors.py", line 502, in detect
    return self._detect_all([img])[0]
  File "eta/detectors/tfmodels_detectors.py", line 518, in _detect_all
    boxes, scores, classes = self._evaluate(imgs)
  File "eta/detectors/tfmodels_detectors.py", line 552, in _evaluate
    return self._detect_fn(imgs)
  File "eta/detectors/tfmodels_detectors.py", line 990, in predict
    detections = detect_fn(image)
TypeError: '_UserObject' object is not callable
```

## Related

Supersedes voxel51/fiftyone#6658