### PR TITLE
Declare Python 3.14 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "argcomplete",


### PR DESCRIPTION
Adds the Python 3.14 classifier. ETA is pure Python with no cp314-blocked dependencies; verified locally on Python 3.14.5 that the package installs and imports cleanly.