### PR TITLE
deps(httplib2): Unpin http2lib version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
             "boto3>=1.15",
             "google-api-python-client",
             "google-cloud-storage>=1.36",
-            "httplib2<=0.15",
+            "httplib2",
             "pysftp",
         ],
     },


### PR DESCRIPTION
# Rationale

Older httplib2 versions are vulnerable to a few CVEs, we should update this package.

Related to https://github.com/voxel51/fiftyone/pull/6726.

## Changes

Removes `httplib2` constraint.

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->