### PR TITLE
docs(RELEASING.MD): update release docs with more detail for procedur…

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,9 +3,10 @@
 > [!NOTE]
 > These steps are to be performed by authorized Voxel51 engineers.
 
-`main` is the trunk: every PR merges to `main`, and nothing originates on a
-release branch. Between releases, `VERSION` in `setup.py` is the next planned
-version. Reviewers of version-bump PRs should always check that the version
+This repository is trunk based with the `main` branch as the trunk.
+Every PR merges to `main` and nothing originates on a release branch.
+Between releases, `VERSION` in `setup.py` is the next planned version.
+Reviewers of version-bump PRs should always check that the version
 matches the tag being cut.
 
 ## Minor / major release (vX.Y.0)
@@ -13,37 +14,80 @@ matches the tag being cut.
 1. Confirm `VERSION` in `setup.py` on `main` is `X.Y.0`.
 
 1. Navigate to the
-   [releases page](https://github.com/voxel51/eta/releases) and select
-   `Draft a new release`.
+   [releases page](https://github.com/voxel51/eta/releases)
+   and select *Draft a new release*
+1. From the *Tag: Select Tag* drop down,
+   select *Create new tag*,
+   enter `vX.Y.0`,
+   select *Create*
+1. Set the *Target* branch to `main`
+1. Select *Generate release notes*
+1. For the *Release label, select *Latest*
+1. Select *Publish release*
+1. Monitor the
+   [publish workflow](https://github.com/voxel51/eta/blob/main/.github/workflows/publish.yml)
+   (triggered by the tag push)
+   and re-run until successful
 
-1. Select `Create new tag` with tag `vX.Y.0` and set the target to `main`.
+   > [!NOTE]
+   > The worklow builds the `.whl` artifacts and publishes them to
+   > [PyPI](https://pypi.org/project/voxel51-eta/)
 
-1. Select `Generate release notes`, then `Set as the latest release`, then
-   `Publish release`.
+1. Validate latest version is published to
+   [https://pypi.org/project/voxel51-eta/](https://pypi.org/project/voxel51-eta/)
 
-   Pushing the tag triggers the
-   [publish workflow](https://github.com/voxel51/eta/blob/main/.github/workflows/publish.yml),
-   which builds the `.whl` artifacts and publishes them to
-   [PyPI](https://pypi.org/project/voxel51-eta/).
-
-1. Open a version-bump PR to `main` advancing `VERSION` to the next planned
-   version.
+1. Open a version-bump PR to `main` advancing `VERSION`
+   to the next planned version
 
 ## Patch release (vX.Y.Z)
 
-1. Cut `release/vX.Y.Z` from the `vX.Y.Z-1` tag.
+1. Merge the fixes on `main`
+1. Create a new branch `release/vX.Y.Z` from the `vX.Y.Z-1` tag
 
-1. Land the fixes on `main` first, then `git cherry-pick -x` them to the
-   release branch via PR. A release branch accepts only cherry-picks of
-   `main` commits and its version bump — no back-merges in either direction.
+    ```shell
+    git checkout vX.Y.Z-1
+    git checkout -b `release/vX.Y.Z`
+    git push
+    ```
+
+1. Cherry pick the changes to the release branch via PR
+
+    ```shell
+    git checkout -b 'cherry-pick/fix-...'
+    git cherry-pick -x <COMMIT_SHA>
+    git push
+    ```
+
+    > [!NOTE]
+    > A release branch accepts only cherry-picks of
+    > `main` commits and its version bump.
 
 1. Open a PR to the release branch bumping `VERSION` to `X.Y.Z`.
+1. Navigate to the
+   [releases page](https://github.com/voxel51/eta/releases)
+   and select *Draft a new release*
+1. From the *Tag: Select Tag* drop down,
+   select *Create new tag*,
+   enter `vX.Y.Z`,
+   select *Create*
+1. Set the *Target* branch to `release/vX.Y.Z`
+1. Select *Generate release notes*
+1. For the *Release label, select *Latest*
+1. Select *Publish release*
+1. Monitor the
+   [publish workflow](https://github.com/voxel51/eta/blob/main/.github/workflows/publish.yml)
+   (triggered by the tag push)
+   and re-run until successful
 
-1. Draft the GitHub release with tag `vX.Y.Z` targeting `release/vX.Y.Z`,
-   following the steps above.
+    > [!NOTE]
+    > The worklow builds the `.whl` artifacts and publishes them to
+    > [PyPI](https://pypi.org/project/voxel51-eta/)
+
+1. Validate latest version is published to
+   [https://pypi.org/project/voxel51-eta/](https://pypi.org/project/voxel51-eta/)
 
 ## Release candidates
 
-Tag `vX.Y.Z-rc.N` on the branch being released. The publish workflow builds
-the rc version via the `RELEASE_VERSION` environment variable and validates
-it against `setup.py`.
+Create and push a tag `vX.Y.Z-rc.N` on the branch being released.
+The publish workflow builds the rc version via the `RELEASE_VERSION`
+environment variable and validates it against `setup.py`.


### PR DESCRIPTION
…al following.

# Rationale

On Friday, we intended to publish the `0.17.0` version of eta.  I didn't notice that the publish workflow failed. Let's update the docs to call that out.

## Changes

* releasing
  * add more steps that are declarative and easier to follow

## Testing

* n/a

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->