### PR TITLE
Fix ±1px shift in render_instance_mask by using round() instead of int()

### DIFF
--- a/eta/core/geometry.py
+++ b/eta/core/geometry.py
@@ -447,7 +447,7 @@ class RelativePoint(Serializable):
             the absolute (x, y) coordinates of this point
         """
         w, h = _to_frame_size(frame_size=frame_size, shape=shape, img=img)
-        return int(w * 1.0 * self.x), int(h * 1.0 * self.y)
+        return int(round(w * self.x)), int(round(h * self.y))
 
     @staticmethod
     def clamp(x, y):


### PR DESCRIPTION
# Rationale

1. The `render_instance_mask()` computes the target region for an instance mask by calling `bounding_box.coords_in()`, which independently floors both the start and end coordinates using `int()`. 
2. Due to floating-point arithmetic, `floor(a + b) != floor(a) + floor(b)`, causing the computed target size to be `±1px` off from the actual mask dimensions. 
3. When this mismatch occurs, the mask is resized with interpolation, shifting pixels by `1-2px`.
4. This affects FiftyOne's `objects_to_segmentations()`, where segmentation labels appear shifted by 1-2px for **_detections_** with fractional pixel coordinates.

## Changes

- Updated `render_instance_mask()` to compute pixel coordinates using `round()` instead of delegating to `coords_in()` (which uses `int()`). 
- The resize behavior is preserved for cases where the mask resolution genuinely differs from the target region.

## Testing

Tested with 11 synthetic cases via FiftyOne's `objects_to_segmentations()`:
- 9 fractional coordinate cases that triggered `±1px` mismatch with `int()` — all pass with `round()`
- 1 exact integer coordinate case — no change in behavior
- 1 resolution mismatch case (**_512x512 mask into 8x8 target region_**) — resize works correctly

## Related

- FiftyOne [PR #7006](https://github.com/voxel51/fiftyone/pull/7006) 


<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->