### PR TITLE
Release v0.16.0: drop Python 3.9

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,4 +41,4 @@ jobs:
       # See
       # [voxel51-eta](https://pypi.org/manage/project/voxel51-eta/settings/publishing)
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ lxml==6.1.0
 numpy>=1.16.3
 opencv-python-headless<5,>=4.1.0.25
 packaging==19.2
-Pillow==10.3.0
+Pillow==12.2.0
 py7zr==0.20.4
 python-dateutil==2.7.0
 pytz==2019.3

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -24,4 +24,4 @@ simplejson==3.8.1
 sortedcontainers==2.1.0
 tabulate==0.8.5
 tzlocal==2.0.0
-urllib3==2.6.3
+urllib3==2.7.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,7 +4,7 @@ Cython>=0.28.5 # 0.29.28
 dill==0.2.7.1
 glob2==0.6
 jsonlines==3.1.0
-lxml==4.9.1
+lxml==6.1.0
 numpy>=1.16.3
 opencv-python-headless<5,>=4.1.0.25
 packaging==19.2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from importlib import metadata
 from setuptools import find_packages, setup
 from wheel.bdist_wheel import bdist_wheel
 
-VERSION = "0.15.5"
+VERSION = "0.16.0"
 
 
 class BdistWheelCustom(bdist_wheel):
@@ -137,11 +137,10 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
     entry_points={"console_scripts": ["eta=eta.core.cli:main"]},
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     cmdclass={"bdist_wheel": BdistWheelCustom},
 )

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     entry_points={"console_scripts": ["eta=eta.core.cli:main"]},
     python_requires=">=3.10",


### PR DESCRIPTION
## Summary
Drops Python 3.9, adds Python 3.12, and cuts release **v0.16.0**.

- `python_requires` bumped to `>=3.10`; removed the 3.9 trove classifier, added the 3.12 classifier
- `setup.py` version bumped `0.15.5` → `0.16.0`

## Release checklist (per RELEASING.md)
- [x] Version in `setup.py` matches branch (`v0.16.0`)
- [x] Merged to `main` (this PR). Draft release tag `v0.16.0` targeting `main` to trigger PyPI publish — _release/tag still pending_
- [x] Open follow-up PR `main` → `develop` to complete Gitflow — #707