### PR TITLE
chore: move static package metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,76 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "voxel51-eta"
+dynamic = ["version"]
+description = "Extensible Toolkit for Analytics"
+readme = "README.md"
+authors = [{ name = "Voxel51, Inc.", email = "info@voxel51.com" }]
+license = { text = "Apache" }
+requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Image Processing",
+    "Topic :: Scientific/Engineering :: Image Recognition",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Scientific/Engineering :: Visualization",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "argcomplete",
+    "dill",
+    "glob2",
+    "jsonlines",
+    "numpy",
+    "opencv-python-headless<5,>=4.1",
+    "packaging",
+    "paramiko>=3,<6",
+    "Pillow>=6.2",
+    "py7zr",
+    "python-dateutil",
+    "pytz",
+    "rarfile",
+    "requests",
+    "retrying",
+    "scikit-image",
+    "sortedcontainers",
+    "tabulate",
+    "tzlocal",
+    "urllib3",
+]
+
+[project.optional-dependencies]
+pipeline = ["blockdiag", "Sphinx", "sphinxcontrib-napoleon"]
+storage = [
+    "azure-identity",
+    "azure-storage-blob>=12.4.0",
+    "boto3>=1.15",
+    "google-api-python-client",
+    "google-cloud-storage>=1.36",
+    "httplib2",
+    "paramiko",
+]
+
+[project.urls]
+Homepage = "https://github.com/voxel51/eta"
+
+[project.scripts]
+eta = "eta.core.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["eta*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/setup.py
+++ b/setup.py
@@ -2,85 +2,19 @@
 """
 Installs ETA.
 
+All static package metadata lives in pyproject.toml; this shim exists to
+support the RELEASE_VERSION environment variable, which the publish
+workflow uses to build release candidate versions.
+
 Copyright 2017-2026, Voxel51, Inc.
 voxel51.com
 """
 
 import os
-import re
-from importlib import metadata
 
-from setuptools import find_packages, setup
-from wheel.bdist_wheel import bdist_wheel
+from setuptools import setup
 
 VERSION = "0.17.0"
-
-
-class BdistWheelCustom(bdist_wheel):
-    def finalize_options(self):
-        bdist_wheel.finalize_options(self)
-        # Pure Python, so build a wheel for any Python version
-        self.universal = True
-
-
-INSTALL_REQUIRES = [
-    "argcomplete",
-    "dill",
-    "glob2",
-    "jsonlines",
-    "numpy",
-    "packaging",
-    "paramiko>=3,<6",
-    "Pillow>=6.2",
-    "py7zr",
-    "python-dateutil",
-    "pytz",
-    "rarfile",
-    "requests",
-    "retrying",
-    "scikit-image",
-    "sortedcontainers",
-    "tabulate",
-    "tzlocal",
-    "urllib3",
-]
-
-
-CHOOSE_INSTALL_REQUIRES = [
-    (
-        (
-            "opencv-python",
-            "opencv-contrib-python",
-            "opencv-contrib-python-headless",
-        ),
-        "opencv-python-headless<5,>=4.1",
-    )
-]
-
-
-def choose_requirement(mains, secondary):
-    chosen = secondary
-    for main in mains:
-        try:
-            name = re.split(r"[!<>=]", main)[0]
-            metadata.version(name)
-            chosen = main
-            break
-        except metadata.PackageNotFoundError:
-            pass
-
-    return str(chosen)
-
-
-def get_install_requirements(install_requires, choose_install_requires):
-    for mains, secondary in choose_install_requires:
-        install_requires.append(choose_requirement(mains, secondary))
-
-    return install_requires
-
-
-with open("README.md", "r") as fh:
-    long_description = fh.read()
 
 
 def get_version():
@@ -96,52 +30,4 @@ def get_version():
     return VERSION
 
 
-setup(
-    name="voxel51-eta",
-    version=get_version(),
-    description="Extensible Toolkit for Analytics",
-    author="Voxel51, Inc.",
-    author_email="info@voxel51.com",
-    url="https://github.com/voxel51/eta",
-    license="Apache",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    packages=find_packages(),
-    include_package_data=True,
-    install_requires=get_install_requirements(
-        INSTALL_REQUIRES, CHOOSE_INSTALL_REQUIRES
-    ),
-    extras_require={
-        "pipeline": ["blockdiag", "Sphinx", "sphinxcontrib-napoleon"],
-        "storage": [
-            "azure-identity",
-            "azure-storage-blob>=12.4.0",
-            "boto3>=1.15",
-            "google-api-python-client",
-            "google-cloud-storage>=1.36",
-            "httplib2",
-            "paramiko",
-        ],
-    },
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        "Topic :: Scientific/Engineering :: Image Processing",
-        "Topic :: Scientific/Engineering :: Image Recognition",
-        "Topic :: Scientific/Engineering :: Information Analysis",
-        "Topic :: Scientific/Engineering :: Visualization",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: POSIX :: Linux",
-        "Operating System :: Microsoft :: Windows",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-    ],
-    entry_points={"console_scripts": ["eta=eta.core.cli:main"]},
-    python_requires=">=3.10",
-    cmdclass={"bdist_wheel": BdistWheelCustom},
-)
+setup(version=get_version())


### PR DESCRIPTION
Stacked on #726 (GitHub will retarget to `release/v0.17.0` when it merges).

Moves all static package metadata to a `[project]` table in pyproject.toml. `setup.py` becomes a shim that only supplies the version, preserving the `RELEASE_VERSION` env override that publish.yml uses for release candidate builds — the publish workflow needs no changes.

Two intentional simplifications:

- **The opencv `choose_requirement` hack is replaced by a static `opencv-python-headless<5,>=4.1` dependency.** The hack probed the build environment for installed opencv variants, but pip's build isolation always hands it an empty environment, so every published wheel already carries exactly that requirement — this is a no-op for installers.
- **The `universal=True` (py2.py3) wheel tag is dropped**; wheels are now `py3-none-any`, matching `requires-python = ">=3.10"`.

Verification, diffing wheels built before/after the change:

- File lists byte-identical (158 files); `entry_points.txt` identical
- METADATA differs only in modern-format equivalences (`Author`/`Home-page` headers → `Author-email`/`Project-URL`, `Dynamic:` markers removed)
- `RELEASE_VERSION=0.17.0-rc.1 python setup.py sdist bdist_wheel` — the exact publish.yml invocation — builds `voxel51_eta-0.17.0rc1` wheel + sdist, and the version-mismatch guard still raises
- Unit tests pass