### PR TITLE
fix: include paramiko in the storage extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(
             "google-api-python-client",
             "google-cloud-storage>=1.36",
             "httplib2",
+            "paramiko",
         ],
     },
     classifiers=[


### PR DESCRIPTION
#718 replaced pysftp with a native paramiko SFTP client and removed pysftp from the `storage` extra, but paramiko was never added in its place. A standalone `voxel51-eta[storage]` install therefore lacks paramiko, and the ImportError raised by `eta.core.storage` advises installing `[storage]` — which would not fix it.

Verified against paramiko 5.0.0 with an SFTP smoke test covering the full `SFTPStorageClient` surface (file/bytes/stream round-trips, recursive dir transfer, `make_dir` octal-as-decimal mode, deletes, keep-open context manager, and unknown-host-key rejection parity with pysftp defaults): 8/8 passed.

Intended for the v0.17.0 release alongside #718.