### PR TITLE
chore: add ruff correctness baseline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,21 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Clone ETA
+        uses: actions/checkout@v6
+      - name: Set up Python 3
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3
+      - name: Install ruff
+        run: pip install ruff==0.16.0
+      - name: Check Python correctness
+        run: ruff check --output-format=github .
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "pre-commit",
     "pylint",
     "pytest",
+    "ruff",
     "Sphinx",
     "sphinx-rtd-theme",
     "sphinxcontrib-napoleon",
@@ -84,6 +85,15 @@ include = ["eta*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+required-version = "==0.16.0"
+target-version = "py310"
+line-length = 79
+
+[tool.ruff.lint]
+select = ["E9", "F63", "F7", "F82", "F811"]
+fixable = []
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
# Rationale

Adopts the ruff correctness policy from voxel51/fiftyone#8123: a pinned ruff limited to correctness rules, with formatting and import sorting intentionally not enforced.

## Changes

- `[tool.ruff]` in `pyproject.toml`: pinned version, correctness rules only (`E9`, `F63`, `F7`, `F82`, `F811`), `fixable = []`
- `lint` job added to the tests workflow
- `ruff` added to the `dev` extra

## Testing

`ruff check .` passes clean with the pinned version and config — no code changes required.

## Related

- voxel51/fiftyone#8123, voxel51/fiftyone-brain#305
