### PR TITLE
fix(video): fix numpy>=2 - Replace fromstring with frombuffer

### DIFF
--- a/eta/core/video.py
+++ b/eta/core/video.py
@@ -3537,7 +3537,7 @@ class FFmpegVideoReader(VideoReader):
 
         width, height = self.frame_size
         try:
-            vec = np.fromstring(self._raw_frame, dtype="uint8")
+            vec = np.frombuffer(self._raw_frame, dtype="uint8")
             return vec.reshape((height, width, 3))
         except ValueError as e:
             # Possible alternative: return all zeros matrix instead


### PR DESCRIPTION
# Rationale

numpy v2 [completely removed](https://github.com/numpy/numpy/pull/28254) binary data mode from `numpy.fromstring`.

V2 requires we use `frombuffer()` in core/video.py
It's OK to change this to `frombuffer` for v1 as well.

## Changes

np.fromstring->np.frombuffer

## Testing

Installed numpy>=2 into fiftyone environment, run test. fails before, passes now.
```bash
pytest tests/unittests/model_tests.py::VideoModelTests::test_image_model_frames
```