### PR TITLE
FOEPD-2833: Update copyright notices to 2026

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 #       - CUDA 9: tensorflow-gpu~=1.12
 #       - CUDA 10: tensorflow-gpu~=1.15
 #
-# Copyright 2017-2025, Voxel51, Inc.
+# Copyright 2017-2026, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2025, Voxel51, Inc.
+   Copyright 2017-2026, Voxel51, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/cli_guide.md
+++ b/docs/cli_guide.md
@@ -1541,4 +1541,4 @@ optional arguments:
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/core_dev_guide.md
+++ b/docs/core_dev_guide.md
@@ -87,4 +87,4 @@ uses a BGR format. This has two impacts:
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/cuda_install_guide.md
+++ b/docs/cuda_install_guide.md
@@ -173,6 +173,6 @@ https://medium.com/@zhanwenchen/install-cuda-and-cudnn-for-tensorflow-gpu-on-ubu
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com
 
 Yash Bhalgat, yash@voxel51.com

--- a/docs/custom_opencv_builds.md
+++ b/docs/custom_opencv_builds.md
@@ -129,4 +129,4 @@ sudo make uninstall
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/docker_build_guide.md
+++ b/docs/docker_build_guide.md
@@ -81,4 +81,4 @@ docker run -it --runtime=nvidia $TAG
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/export_tf_graphs_guide.md
+++ b/docs/export_tf_graphs_guide.md
@@ -123,4 +123,4 @@ etat.export_frozen_inference_graph(
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/guide2html.bash
+++ b/docs/guide2html.bash
@@ -8,7 +8,7 @@
 #   bash guide2html.bash modules_dev_guide.md
 #   bash guide2html.bash pipelines_dev_guide.md
 #
-# Copyright 2017-2025, Voxel51, Inc.
+# Copyright 2017-2026, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/docs/guide2tex.bash
+++ b/docs/guide2tex.bash
@@ -11,7 +11,7 @@
 #   bash guide2tex.bash modules_dev_guide.md
 #   bash guide2tex.bash pipelines_dev_guide.md
 #
-# Copyright 2017-2025, Voxel51, Inc.
+# Copyright 2017-2026, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/docs/linting_guide.md
+++ b/docs/linting_guide.md
@@ -93,4 +93,4 @@ information.
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/logging_guide.md
+++ b/docs/logging_guide.md
@@ -137,4 +137,4 @@ Formatter syntax
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/markdown_style_guide.md
+++ b/docs/markdown_style_guide.md
@@ -61,9 +61,9 @@ bash /your/command/here
 ```
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com
 ```
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/models_dev_guide.md
+++ b/docs/models_dev_guide.md
@@ -328,4 +328,4 @@ deletes the associated entry from the `manifest.json` file.
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/modules_dev_guide.md
+++ b/docs/modules_dev_guide.md
@@ -515,7 +515,7 @@ Info:
     type: {{the type of the module}}
     version: {{the module version}}
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 '''
 #
@@ -897,4 +897,4 @@ area = circle.area()  # pi
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/pipelines_dev_guide.md
+++ b/docs/pipelines_dev_guide.md
@@ -326,4 +326,4 @@ package.
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/python_style_guide.md
+++ b/docs/python_style_guide.md
@@ -102,4 +102,4 @@ def parse_object(d, key, cls, default=None):
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/storage_dev_guide.md
+++ b/docs/storage_dev_guide.md
@@ -333,4 +333,4 @@ with etas.SFTPStorageClient(hostname, username, private_key_path) as client:
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/virtualenv_guide.md
+++ b/docs/virtualenv_guide.md
@@ -121,4 +121,4 @@ http://stuarteberg.github.io/conda-docs/_downloads/conda-pip-virtualenv-translat
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/docs/visualize_tf_graphs_guide.md
+++ b/docs/visualize_tf_graphs_guide.md
@@ -59,4 +59,4 @@ TensorBoard.
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/eta/__init__.py
+++ b/eta/__init__.py
@@ -1,7 +1,7 @@
 """
 ETA package initialization.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 import logging

--- a/eta/classifiers/__init__.py
+++ b/eta/classifiers/__init__.py
@@ -1,7 +1,7 @@
 """
 Classifiers package declaration.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/classifiers/tfslim_classifiers.py
+++ b/eta/classifiers/tfslim_classifiers.py
@@ -2,7 +2,7 @@
 Interface to the TF-Slim image classification library available at
 https://github.com/voxel51/models/tree/master/research/slim.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 import logging

--- a/eta/classifiers/vgg16_classifiers.py
+++ b/eta/classifiers/vgg16_classifiers.py
@@ -2,7 +2,7 @@
 Classifier interface to the VGG-16 implementation from the `eta.core.vgg16`
 module.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 import numpy as np

--- a/eta/classifiers/voting_classifiers.py
+++ b/eta/classifiers/voting_classifiers.py
@@ -1,7 +1,7 @@
 """
 A collection of classifiers that use voting to generate predictions.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from eta.core.config import Config

--- a/eta/constants.py
+++ b/eta/constants.py
@@ -1,7 +1,7 @@
 """
 ETA package-wide constants.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/__init__.py
+++ b/eta/core/__init__.py
@@ -1,6 +1,6 @@
 """
 Package declaration.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """

--- a/eta/core/annotations.py
+++ b/eta/core/annotations.py
@@ -4,7 +4,7 @@ Core utilities for rendering annotations on media.
 @todo improve efficiency by minimizing number of times that images are copied
 and rendered.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from copy import deepcopy

--- a/eta/core/builder.py
+++ b/eta/core/builder.py
@@ -1,7 +1,7 @@
 """
 Core pipeline building system.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import defaultdict

--- a/eta/core/c3d.py
+++ b/eta/core/c3d.py
@@ -8,7 +8,7 @@ C3D implementation in TensorFlow:
 https://github.com/hx173149/C3D-tensorflow
 Hou Xin, 2016
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/cli.py
+++ b/eta/core/cli.py
@@ -1,7 +1,7 @@
 """
 Definition of the `eta` command-line interface (CLI).
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/config.py
+++ b/eta/core/config.py
@@ -1,7 +1,7 @@
 """
 Core tools for defining, reading and writing configuration files.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/data.py
+++ b/eta/core/data.py
@@ -1,7 +1,7 @@
 """
 Core tools and data structures for working with data.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import defaultdict

--- a/eta/core/datasets/__init__.py
+++ b/eta/core/datasets/__init__.py
@@ -1,7 +1,7 @@
 """
 Datasets package declaration.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 
 Tyler Ganter, tyler@voxel51.com

--- a/eta/core/datasets/builders.py
+++ b/eta/core/datasets/builders.py
@@ -2,7 +2,7 @@
 Core definition of `LabeledDatasetBuilder`s, which serve the purpose of
 managing and applying a series of `DatasetTransformer`s to `LabeledDataset`s.
 
-Copyright 2017-2025 Voxel51, Inc.
+Copyright 2017-2026 Voxel51, Inc.
 voxel51.com
 
 Ben Kane, ben@voxel51.com

--- a/eta/core/datasets/labeled_datasets.py
+++ b/eta/core/datasets/labeled_datasets.py
@@ -1,7 +1,7 @@
 """
 Core interfaces, data structures, and methods for working with datasets.
 
-Copyright 2017-2025 Voxel51, Inc.
+Copyright 2017-2026 Voxel51, Inc.
 voxel51.com
 
 Ben Kane, ben@voxel51.com

--- a/eta/core/datasets/split_methods.py
+++ b/eta/core/datasets/split_methods.py
@@ -1,7 +1,7 @@
 """
 Core methods for splitting iterables into subsets.
 
-Copyright 2017-2025 Voxel51, Inc.
+Copyright 2017-2026 Voxel51, Inc.
 voxel51.com
 
 Matthew Lightman, matthew@voxel51.com

--- a/eta/core/datasets/transformers.py
+++ b/eta/core/datasets/transformers.py
@@ -2,7 +2,7 @@
 Core definition of `DatasetTransformer`s, which define the interface and
 implementations of applying transformations to `BuilderDataset`s.
 
-Copyright 2017-2025 Voxel51, Inc.
+Copyright 2017-2026 Voxel51, Inc.
 voxel51.com
 
 Matthew Lightman, matthew@voxel51.com

--- a/eta/core/datasets/utils.py
+++ b/eta/core/datasets/utils.py
@@ -1,7 +1,7 @@
 """
 Utilities for working with `LabeledDataset`s.
 
-Copyright 2017-2025 Voxel51, Inc.
+Copyright 2017-2026 Voxel51, Inc.
 voxel51.com
 
 Jason Corso, jason@voxel51.com

--- a/eta/core/datasets/video2image.py
+++ b/eta/core/datasets/video2image.py
@@ -1,7 +1,7 @@
 """
 Convert LabeledVideoDataset to LabeledImageDataset
 
-Copyright 2017-2025 Voxel51, Inc.
+Copyright 2017-2026 Voxel51, Inc.
 voxel51.com
 
 Matthew Lightman, matthew@voxel51.com

--- a/eta/core/diagram.py
+++ b/eta/core/diagram.py
@@ -3,7 +3,7 @@ Core tools for building block diagrams of modules and pipelines.
 
 Block diagrams are built using the `blockdiag` package.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 import copy

--- a/eta/core/events.py
+++ b/eta/core/events.py
@@ -3,7 +3,7 @@ Core tools and data structures for working with events in images and videos.
 
 @todo add support for storing polylines and keypoints within events
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import defaultdict

--- a/eta/core/features.py
+++ b/eta/core/features.py
@@ -1,7 +1,7 @@
 """
 Core interfaces, data structures, and methods for feature extraction.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/frames.py
+++ b/eta/core/frames.py
@@ -1,7 +1,7 @@
 """
 Core tools and data structures for working with frames of videos.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/frameutils.py
+++ b/eta/core/frameutils.py
@@ -1,7 +1,7 @@
 """
 Utilities for working with frames of videos.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -2,7 +2,7 @@
 Core data structures for working with geometric concepts like points and
 bounding boxes.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/gps.py
+++ b/eta/core/gps.py
@@ -1,7 +1,7 @@
 """
 Core utilities for working with GPS coordinates.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/graph.py
+++ b/eta/core/graph.py
@@ -1,7 +1,7 @@
 """
 Core infrastructure for graph manipulation.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/image.py
+++ b/eta/core/image.py
@@ -8,7 +8,7 @@ Notes::
         produced outside of this library must be converted to RGB. This
         conversion can be done via `eta.core.image.bgr_to_rgb()`
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/job.py
+++ b/eta/core/job.py
@@ -1,7 +1,7 @@
 """
 Core job infrastructure for running modules in a pipeline.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/keypoints.py
+++ b/eta/core/keypoints.py
@@ -1,7 +1,7 @@
 """
 Core data structures for working with keypoints.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 import eta.core.data as etad

--- a/eta/core/labels.py
+++ b/eta/core/labels.py
@@ -1,7 +1,7 @@
 """
 Core data structures for working with labels.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import defaultdict

--- a/eta/core/learning.py
+++ b/eta/core/learning.py
@@ -1,7 +1,7 @@
 """
 Core infrastructure for deploying ML models.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/logging.py
+++ b/eta/core/logging.py
@@ -3,7 +3,7 @@ Core logging infrastructure.
 
 Note that calling this module's methods will modify your **root logger**.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/logo.py
+++ b/eta/core/logo.py
@@ -1,7 +1,7 @@
 """
 Tools for rendering logos on images.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/metadata.py
+++ b/eta/core/metadata.py
@@ -2,7 +2,7 @@
 Tools for generating metadata JSON files for ETA modules programmatically from
 source.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import defaultdict

--- a/eta/core/models.py
+++ b/eta/core/models.py
@@ -4,7 +4,7 @@ Core infrastructure for managing models across local and remote storage.
 See `docs/models_dev_guide.md` for detailed information about the design of
 the ETA model management system.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import defaultdict

--- a/eta/core/module.py
+++ b/eta/core/module.py
@@ -4,7 +4,7 @@ Core module infrastructure.
 See `docs/modules_dev_guide.md` for detailed information about the design and
 usage of ETA modules.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import OrderedDict

--- a/eta/core/numutils.py
+++ b/eta/core/numutils.py
@@ -1,7 +1,7 @@
 """
 Core numeric and computational utilities.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import defaultdict

--- a/eta/core/objects.py
+++ b/eta/core/objects.py
@@ -1,7 +1,7 @@
 """
 Core tools and data structures for working with objects in images and videos.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import defaultdict

--- a/eta/core/pipeline.py
+++ b/eta/core/pipeline.py
@@ -4,7 +4,7 @@ Core pipeline infrastructure.
 See `docs/pipelines_dev_guide.md` for detailed information about the design of
 the ETA pipeline system.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import defaultdict

--- a/eta/core/polylines.py
+++ b/eta/core/polylines.py
@@ -1,7 +1,7 @@
 """
 Core data structures for working with polylines and polygons.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 import eta.core.data as etad

--- a/eta/core/primitives.py
+++ b/eta/core/primitives.py
@@ -1,7 +1,7 @@
 """
 Implementations of computer vision primitive algorithms.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/serial.py
+++ b/eta/core/serial.py
@@ -1,7 +1,7 @@
 """
 Core data structures for working with data that can be read/written to disk.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from base64 import b64encode, b64decode

--- a/eta/core/status.py
+++ b/eta/core/status.py
@@ -1,7 +1,7 @@
 """
 Core status infrastructure for pipelines and jobs.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/storage.py
+++ b/eta/core/storage.py
@@ -12,7 +12,7 @@ This module currently provides clients for the following storage resources:
 - Web storage via HTTP requests
 - Local disk storage
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/tfutils.py
+++ b/eta/core/tfutils.py
@@ -1,7 +1,7 @@
 """
 Core utilities for working with TensorFlow models.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from copy import copy

--- a/eta/core/types.py
+++ b/eta/core/types.py
@@ -4,7 +4,7 @@ Core type system for ETA modules and pipelines.
 More types may be defined in other modules, but they must inherit from the
 base type `eta.core.types.Type` defined here.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/utils.py
+++ b/eta/core/utils.py
@@ -1,7 +1,7 @@
 """
 Core system and file I/O utilities.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/vgg16.py
+++ b/eta/core/vgg16.py
@@ -11,7 +11,7 @@ David Frossard, 2016
 Model architecture:
 https://gist.github.com/ksimonyan/211839e770f7b538e2d8#file-readme-md
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -10,7 +10,7 @@ Notes::
         produced outside of this library must be converted to RGB. This
         conversion can be done via `eta.core.image.bgr_to_rgb()`
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from copy import deepcopy

--- a/eta/core/web.py
+++ b/eta/core/web.py
@@ -1,7 +1,7 @@
 """
 Tools for downloading files from the web.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 import io

--- a/eta/core/ziputils.py
+++ b/eta/core/ziputils.py
@@ -8,7 +8,7 @@ specifically designed to automate the processing of parallel files and
 directories that arise when ETA modules support both both single inputs or zip
 files containing multiple inputs of the same type.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/detectors/__init__.py
+++ b/eta/detectors/__init__.py
@@ -1,7 +1,7 @@
 """
 Detectors package declaration.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 # Import all detectors into the `eta.detectors` namespace

--- a/eta/detectors/efficientdet.py
+++ b/eta/detectors/efficientdet.py
@@ -4,7 +4,7 @@ Interface to the EfficientDet object detection model.
 This module wraps the EfficientDet implementation at
 https://github.com/voxel51/automl/tree/master/efficientdet.
 
-Copyright 2017-2025 Voxel51, Inc.
+Copyright 2017-2026 Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com

--- a/eta/detectors/tfmodels_detectors.py
+++ b/eta/detectors/tfmodels_detectors.py
@@ -2,7 +2,7 @@
 Interface to the TF-Models Object Detection Library available at
 https://github.com/voxel51/models/tree/master/research/object_detection.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/detectors/utils.py
+++ b/eta/detectors/utils.py
@@ -1,7 +1,7 @@
 """
 Detectors utilities.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 import os

--- a/eta/detectors/yolo.py
+++ b/eta/detectors/yolo.py
@@ -2,7 +2,7 @@
 Tnterface to the YOLOv4 object detection library available at
 https://github.com/voxel51/darkflow.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com

--- a/eta/examples/README.md
+++ b/eta/examples/README.md
@@ -163,4 +163,4 @@ bash clean.bash
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/eta/examples/clean.bash
+++ b/eta/examples/clean.bash
@@ -4,7 +4,7 @@
 # Usage:
 #   bash clean.bash
 #
-# Copyright 2017-2025, Voxel51, Inc.
+# Copyright 2017-2026, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/eta/examples/demo_cats/README.md
+++ b/eta/examples/demo_cats/README.md
@@ -19,4 +19,4 @@ viewer of choice.
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/eta/examples/demo_embed_vgg16/README.md
+++ b/eta/examples/demo_embed_vgg16/README.md
@@ -20,4 +20,4 @@ capabilities supported in ETA.
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/eta/examples/demo_embed_vgg16/embed_image.py
+++ b/eta/examples/demo_embed_vgg16/embed_image.py
@@ -7,7 +7,7 @@ infrastructure, which is the preferred approach for ETA modules since they
 maintain the on-disk backing store for the class which is used to communicate
 between modules.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/examples/demo_embed_vgg16/embed_image_direct.py
+++ b/eta/examples/demo_embed_vgg16/embed_image_direct.py
@@ -6,7 +6,7 @@ This example has the same effect as `embed_image.py` except that it directly
 uses the low-level functionality rather than the higher level `Featurizer`
 functionality. It is included here for pedagogical reasons with ETA.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/examples/demo_embed_vgg16/embed_video.py
+++ b/eta/examples/demo_embed_vgg16/embed_video.py
@@ -6,7 +6,7 @@ Example of embedding the frames of a video in the VGG-16 feature space using
 Also shows the use of the `frame_preprocessor` functionality to embed a
 cropped version of each frame.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/examples/demo_image_classifier/README.md
+++ b/eta/examples/demo_image_classifier/README.md
@@ -25,4 +25,4 @@ corresponding to the model that you ran in your image viewer of choice.
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/eta/examples/demo_instance_segmentation/README.md
+++ b/eta/examples/demo_instance_segmentation/README.md
@@ -21,4 +21,4 @@ To visualize the results, view `out/people-annotated.mp4` and
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/eta/examples/demo_object_detector/README.md
+++ b/eta/examples/demo_object_detector/README.md
@@ -21,4 +21,4 @@ To visualize the results, view `out/people-annotated.mp4` and
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/eta/examples/demo_semantic_segmentation/README.md
+++ b/eta/examples/demo_semantic_segmentation/README.md
@@ -17,4 +17,4 @@ of choice.
 
 ## Copyright
 
-Copyright 2017-2025, Voxel51, Inc.<br> voxel51.com
+Copyright 2017-2026, Voxel51, Inc.<br> voxel51.com

--- a/eta/examples/download_data.py
+++ b/eta/examples/download_data.py
@@ -5,7 +5,7 @@ Downloads example data from Google Drive.
 Usage:
     python download_data.py
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/apply_classifier_to_objects.py
+++ b/eta/modules/apply_classifier_to_objects.py
@@ -7,7 +7,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/apply_image_classifier.py
+++ b/eta/modules/apply_image_classifier.py
@@ -7,7 +7,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/apply_image_model.py
+++ b/eta/modules/apply_image_model.py
@@ -7,7 +7,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/apply_image_semantic_segmenter.py
+++ b/eta/modules/apply_image_semantic_segmenter.py
@@ -7,7 +7,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/apply_object_detector.py
+++ b/eta/modules/apply_object_detector.py
@@ -7,7 +7,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/apply_video_classifier.py
+++ b/eta/modules/apply_video_classifier.py
@@ -6,7 +6,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/apply_video_event_detector.py
+++ b/eta/modules/apply_video_event_detector.py
@@ -7,7 +7,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/apply_video_frames_classifier.py
+++ b/eta/modules/apply_video_frames_classifier.py
@@ -7,7 +7,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 from collections import defaultdict, deque

--- a/eta/modules/apply_video_model.py
+++ b/eta/modules/apply_video_model.py
@@ -6,7 +6,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/clip_videos.py
+++ b/eta/modules/clip_videos.py
@@ -6,7 +6,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/embed_vgg16.py
+++ b/eta/modules/embed_vgg16.py
@@ -6,7 +6,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/format_videos.py
+++ b/eta/modules/format_videos.py
@@ -6,7 +6,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/sample_videos.py
+++ b/eta/modules/sample_videos.py
@@ -9,7 +9,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 import logging

--- a/eta/modules/video_stream_info.py
+++ b/eta/modules/video_stream_info.py
@@ -6,7 +6,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/visualize_image_labels.py
+++ b/eta/modules/visualize_image_labels.py
@@ -6,7 +6,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/modules/visualize_labels.py
+++ b/eta/modules/visualize_labels.py
@@ -6,7 +6,7 @@ Info:
     type: eta.core.types.Module
     version: 0.1.0
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/segmenters/__init__.py
+++ b/eta/segmenters/__init__.py
@@ -1,7 +1,7 @@
 """
 Segmenters package declaration.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/eta/segmenters/tf_segmenters.py
+++ b/eta/segmenters/tf_segmenters.py
@@ -2,7 +2,7 @@
 Generic interface for performing inference on semantic segmentation models
 stored as frozen TF graphs.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 import logging

--- a/eta/tensorflow/install_automl.bash
+++ b/eta/tensorflow/install_automl.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Installs the `eta/tensorflow/automl` submodule.
 #
-# Copyright 2017-2025, Voxel51, Inc.
+# Copyright 2017-2026, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/eta/tensorflow/install_darkflow.bash
+++ b/eta/tensorflow/install_darkflow.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Installs the `eta/tensorflow/darkflow` submodule.
 #
-# Copyright 2017-2025, Voxel51, Inc.
+# Copyright 2017-2026, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/eta/tensorflow/install_models.bash
+++ b/eta/tensorflow/install_models.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Installs the `eta/tensorflow/models` submodule.
 #
-# Copyright 2017-2025, Voxel51, Inc.
+# Copyright 2017-2026, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/install.bash
+++ b/install.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Installs ETA and its dependencies.
 #
-# Copyright 2017-2025, Voxel51, Inc.
+# Copyright 2017-2026, Voxel51, Inc.
 # voxel51.com
 #
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """
 Installs ETA.
 
-Copyright 2017-2025, Voxel51, Inc.
+Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 

--- a/sphinx/generate_docs.bash
+++ b/sphinx/generate_docs.bash
@@ -4,7 +4,7 @@
 # Usage:
 #   bash sphinx/generate_docs.bash
 #
-# Copyright 2017-2025, Voxel51, Inc.
+# Copyright 2017-2026, Voxel51, Inc.
 # voxel51.com
 #
 


### PR DESCRIPTION
# Rationale

n/a

## Changes

Updates copyright year to 2026. Does not add copyright notices to files without them.

## Testing

n/a
