### PR TITLE
Read optional package metadata fields with fallbacks

### DIFF
--- a/eta/constants.py
+++ b/eta/constants.py
@@ -44,11 +44,14 @@ DEFAULT_LOGO_CONFIG_PATH = os.path.join(
 
 
 # Package metadata
+# Wheels built from pyproject metadata omit some legacy fields (eg "author"
+# and "home-page"), and indexing a missing key warns on Python 3.12+ and
+# raises on Python 3.14+, so optional fields must use `get()` with fallbacks
 NAME = _META["name"]
 VERSION = _META["version"]
 DESCRIPTION = _META["summary"]
-AUTHOR = _META["author"]
-AUTHOR_EMAIL = _META["author-email"]
-URL = _META["home-page"]
-LICENSE = _META["license"]
+AUTHOR = _META.get("author", "Voxel51, Inc.")
+AUTHOR_EMAIL = _META.get("author-email", "info@voxel51.com")
+URL = _META.get("home-page", "https://github.com/voxel51/eta")
+LICENSE = _META.get("license", "Apache")
 VERSION_LONG = "%s v%s, %s" % (NAME, VERSION, AUTHOR)


### PR DESCRIPTION
Fixes #735

The 0.17.0 wheels are built from pyproject metadata, which emits `Author-email` but no separate `Author` field, and puts the homepage under `Project-URL` with no `Home-page` field. `eta/constants.py` indexed those keys directly, and on Python 3.12+ a missing metadata key emits a `DeprecationWarning` (a hard `KeyError` on 3.14+), so `import eta` crashes under `warnings.simplefilter("error")`:

```
DeprecationWarning: Implicit None on return values is deprecated and will raise KeyErrors.
```

This switches the optional fields to `get()` with fallbacks. Verified by installing the patched package and importing with warnings-as-errors:

```
OK: voxel51-eta v0.18.0, Voxel51, Inc.
AUTHOR: Voxel51, Inc. | EMAIL: "Voxel51, Inc." <info@voxel51.com> | URL: https://github.com/voxel51/eta | LICENSE: Apache
```