### PR TITLE
Bump develop to 0.18.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from importlib import metadata
 from setuptools import find_packages, setup
 from wheel.bdist_wheel import bdist_wheel
 
-VERSION = "0.16.0"
+VERSION = "0.18.0"
 
 
 class BdistWheelCustom(bdist_wheel):


### PR DESCRIPTION
Bumps the develop version to 0.18.0 while the 0.17.0 release (#724) is in flight, so the post-release main -> develop back-merge has no version-file conflict.